### PR TITLE
Bundled rendering engines may not trigger an error if a jar is missing

### DIFF
--- a/src/main/java/org/jbake/parser/AsciidoctorEngine.java
+++ b/src/main/java/org/jbake/parser/AsciidoctorEngine.java
@@ -37,6 +37,11 @@ public class AsciidoctorEngine extends MarkupEngine {
 
     private Asciidoctor engine;
 
+    public AsciidoctorEngine() {
+        Class engineClass = Asciidoctor.class;
+        assert engineClass!=null;
+    }
+
     private Asciidoctor getEngine() {
         try {
             lock.readLock().lock();

--- a/src/main/java/org/jbake/parser/Engines.java
+++ b/src/main/java/org/jbake/parser/Engines.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -129,6 +130,9 @@ public class Engines {
         if (engine != null) {
             for (String extension : extensions) {
                 register(extension, engine);
+            }
+            if (engine instanceof ErrorEngine) {
+                LOGGER.warn("Unable to load a suitable rendering engine for extensions {}", Arrays.toString(extensions));
             }
         }
     }

--- a/src/main/java/org/jbake/parser/MarkdownEngine.java
+++ b/src/main/java/org/jbake/parser/MarkdownEngine.java
@@ -10,6 +10,11 @@ import org.pegdown.PegDownProcessor;
  */
 public class MarkdownEngine extends MarkupEngine {
 
+    public MarkdownEngine() {
+        Class engineClass = PegDownProcessor.class;
+        assert engineClass!=null;
+    }
+
     @Override
     public void processBody(final ParserContext context) {
         String[] mdExts = context.getConfig().getStringArray("markdown.extensions");


### PR DESCRIPTION
If a jar of a rendering engine is not found, make sure that the engine will not be loaded. This avoids errors at runtime if a class couldn't be found.
