### PR TITLE
Plugin bootstrap proof of concept

### DIFF
--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -40,6 +40,13 @@
             </includes>
         </fileSet>
         <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>plugin</outputDirectory>
+            <excludes>
+              <exclude>**/*</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
             <directory>${basedir}</directory>
             <outputDirectory></outputDirectory>
             <includes>

--- a/src/main/java/org/jbake/plugins/JBakePlugin.java
+++ b/src/main/java/org/jbake/plugins/JBakePlugin.java
@@ -1,0 +1,6 @@
+package org.jbake.plugins;
+
+public interface JBakePlugin {
+
+  void init();
+}

--- a/src/main/scripts/jbake
+++ b/src/main/scripts/jbake
@@ -1,3 +1,3 @@
 #!/bin/bash
 JBAKE_HOME="`dirname "$0"`"
-java -jar ${JBAKE_HOME}/jbake-core.jar $@
+java -cp "${JBAKE_HOME}/jbake-core.jar:plugin/*" org.jbake.launcher.Main $@


### PR DESCRIPTION
Not really meant to be pulled, just an example how a plugin system could be bootstrapped:
- A `plugin` directory is created next to `lib`. JARs can be dropped in here.
- `jbake` script adds `plugin` to classpath (`jbake.bat` not modified and only tested on Ubuntu, not Mac).
- Plugins implement the `JBakePlugin` interface and declare themselves as a service for that interface.
- In `Main`, a `ServiceLoader` picks up all implementations of `JBakePlugin` and calls `init` on each one.
