### PR TITLE
Added character encoding to configuration which is used for rendering.

### DIFF
--- a/src/main/java/org/jbake/app/Parser.java
+++ b/src/main/java/org/jbake/app/Parser.java
@@ -1,20 +1,6 @@
 package org.jbake.app;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.petebevin.markdown.MarkdownProcessor;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.io.IOUtils;
 import org.asciidoctor.Asciidoctor;
@@ -25,7 +11,19 @@ import org.asciidoctor.DocumentHeader;
 import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 
-import com.petebevin.markdown.MarkdownProcessor;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Parses a File for content.
@@ -38,13 +36,7 @@ public class Parser {
 	private CompositeConfiguration config;
 	private Map<String, Object> content = new HashMap<String, Object>();
 	private Asciidoctor asciidoctor;
-	
-	/**
-	 * Creates a new instance of Parser.
-	 */
-	public Parser() {
-		asciidoctor = Factory.create();
-	}
+
 	
 	public Parser(CompositeConfiguration config) {
 		this.config = config;
@@ -59,11 +51,11 @@ public class Parser {
 	 */
 	public Map<String, Object> processFile(File file) {
 		content = new HashMap<String, Object>();
-		BufferedReader reader = null;
-		List<String> fileContents = null;
-		try {
-			reader = new BufferedReader(new FileReader(file));
-			fileContents = IOUtils.readLines(reader);
+        InputStream is = null;
+        List<String> fileContents = null;
+        try {
+            is = new FileInputStream(file);
+            fileContents = IOUtils.readLines(is, config.getString("render.encoding"));
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
 			return null;

--- a/src/main/java/org/jbake/app/Renderer.java
+++ b/src/main/java/org/jbake/app/Renderer.java
@@ -1,7 +1,11 @@
 package org.jbake.app;
 
+import freemarker.template.Configuration;
+import freemarker.template.DefaultObjectWrapper;
+import freemarker.template.Template;
+import org.apache.commons.configuration.CompositeConfiguration;
+
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -11,13 +15,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.commons.configuration.CompositeConfiguration;
-import org.jbake.launcher.Main;
-import freemarker.template.Configuration;
-import freemarker.template.DefaultObjectWrapper;
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
 
 /**
  * Render output to a file.
@@ -48,6 +45,7 @@ public class Renderer {
 		this.destination = destination;
 		this.config = config;
 		templateCfg = new Configuration();
+        templateCfg.setDefaultEncoding(config.getString("render.encoding"));
 		try {
 			templateCfg.setDirectoryForTemplateLoading(templatesPath);
 		} catch (IOException e) {
@@ -90,8 +88,8 @@ public class Renderer {
 			outputFile.getParentFile().mkdirs();
 			outputFile.createNewFile();
 		}
-		
-		Writer out = new OutputStreamWriter(new FileOutputStream(outputFile));
+
+        Writer out = new OutputStreamWriter(new FileOutputStream(outputFile), config.getString("render.encoding"));
 		template.process(model, out);
 		out.close();
 	}

--- a/src/main/resources/default.properties
+++ b/src/main/resources/default.properties
@@ -24,6 +24,9 @@ render.index=true
 index.file=index.html
 # render feed file?
 render.feed=true
+# character encoding MIME name used for rendering.
+# use one of http://www.iana.org/assignments/character-sets/character-sets.xhtml
+render.encoding=UTF-8
 # filename to use for feed
 feed.file=feed.xml
 # render archive file?

--- a/src/test/java/org/jbake/app/RendererTest.java
+++ b/src/test/java/org/jbake/app/RendererTest.java
@@ -1,20 +1,18 @@
 package org.jbake.app;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.Map;
-import java.util.Scanner;
-
 import org.apache.commons.configuration.CompositeConfiguration;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Map;
+import java.util.Scanner;
 
 public class RendererTest {
 
@@ -49,7 +47,7 @@ public class RendererTest {
 	
 	@Test
 	public void render() throws Exception {
-		Parser parser = new Parser();
+		Parser parser = new Parser(config);
 		Renderer renderer = new Renderer(sourceFolder, destinationFolder, templateFolder, config);
 		
 		File sampleFile = new File(sourceFolder.getPath()+File.separator+"content"+File.separator+"blog"+File.separator+"2013"+File.separator+"second-post.html");

--- a/src/test/resources/custom.properties
+++ b/src/test/resources/custom.properties
@@ -6,6 +6,7 @@ index.file=index.html
 render.feed=true
 feed.file=feed.xml
 render.archive=true
+render.encoding=UTF-8
 archive.file=archive.html
 render.tags=false
 tag.path=tags


### PR DESCRIPTION
Hi, I've updated app to support character encoding configuration for rendering. It's helpful when you render pages with special characters and default locale on OS does not met your requirements. In such cases rendered pages contain odd characters (e.g. question marks) instead of required characters (e.g. čřžý). See attached picture:

![result](https://f.cloud.github.com/assets/352668/1556012/ee15c144-4ea4-11e3-96ff-26d89d77c387.png)

To set character encoding for app you have to change it in configuration file of application. As default encoding I've set UTF-8. If you decide to accept this pull request, please mention this configuration option in "Getting started".

Encoding is applied for page/post rendering and also for template rendering.

Hope this will be helpful :)
