### PR TITLE
Use SLF4J for logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,8 @@
 		<jetty.version>8.1.12.v20130726</jetty.version>
         <orientdb.version>1.6.2</orientdb.version>
         <groovy.version>2.2.1</groovy.version>
+        <slf4j.version>1.7.5</slf4j.version>
+        <logback.version>1.0.9</logback.version>
     </properties>
 
 	<build>
@@ -255,31 +257,24 @@
             <optional>true</optional>
         </dependency>
 		<!-- sl4j Logging -->
-		<!-- <dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.5</version>
+			<version>${slf4j.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-ext</artifactId>
-			<version>1.7.5</version>
-		</dependency>	 -->
-		<!-- log4j Logging -->	
-		<!-- <dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.0-beta9</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.0-beta9</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.0-beta9</version>
-		</dependency>	 -->		
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logback.version}</version>
+            <optional>true</optional>
+        </dependency>
 	</dependencies>
 </project>

--- a/src/main/java/org/jbake/app/Asset.java
+++ b/src/main/java/org/jbake/app/Asset.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Deals with assets (static files such as css, js or image files).
@@ -14,7 +16,9 @@ import org.apache.commons.io.FileUtils;
  */
 public class Asset {
 
-	private File source;
+    private static final Logger LOGGER = LoggerFactory.getLogger(Asset.class);
+
+    private File source;
 	private File destination;
 	
 	/**
@@ -39,7 +43,7 @@ public class Asset {
 			Arrays.sort(assets);
 			for (int i = 0; i < assets.length; i++) {
 				if (assets[i].isFile()) {
-					System.out.print("Copying [" + assets[i].getPath() + "]... ");
+					LOGGER.info("Copying [{}]...", assets[i].getPath());
 					File sourceFile = assets[i];
 					File destFile = new File(sourceFile.getPath().replace(source.getPath()+File.separator+"assets", destination.getPath()));
 					try {
@@ -47,7 +51,7 @@ public class Asset {
 					} catch (IOException e) {
 						e.printStackTrace();
 					}
-					System.out.println("done!");
+					LOGGER.info("done!");
 				} 
 				
 				if (assets[i].isDirectory()) {

--- a/src/main/java/org/jbake/app/Parser.java
+++ b/src/main/java/org/jbake/app/Parser.java
@@ -5,6 +5,8 @@ import org.apache.commons.io.IOUtils;
 import org.jbake.parser.Engines;
 import org.jbake.parser.MarkupEngine;
 import org.jbake.parser.ParserContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -26,6 +28,7 @@ import java.util.Map;
  * @author Jonathan Bullock <jonbullock@gmail.com>
  */
 public class Parser {
+    private final static Logger LOGGER = LoggerFactory.getLogger(Parser.class);
 
     private CompositeConfiguration config;
     private String contentPath;
@@ -71,7 +74,7 @@ public class Parser {
 
         MarkupEngine engine = Engines.get(FileUtil.fileExt(file));
         if (engine==null) {
-            System.err.println("Unable to find suitable markup engine for "+file);
+            LOGGER.error("Unable to find suitable markup engine for {}",file);
             return null;
         }
 
@@ -84,7 +87,7 @@ public class Parser {
 
         if (content.get("type")==null||content.get("status")==null) {
             // output error
-            System.err.println("Error parsing meta data from header!");
+            LOGGER.error("Error parsing meta data from header!");
             return null;
         }
 
@@ -95,7 +98,7 @@ public class Parser {
         if (engine.validate(context)) {
             engine.processBody(context);
         } else {
-            System.out.println("Incomplete source file (" + file + ") for markup engine:" + engine.getClass().getSimpleName());
+            LOGGER.error("Incomplete source file ({}) for markup engine:", file, engine.getClass().getSimpleName());
             return null;
         }
 

--- a/src/main/java/org/jbake/app/Renderer.java
+++ b/src/main/java/org/jbake/app/Renderer.java
@@ -3,6 +3,8 @@ package org.jbake.app;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.template.DelegatingTemplateEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -19,6 +21,8 @@ import java.util.Set;
  * @author Jonathan Bullock <jonbullock@gmail.com>
  */
 public class Renderer {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(Renderer.class);
 
     // TODO: should all content be made available to all templates via this class??
 
@@ -68,7 +72,8 @@ public class Renderer {
         }
         File outputFile = new File(outputFilename + config.getString("output.extension"));
 
-        System.out.print("Rendering [" + outputFile + "]... ");
+        StringBuilder sb = new StringBuilder();
+        sb.append("Rendering [").append(outputFile).append("]... ");
         Map<String, Object> model = new HashMap<String, Object>();
         model.put("content", content);
         model.put("renderer", renderingEngine);
@@ -78,10 +83,11 @@ public class Renderer {
             Writer out = createWriter(outputFile);
             renderingEngine.renderDocument(model, findTemplateName(docType), out);
             out.close();
-            System.out.println("done!");
+            sb.append("done!");
+            LOGGER.info(sb.toString());
         } catch (Exception e) {
-            e.printStackTrace();
-            System.out.println("failed!");
+            sb.append("failed!");
+            LOGGER.error(sb.toString(), e);
             throw new Exception("Failed to render file");
         }
     }
@@ -102,7 +108,8 @@ public class Renderer {
      */
     public void renderIndex(String indexFile) {
         File outputFile = new File(destination.getPath() + File.separator + indexFile);
-        System.out.print("Rendering index [" + outputFile + "]...");
+        StringBuilder sb = new StringBuilder();
+        sb.append("Rendering index [").append(outputFile).append("]...");
         Map<String, Object> model = new HashMap<String, Object>();
         model.put("renderer", renderingEngine);
 
@@ -110,10 +117,12 @@ public class Renderer {
             Writer out = createWriter(outputFile);
             renderingEngine.renderDocument(model, findTemplateName("index"), out);
             out.close();
-            System.out.println("done!");
+            sb.append("done!");
+            LOGGER.info(sb.toString());
         } catch (Exception e) {
-            e.printStackTrace();
-            System.out.println("failed!");
+            sb.append("failed!");
+            LOGGER.error(sb.toString(), e);
+
         }
     }
 
@@ -125,17 +134,19 @@ public class Renderer {
      */
     public void renderSitemap(String sitemapFile) {
         File outputFile = new File(destination.getPath() + File.separator + sitemapFile);
-        System.out.print("Rendering sitemap [" + outputFile + "]... ");
+        StringBuilder sb = new StringBuilder();
+        sb.append("Rendering sitemap [").append(outputFile).append("]... ");
 
         Map<String, Object> model = new HashMap<String, Object>();
 
         try {
             Writer out = createWriter(outputFile);
             renderingEngine.renderDocument(model, findTemplateName("sitemap"), out);
-            System.out.println("done!");
+            sb.append("done!");
+            LOGGER.info(sb.toString());
         } catch (Exception e) {
-            e.printStackTrace();
-            System.out.println("failed!");
+            sb.append("failed!");
+            LOGGER.error(sb.toString(), e);
         }
     }
 
@@ -146,7 +157,8 @@ public class Renderer {
      */
     public void renderFeed(String feedFile) {
         File outputFile = new File(destination.getPath() + File.separator + feedFile);
-        System.out.print("Rendering feed [" + outputFile + "]... ");
+        StringBuilder sb = new StringBuilder();
+        sb.append("Rendering feed [").append(outputFile).append("]... ");
         Map<String, Object> model = new HashMap<String, Object>();
         model.put("renderer", renderingEngine);
 
@@ -154,10 +166,11 @@ public class Renderer {
             Writer out = createWriter(outputFile);
             renderingEngine.renderDocument(model, findTemplateName("feed"), out);
             out.close();
-            System.out.println("done!");
+            sb.append("done!");
+            LOGGER.info(sb.toString());
         } catch (Exception e) {
-            e.printStackTrace();
-            System.out.println("failed!");
+            sb.append("failed!");
+            LOGGER.error(sb.toString(), e);
         }
     }
 
@@ -168,7 +181,8 @@ public class Renderer {
      */
     public void renderArchive(String archiveFile) {
         File outputFile = new File(destination.getPath() + File.separator + archiveFile);
-        System.out.print("Rendering archive [" + outputFile + "]... ");
+        StringBuilder sb = new StringBuilder();
+        sb.append("Rendering archive [").append(outputFile).append("]... ");
         Map<String, Object> model = new HashMap<String, Object>();
         model.put("renderer", renderingEngine);
 
@@ -176,10 +190,11 @@ public class Renderer {
             Writer out = createWriter(outputFile);
             renderingEngine.renderDocument(model, findTemplateName("archive"), out);
             out.close();
-            System.out.println("done!");
+            sb.append("done!");
+            LOGGER.info(sb.toString());
         } catch (Exception e) {
-            e.printStackTrace();
-            System.out.println("failed!");
+            sb.append("failed!");
+            LOGGER.error(sb.toString(), e);
         }
     }
 
@@ -197,16 +212,18 @@ public class Renderer {
 
             tag = tag.trim().replace(" ", "-");
             File outputFile = new File(destination.getPath() + File.separator + tagPath + File.separator + tag + config.getString("output.extension"));
-            System.out.print("Rendering tags [" + outputFile + "]... ");
+            StringBuilder sb = new StringBuilder();
+            sb.append("Rendering tags [").append(outputFile).append("]... ");
 
             try {
                 Writer out = createWriter(outputFile);
                 renderingEngine.renderDocument(model, findTemplateName("tag"), out);
                 out.close();
-                System.out.println("done!");
+                sb.append("done!");
+                LOGGER.info(sb.toString());
             } catch (Exception e) {
-                e.printStackTrace();
-                System.out.println("failed!");
+                sb.append("failed!");
+                LOGGER.error(sb.toString(), e);
             }
         }
     }

--- a/src/main/java/org/jbake/launcher/JettyServer.java
+++ b/src/main/java/org/jbake/launcher/JettyServer.java
@@ -6,6 +6,8 @@ import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -15,6 +17,7 @@ import org.eclipse.jetty.server.nio.SelectChannelConnector;
  *
  */
 public class JettyServer {
+    private final static Logger LOGGER = LoggerFactory.getLogger(JettyServer.class);
 
 	/**
 	 * Run Jetty web server serving out supplied path on supplied port
@@ -38,8 +41,8 @@ public class JettyServer {
         handlers.setHandlers(new Handler[] { resource_handler, new DefaultHandler() });
         server.setHandler(handlers);
  
-        System.out.println("Serving out contents of: [" + path + "] on http://localhost:" + port + "/");
-        System.out.println("(To stop server hit CTRL-C)");
+        LOGGER.info("Serving out contents of: [{}] on http://localhost:{}/", path, port);
+        LOGGER.info("(To stop server hit CTRL-C)");
         
         try {
 			server.start();

--- a/src/main/java/org/jbake/parser/AsciidoctorEngine.java
+++ b/src/main/java/org/jbake/parser/AsciidoctorEngine.java
@@ -6,6 +6,8 @@ import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Attributes;
 import org.asciidoctor.DocumentHeader;
 import org.asciidoctor.Options;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -29,6 +31,8 @@ import static org.asciidoctor.SafeMode.UNSAFE;
  * @author Cédric Champeau
  */
 public class AsciidoctorEngine extends MarkupEngine {
+    private final static Logger LOGGER = LoggerFactory.getLogger(AsciidoctorEngine.class);
+
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     private Asciidoctor engine;
@@ -41,9 +45,9 @@ public class AsciidoctorEngine extends MarkupEngine {
                 try {
                     lock.writeLock().lock();
                     if (engine==null) {
-                        System.out.print("Initializing Asciidoctor engine...");
+                        LOGGER.info("Initializing Asciidoctor engine...");
                         engine = Asciidoctor.Factory.create();
-                        System.out.println(" ok");
+                        LOGGER.info("Asciidoctor engine initialized.");
                     }
                 } finally {
                     lock.readLock().lock();

--- a/src/main/java/org/jbake/parser/Engines.java
+++ b/src/main/java/org/jbake/parser/Engines.java
@@ -1,5 +1,8 @@
 package org.jbake.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
@@ -36,6 +39,8 @@ import java.util.Set;
  *
  */
 public class Engines {
+    private final static Logger LOGGER = LoggerFactory.getLogger(Engines.class);
+
     private final static Engines INSTANCE;
 
     static {
@@ -64,7 +69,7 @@ public class Engines {
     private void registerEngine(String fileExtension, MarkupEngine markupEngine) {
         MarkupEngine old = parsers.put(fileExtension, markupEngine);
         if (old != null) {
-            System.out.println("Registered a markup engine for extension [." + fileExtension + "] but another one was already defined:" + old);
+            LOGGER.warn("Registered a markup engine for extension [.{}] but another one was already defined: {}", fileExtension, old);
         }
     }
 

--- a/src/main/java/org/jbake/template/DelegatingTemplateEngine.java
+++ b/src/main/java/org/jbake/template/DelegatingTemplateEngine.java
@@ -3,6 +3,8 @@ package org.jbake.template;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.Writer;
@@ -17,6 +19,8 @@ import java.util.Map;
  * @author Cédric Champeau
  */
 public class DelegatingTemplateEngine extends AbstractTemplateEngine {
+    private final static Logger LOGGER = LoggerFactory.getLogger(DelegatingTemplateEngine.class);
+
     private final TemplateEngines renderers;
 
     public DelegatingTemplateEngine(final CompositeConfiguration config, final ODatabaseDocumentTx db, final File destination, final File templatesPath) {
@@ -40,7 +44,7 @@ public class DelegatingTemplateEngine extends AbstractTemplateEngine {
         if (engine!=null) {
             engine.renderDocument(model, templateName, writer);
         } else {
-            System.err.println("Warning - No template engine found for template: "+templateName);
+            LOGGER.error("Warning - No template engine found for template: {}",templateName);
         }
     }
 }

--- a/src/main/java/org/jbake/template/TemplateEngines.java
+++ b/src/main/java/org/jbake/template/TemplateEngines.java
@@ -2,6 +2,8 @@ package org.jbake.template;
 
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import org.apache.commons.configuration.CompositeConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,6 +35,7 @@ import java.util.Set;
  * @author Cédric Champeau
  */
 public class TemplateEngines {
+    private final static Logger LOGGER = LoggerFactory.getLogger(TemplateEngines.class);
 
     private final Map<String, AbstractTemplateEngine> templateEngines;
 
@@ -48,7 +51,7 @@ public class TemplateEngines {
     private void registerEngine(String fileExtension, AbstractTemplateEngine templateEngine) {
         AbstractTemplateEngine old = templateEngines.put(fileExtension, templateEngine);
         if (old != null) {
-            System.out.println("Registered a template engine for extension [." + fileExtension + "] but another one was already defined:" + old);
+            LOGGER.warn("Registered a template engine for extension [.{}] but another one was already defined: {}", fileExtension, old);
         }
     }
 


### PR DESCRIPTION
Currently JBake uses lots of `System.out.println` for reporting. This is annoying when it comes to integrating into another project (for example, the upcoming Gradle plugin).

This PR replaces `System.out.println` with `SLF4J` logging, apart from the `Main` class where it makes sense to keep it.
