### PR TITLE
Disable caching by default

### DIFF
--- a/src/main/resources/default.properties
+++ b/src/main/resources/default.properties
@@ -66,6 +66,6 @@ date.format=yyyy-MM-dd
 # http://www.decodified.com/pegdown/api/org/pegdown/Extensions.html
 markdown.extensions=HARDWRAPS,AUTOLINKS,FENCED_CODE_BLOCKS,DEFINITIONS
 # database store (local, memory)
-db.store=local
+db.store=memory
 # database path
 db.path=cache


### PR DESCRIPTION
Switched the default from `local` to `memory` for backwards compatibility. For people who want to use the new caching system, they will have to enable it by setting:

```
db.store=local
```

in their `jbake.properties` file. I think we should stick with that until we made caching more robust.
