### PR TITLE
Avoid sharing CompositeConfiguration for thread safety

### DIFF
--- a/src/main/java/org/jbake/app/ConfigUtil.java
+++ b/src/main/java/org/jbake/app/ConfigUtil.java
@@ -1,41 +1,33 @@
 package org.jbake.app;
 
-import java.io.File;
-
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
+
+import java.io.File;
 
 /**
  * Provides Configuration related functions.
  *
  * @author Jonathan Bullock <jonbullock@gmail.com>
- *
  */
 public class ConfigUtil {
-	
-	public final static String DATE_FORMAT = "date.format";
-	
-	private static CompositeConfiguration config;
-	
-	public static CompositeConfiguration load(File source) throws ConfigurationException {
-		if (config == null) {
-			config = new CompositeConfiguration();
-			config.setListDelimiter(',');
-			File customConfigFile = new File(source, "custom.properties");
-			if (customConfigFile.exists()) {
-				config.addConfiguration(new PropertiesConfiguration(customConfigFile));
-			}
-			customConfigFile = new File(source, "jbake.properties");
-			if (customConfigFile.exists()) {
-				config.addConfiguration(new PropertiesConfiguration(customConfigFile));
-			}
-			config.addConfiguration(new PropertiesConfiguration("default.properties"));
-		}
-		return config;
-	}
-	
-	public static void reset() {
-		config = null;
-	}
+
+    public final static String DATE_FORMAT = "date.format";
+
+    public static CompositeConfiguration load(File source) throws ConfigurationException {
+        CompositeConfiguration config = new CompositeConfiguration();
+        config.setListDelimiter(',');
+        File customConfigFile = new File(source, "custom.properties");
+        if (customConfigFile.exists()) {
+            config.addConfiguration(new PropertiesConfiguration(customConfigFile));
+        }
+        customConfigFile = new File(source, "jbake.properties");
+        if (customConfigFile.exists()) {
+            config.addConfiguration(new PropertiesConfiguration(customConfigFile));
+        }
+        config.addConfiguration(new PropertiesConfiguration("default.properties"));
+        return config;
+    }
+
 }

--- a/src/main/java/org/jbake/app/Oven.java
+++ b/src/main/java/org/jbake/app/Oven.java
@@ -49,6 +49,14 @@ public class Oven {
         this.isClearCache = isClearCache;
 	}
 
+    public CompositeConfiguration getConfig() {
+        return config;
+    }
+
+    public void setConfig(final CompositeConfiguration config) {
+        this.config = config;
+    }
+
     private void ensureSource() throws Exception {
         if (!FileUtil.isExistingFolder(source)) {
             throw new Exception("Error: Source folder must exist!");

--- a/src/test/java/org/jbake/app/ConfigUtilTest.java
+++ b/src/test/java/org/jbake/app/ConfigUtilTest.java
@@ -11,7 +11,6 @@ public class ConfigUtilTest {
 
 	@Test
 	public void load() throws Exception {
-		ConfigUtil.reset();
 		CompositeConfiguration config = ConfigUtil.load(new File(this.getClass().getResource("/").getFile()));
 		
 		// check default.properties values exist

--- a/src/test/java/org/jbake/app/CrawlerTest.java
+++ b/src/test/java/org/jbake/app/CrawlerTest.java
@@ -13,7 +13,6 @@ public class CrawlerTest {
 	
 	@Test
 	public void crawl() throws ConfigurationException {
-		ConfigUtil.reset();
 		CompositeConfiguration config = ConfigUtil.load(new File(this.getClass().getResource("/").getFile()));
 		Assert.assertEquals(".html", config.getString("output.extension"));
 				

--- a/src/test/java/org/jbake/app/GroovyRendererTest.java
+++ b/src/test/java/org/jbake/app/GroovyRendererTest.java
@@ -44,7 +44,6 @@ public class GroovyRendererTest {
             throw new Exception("Cannot find template folder!");
         }
 
-        ConfigUtil.reset();
         config = ConfigUtil.load(new File(this.getClass().getResource("/").getFile()));
         Iterator<String> keys = config.getKeys();
         while (keys.hasNext()) {

--- a/src/test/java/org/jbake/app/MdParserTest.java
+++ b/src/test/java/org/jbake/app/MdParserTest.java
@@ -67,7 +67,6 @@ public class MdParserTest {
 
     @Before
     public void createSampleFile() throws Exception {
-        ConfigUtil.reset();
 
         configFile = new File(this.getClass().getResource(".").getFile());
         config = ConfigUtil.load(configFile);

--- a/src/test/java/org/jbake/app/ParserTest.java
+++ b/src/test/java/org/jbake/app/ParserTest.java
@@ -37,7 +37,6 @@ public class ParserTest {
 	
 	@Before
 	public void createSampleFile() throws Exception {
-		ConfigUtil.reset();
 		rootPath = new File(this.getClass().getResource(".").getFile());
 		config = ConfigUtil.load(rootPath);
 		parser = new Parser(config,rootPath.getPath());

--- a/src/test/java/org/jbake/app/RendererTest.java
+++ b/src/test/java/org/jbake/app/RendererTest.java
@@ -51,7 +51,6 @@ public class RendererTest {
             throw new Exception("Cannot find template folder!");
         }
 
-        ConfigUtil.reset();
         config = ConfigUtil.load(new File(this.getClass().getResource("/").getFile()));
         Assert.assertEquals(".html", config.getString("output.extension"));
         db = DBUtil.createDB("memory", "documents"+System.currentTimeMillis());


### PR DESCRIPTION
- Removes the static field in `ConfigUtil`
- Adds a getter/setter for configuration in `Oven` (useful if you want to tweak configuration before calling `bake`)
