### PR TITLE
Add support for Thymeleaf template engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <groovy.version>2.2.1</groovy.version>
         <slf4j.version>1.7.5</slf4j.version>
         <logback.version>1.0.9</logback.version>
+        <thymeleaf.version>2.1.2.RELEASE</thymeleaf.version>
     </properties>
 
 	<build>
@@ -254,6 +255,12 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${groovy.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf</artifactId>
+            <version>${thymeleaf.version}</version>
             <optional>true</optional>
         </dependency>
 		<!-- sl4j Logging -->

--- a/src/main/java/org/jbake/app/Renderer.java
+++ b/src/main/java/org/jbake/app/Renderer.java
@@ -11,6 +11,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -112,6 +113,7 @@ public class Renderer {
         sb.append("Rendering index [").append(outputFile).append("]...");
         Map<String, Object> model = new HashMap<String, Object>();
         model.put("renderer", renderingEngine);
+        model.put("content", Collections.singletonMap("type","index"));
 
         try {
             Writer out = createWriter(outputFile);
@@ -138,6 +140,7 @@ public class Renderer {
         sb.append("Rendering sitemap [").append(outputFile).append("]... ");
 
         Map<String, Object> model = new HashMap<String, Object>();
+        model.put("content", Collections.singletonMap("type","sitemap"));
 
         try {
             Writer out = createWriter(outputFile);
@@ -161,6 +164,7 @@ public class Renderer {
         sb.append("Rendering feed [").append(outputFile).append("]... ");
         Map<String, Object> model = new HashMap<String, Object>();
         model.put("renderer", renderingEngine);
+        model.put("content", Collections.singletonMap("type","feed"));
 
         try {
             Writer out = createWriter(outputFile);
@@ -185,6 +189,7 @@ public class Renderer {
         sb.append("Rendering archive [").append(outputFile).append("]... ");
         Map<String, Object> model = new HashMap<String, Object>();
         model.put("renderer", renderingEngine);
+        model.put("content", Collections.singletonMap("type","archive"));
 
         try {
             Writer out = createWriter(outputFile);
@@ -209,6 +214,7 @@ public class Renderer {
             Map<String, Object> model = new HashMap<String, Object>();
             model.put("renderer", renderingEngine);
             model.put("tag", tag);
+            model.put("content", Collections.singletonMap("type","tag"));
 
             tag = tag.trim().replace(" ", "-");
             File outputFile = new File(destination.getPath() + File.separator + tagPath + File.separator + tag + config.getString("output.extension"));

--- a/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
+++ b/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
@@ -1,0 +1,130 @@
+package org.jbake.template;
+
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.jbake.app.DBUtil;
+import org.jbake.app.DocumentList;
+import org.jbake.model.DocumentTypes;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.context.VariablesMap;
+import org.thymeleaf.templateresolver.FileTemplateResolver;
+
+import java.io.File;
+import java.io.Writer;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * <p>A template engine which renders pages using Thymeleaf.</p>
+ *
+ * <p>This template engine is not recommanded for large sites because the whole model
+ * is loaded into memory due to Thymeleaf internal limitations.</p>
+ *
+ * <p>The default rendering mode is "HTML5", but it is possible to use another mode
+ * for each document type, by adding a key in the configuration, for example:</p>
+ * <p/>
+ * <code>
+ *     template.feed.thymeleaf.mode=XML
+ * </code>
+ *
+ * @author Cédric Champeau
+ */
+public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private TemplateEngine templateEngine;
+    private FileTemplateResolver templateResolver;
+
+    public ThymeleafTemplateEngine(final CompositeConfiguration config, final ODatabaseDocumentTx db, final File destination, final File templatesPath) {
+        super(config, db, destination, templatesPath);
+        initializeTemplateEngine();
+    }
+
+    private void initializeTemplateEngine() {
+        templateResolver = new FileTemplateResolver();
+        templateResolver.setPrefix(templatesPath.getAbsolutePath() + File.separatorChar);
+        templateEngine = new TemplateEngine();
+        templateEngine.setTemplateResolver(templateResolver);
+    }
+
+    @Override
+    public void renderDocument(final Map<String, Object> model, final String templateName, final Writer writer) throws RenderingException {
+        String localeString = config.getString("thymeleaf.locale");
+        Locale locale = localeString != null ? Locale.forLanguageTag(localeString) : Locale.getDefault();
+        Context context = new Context(locale, wrap(model));
+        lock.lock();
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> config = (Map<String, Object>) model.get("config");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> content = (Map<String, Object>) model.get("content");
+            String mode = "HTML5";
+            if (config != null && content != null) {
+                String key = "template_" + content.get("type") + "_thymeleaf_mode";
+                String configMode = (String) config.get(key);
+                if (configMode != null) {
+                    mode = configMode;
+                }
+            }
+            templateResolver.setTemplateMode(mode);
+            templateEngine.process(templateName, context, writer);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private VariablesMap<String, Object> wrap(final Map<String, Object> model) {
+        return new JBakeVariablesMap(model);
+    }
+
+    private class JBakeVariablesMap extends VariablesMap<String, Object> {
+
+        public JBakeVariablesMap(final Map<String, Object> model) {
+            super(model);
+            completeModel();
+        }
+
+        private void completeModel() {
+            put("db", db);
+            put("alltags", getAllTags());
+            put("tag_posts", getTagPosts());
+            put("published_date", new Date());
+            String[] documentTypes = DocumentTypes.getDocumentTypes();
+            for (String docType : documentTypes) {
+                put(docType + "s", DocumentList.wrap(DBUtil.query(db, "select * from " + docType + " order by date desc").iterator()));
+                put("published_" + docType + "s", DocumentList.wrap(DBUtil.query(db, "select * from " + docType + " where status='published' order by date desc").iterator()));
+            }
+        }
+
+        private Object getTagPosts() {
+            Object tagName = get("tag");
+            if (tagName != null) {
+                String tag = tagName.toString();
+                // fetch the tag posts from db
+                List<ODocument> query = DBUtil.query(db, "select * from post where status='published' where ? in tags order by date desc", tag);
+                return DocumentList.wrap(query.iterator());
+            } else {
+                return Collections.emptyList();
+            }
+        }
+
+        private Object getAllTags() {
+            List<ODocument> query = db.query(new OSQLSynchQuery<ODocument>("select tags from post where status='published'"));
+            Set<String> result = new HashSet<String>();
+            for (ODocument document : query) {
+                String[] tags = DBUtil.toStringArray(document.field("tags"));
+                Collections.addAll(result, tags);
+            }
+            return result;
+        }
+    }
+}

--- a/src/main/resources/META-INF/org.jbake.parser.TemplateEngines.properties
+++ b/src/main/resources/META-INF/org.jbake.parser.TemplateEngines.properties
@@ -1,2 +1,3 @@
 org.jbake.template.FreemarkerTemplateEngine=ftl
 org.jbake.template.GroovyTemplateEngine=groovy,gsp,gxml
+org.jbake.template.ThymeleafTemplateEngine=thyme

--- a/src/test/java/org/jbake/app/ThymeleafRendererTest.java
+++ b/src/test/java/org/jbake/app/ThymeleafRendererTest.java
@@ -1,0 +1,227 @@
+package org.jbake.app;
+
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Scanner;
+
+public class ThymeleafRendererTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File sourceFolder;
+    private File destinationFolder;
+    private File templateFolder;
+    private CompositeConfiguration config;
+    private ODatabaseDocumentTx db;
+
+    @Before
+    public void setup() throws Exception, IOException, URISyntaxException {
+        URL sourceUrl = this.getClass().getResource("/");
+
+        sourceFolder = new File(sourceUrl.getFile());
+        if (!sourceFolder.exists()) {
+            throw new Exception("Cannot find sample data structure!");
+        }
+
+        destinationFolder = folder.getRoot();
+
+        templateFolder = new File(sourceFolder, "thymeleafTemplates");
+        if (!templateFolder.exists()) {
+            throw new Exception("Cannot find template folder!");
+        }
+
+        config = ConfigUtil.load(new File(this.getClass().getResource("/").getFile()));
+        Iterator<String> keys = config.getKeys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            if (key.startsWith("template") && key.endsWith(".file")) {
+                String old = (String)config.getProperty(key);
+                config.setProperty(key, old.substring(0, old.length()-4)+".thyme");
+            }
+        }
+        Assert.assertEquals(".html", config.getString("output.extension"));
+        db = DBUtil.createDB("memory", "documents"+System.currentTimeMillis());
+    }
+
+    @After
+    public void cleanup() throws InterruptedException {
+        db.drop();
+        db.close();
+    }
+
+    @Test
+    public void render() throws Exception {
+        Parser parser = new Parser(config, sourceFolder.getPath());
+        Renderer renderer = new Renderer(db, destinationFolder, templateFolder, config);
+
+        File sampleFile = new File(sourceFolder.getPath() + File.separator + "content" + File.separator + "blog" + File.separator + "2013" + File.separator + "second-post.html");
+        Map<String, Object> content = parser.processFile(sampleFile);
+        content.put("uri", "/second-post.html");
+        renderer.render(content);
+        File outputFile = new File(destinationFolder, "second-post.html");
+        Assert.assertTrue(outputFile.exists());
+        Scanner scanner = new Scanner(outputFile);
+        boolean foundTitle = false;
+        boolean foundDate = false;
+        boolean foundBody = false;
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.contains("<h2>Second Post</h2>")) {
+                foundTitle = true;
+            }
+            if (line.trim().startsWith("<p class=\"post-date\">28") && line.endsWith("2013</p>")) {
+                foundDate = true;
+            }
+            if (line.contains("Lorem ipsum dolor sit amet")) {
+                foundBody = true;
+            }
+            if (foundTitle && foundDate && foundBody) {
+                break;
+            }
+        }
+
+        Assert.assertTrue(foundTitle);
+        Assert.assertTrue(foundDate);
+        Assert.assertTrue(foundBody);
+    }
+
+    @Test
+    public void renderIndex() throws Exception {
+        //setup
+        Crawler crawler = new Crawler(db, sourceFolder, config);
+        crawler.crawl(new File(sourceFolder.getPath() + File.separator + "content"));
+        Renderer renderer = new Renderer(db, destinationFolder, templateFolder, config);
+        //exec
+        renderer.renderIndex("index.html");
+
+        //validate
+        File outputFile = new File(destinationFolder, "index.html");
+        Assert.assertTrue(outputFile.exists());
+        Scanner scanner = new Scanner(outputFile);
+
+        boolean foundFirstTitle = false;
+        boolean foundSecondTitle = false;
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.contains("<h4><a href=\"/blog/2012/first-post.html\" shape=\"rect\">First Post</a></h4>")) {
+                foundFirstTitle = true;
+            }
+            if (line.contains("<h4><a href=\"/blog/2013/second-post.html\" shape=\"rect\">Second Post</a></h4>")) {
+                foundSecondTitle = true;
+            }
+            if (foundFirstTitle && foundSecondTitle) {
+                break;
+            }
+        }
+
+        Assert.assertTrue(foundFirstTitle);
+        Assert.assertTrue(foundSecondTitle);
+    }
+
+    @Test
+    public void renderFeed() throws Exception {
+        Crawler crawler = new Crawler(db, sourceFolder, config);
+        crawler.crawl(new File(sourceFolder.getPath() + File.separator + "content"));
+        Renderer renderer = new Renderer(db, destinationFolder, templateFolder, config);
+        renderer.renderFeed("feed.xml");
+        File outputFile = new File(destinationFolder, "feed.xml");
+        Assert.assertTrue(outputFile.exists());
+        Scanner scanner = new Scanner(outputFile);
+
+        boolean foundDescription = false;
+        boolean foundFirstTitle = false;
+        boolean foundSecondTitle = false;
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.contains("<description>My corner of the Internet</description>")) {
+                foundDescription = true;
+            }
+            if (line.contains("<title>Second Post</title>")) {
+                foundFirstTitle = true;
+            }
+            if (line.contains("<title>First Post</title>")) {
+                foundSecondTitle = true;
+            }
+            if (foundDescription && foundFirstTitle && foundSecondTitle) {
+                break;
+            }
+        }
+
+        Assert.assertTrue(foundDescription);
+        Assert.assertTrue(foundFirstTitle);
+        Assert.assertTrue(foundSecondTitle);
+    }
+
+    @Test
+    public void renderArchive() throws Exception {
+        Crawler crawler = new Crawler(db, sourceFolder, config);
+        crawler.crawl(new File(sourceFolder.getPath() + File.separator + "content"));
+        Renderer renderer = new Renderer(db, destinationFolder, templateFolder, config);
+        renderer.renderArchive("archive.html");
+        File outputFile = new File(destinationFolder, "archive.html");
+        Assert.assertTrue(outputFile.exists());
+        Scanner scanner = new Scanner(outputFile);
+
+        boolean foundFirstPost = false;
+        boolean foundSecondPost = false;
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.contains("<a href=\"/blog/2013/second-post.html\" shape=\"rect\">Second Post</a></h4>")) {
+                foundFirstPost = true;
+            }
+            if (line.contains("<a href=\"/blog/2012/first-post.html\" shape=\"rect\">First Post</a></h4>")) {
+                foundSecondPost = true;
+            }
+            if (foundFirstPost && foundSecondPost) {
+                break;
+            }
+        }
+
+        Assert.assertTrue(foundFirstPost);
+        Assert.assertTrue(foundSecondPost);
+    }
+
+    @Test
+    public void renderTags() throws Exception {
+        Crawler crawler = new Crawler(db, sourceFolder, config);
+        crawler.crawl(new File(sourceFolder.getPath() + File.separator + "content"));
+        Renderer renderer = new Renderer(db, destinationFolder, templateFolder, config);
+        renderer.renderTags(crawler.getTags(), "tags");
+        File outputFile = new File(destinationFolder + File.separator + "tags" + File.separator + "blog.html");
+        Assert.assertTrue(outputFile.exists());
+        Scanner scanner = new Scanner(outputFile);
+
+        boolean foundFirstPost = false;
+        boolean foundSecondPost = false;
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.contains("<a href=\"/blog/2013/second-post.html\" shape=\"rect\">Second Post</a></h4>")) {
+                foundFirstPost = true;
+            }
+            if (line.contains("<a href=\"/blog/2012/first-post.html\" shape=\"rect\">First Post</a></h4>")) {
+                foundSecondPost = true;
+            }
+            if (foundFirstPost && foundSecondPost) {
+                break;
+            }
+        }
+
+        Assert.assertTrue(foundFirstPost);
+        Assert.assertTrue(foundSecondPost);
+    }
+
+}

--- a/src/test/resources/custom.properties
+++ b/src/test/resources/custom.properties
@@ -13,3 +13,4 @@ tag.path=tags
 test.property=testing123
 markdown.extensions=HARDWRAPS,AUTOLINKS,FENCED_CODE_BLOCKS,DEFINITIONS
 site.host=http://www.jbake.org
+template.feed.thymeleaf.mode=XML

--- a/src/test/resources/thymeleafTemplates/archive.thyme
+++ b/src/test/resources/thymeleafTemplates/archive.thyme
@@ -1,0 +1,25 @@
+<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+      <head th:replace="header.thyme::head"/>
+      <body>
+      <div th:replace="header.thyme::top"/>
+
+	<div class="row-fluid marketing">
+		<div class="span12">
+			<h2>Archive</h2>
+			<div th:each="post : ${posts}" th:with='last_month=null' th:remove='tag'>
+			    <h3 th:if='${last_month!=#dates.format(post.date,"MMMM yyyy")}' th:text='${#dates.format(post.date,"MMMM yyyy")}'>June 2014</h3>
+
+				<h4><span th:text='${#dates.format(post.date,"dd MMMM")}' th:remove='tag'/> - <a th:href="${post.uri}" th:text='${post.title}' href="foo.html">Post title</a></h4>
+				<span th:remove='all' th:with='last_month = ${#dates.format(post.date,"MMMM yyyy")}'/>
+			</div>
+		</div>
+	</div>
+
+	<hr/>
+
+    <div th:replace="footer.thyme::footer"></div>
+    </body>
+</html>

--- a/src/test/resources/thymeleafTemplates/feed.thyme
+++ b/src/test/resources/thymeleafTemplates/feed.thyme
@@ -1,0 +1,21 @@
+<rss version="2.0" xmlns="http://www.w3.org/1999/xhtml"
+                   xmlns:th="http://www.thymeleaf.org"
+    xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>JonathanBullock.com</title>
+    <link>http://jonathanbullock.com/</link>
+    <atom:link href="http://jonathanbullock.com/feed.xml" rel="self" type="application/rss+xml" />
+    <description>My corner of the Internet</description>
+    <language>en-gb</language>
+    <pubDate th:text='${#dates.format(published_date,"EEE, d MMM yyyy HH:mm:ss Z")}'>2014-01-30</pubDate>
+    <lastBuildDate th:text='${#dates.format(published_date,"EEE, d MMM yyyy HH:mm:ss Z")}'>2014-01-30</lastBuildDate>
+
+    <item th:each="post: ${posts}">
+      <title th:text='${post.title}'>Title of the post</title>
+      <link th:text='${"http://jonathanbullock.com"+post.uri}'>http://jonathanbullock.com/blog/foo.html</link>
+      <pubDate th:text='${#dates.format(post.date,"EEE, d MMM yyyy HH:mm:ss Z")}'>2014-01-30</pubDate>
+      <guid isPermaLink="false" th:text="${post.uri}">http://jonathanbullock.com/blog/foo.html</guid>
+      	<description th:text='${#strings.escapeXml(post.body)}'>Body of the post</description>
+    </item>
+  </channel> 
+</rss>

--- a/src/test/resources/thymeleafTemplates/footer.thyme
+++ b/src/test/resources/thymeleafTemplates/footer.thyme
@@ -1,0 +1,24 @@
+<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+
+  <body>
+
+    <div th:fragment="footer">
+    <div>
+
+      <div class="footer">
+        <p>&copy; Jonathan Bullock 2013 | Mixed with <a href="http://twitter.github.com/bootstrap/">Bootstrap v2.3.1</a> | Baked with <a href="http://jbake.org">JBake ${version}</a></p>
+      </div>
+
+    </div> <!-- /container -->
+
+    <!-- Le javascript
+    ================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <script src="/js/jquery-1.9.1.min.js"></script>
+    <script src="/js/bootstrap.min.js"></script>
+    </div>
+  </body>
+</html>

--- a/src/test/resources/thymeleafTemplates/header.thyme
+++ b/src/test/resources/thymeleafTemplates/header.thyme
@@ -1,0 +1,81 @@
+<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+<html lang="en">
+  <head th:fragment="head">
+    <meta charset="utf-8"/>
+    <title>Jonathan Bullock</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description" content=""/>
+    <meta name="author" content="Jonathan Bullock"/>
+
+    <!-- Le styles -->
+    <link href="/css/bootstrap.min.css" rel="stylesheet"/>
+    <style type="text/css">
+      body {
+        padding-top: 20px;
+        padding-bottom: 40px;
+      }
+
+      /* Custom container */
+      .container-narrow {
+        margin: 0 auto;
+        max-width: 700px;
+      }
+      .container-narrow > hr {
+        margin: 30px 0;
+      }
+
+      /* Main marketing message and sign up button */
+      .jumbotron {
+        margin: 60px 0;
+        text-align: center;
+      }
+      .jumbotron h1 {
+        font-size: 72px;
+        line-height: 1;
+      }
+      .jumbotron .btn {
+        font-size: 21px;
+        padding: 14px 24px;
+      }
+
+      /* Supporting marketing content */
+      .marketing {
+        margin: 60px 0;
+      }
+      .marketing p + h4 {
+        margin-top: 28px;
+      }
+    </style>
+    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet"/>
+
+    <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
+    <!--[if lt IE 9]>
+      <script src="/js/html5shiv.js"></script>
+    <![endif]-->
+
+    <!-- Fav and touch icons -->
+    <!--<link rel="apple-touch-icon-precomposed" sizes="144x144" href="../assets/ico/apple-touch-icon-144-precomposed.png"/>
+    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="../assets/ico/apple-touch-icon-114-precomposed.png"/>
+    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="../assets/ico/apple-touch-icon-72-precomposed.png"/>
+    <link rel="apple-touch-icon-precomposed" href="../assets/ico/apple-touch-icon-57-precomposed.png"/>
+    <link rel="shortcut icon" href="../assets/ico/favicon.png"/>-->
+  </head>
+  <body>
+    <div th:fragment="top">
+    <div class="container-narrow">
+    
+    <div class="masthead">
+        <ul class="nav nav-pills pull-right">
+          <li><a href="/">Home</a></li>
+          <li><a href="/about.html">About</a></li>
+          <li><a href="/projects.html">Projects</a></li>
+          <li><a href="/feed.xml">Subscribe</a></li>
+        </ul>
+        <h3 class="muted">Jonathan Bullock</h3>
+      </div>
+
+      <hr/>
+    </div>
+    </div>
+  </body>
+</html>

--- a/src/test/resources/thymeleafTemplates/index.thyme
+++ b/src/test/resources/thymeleafTemplates/index.thyme
@@ -1,0 +1,31 @@
+<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+      <head th:replace="header.thyme::head"/>
+      <body>
+      <div th:replace="header.thyme::top"/>
+
+      <!--<div class="jumbotron">
+        <h1>Bake your own site!</h1>
+        <p class="lead">Cras justo odio, dapibus ac facilisis in, egestas eget quam. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
+        <a class="btn btn-large btn-success" href="#">Sign up today</a>
+      </div>
+
+	<hr/>-->
+
+	<div class="row-fluid marketing">
+		<div class="span12">
+			<div th:each="post : ${posts}">
+			<h4><a th:href='${post.uri}' th:text='${post.title}' href="post_uri.html">Post title</a></h4>
+			<p th:text='${#dates.format(post.date,"dd MMMM yyyy") + " - " + #strings.substring(post.body,0, 150)}'>...</p>
+			</div>
+			<a href="/archive.html">Archive</a>
+		</div>
+	</div>
+
+	<hr/>
+
+    <div th:replace="footer.thyme::footer"></div>
+    </body>
+</html>

--- a/src/test/resources/thymeleafTemplates/page.thyme
+++ b/src/test/resources/thymeleafTemplates/page.thyme
@@ -1,0 +1,21 @@
+<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+      <head th:replace="header.thyme::head"/>
+      <body>
+      <div th:replace="header.thyme::top"/>
+
+      <div class="row-fluid marketing">
+        <div class="span12">
+          <h4 th:text='${content.title}'>Page title</h4>
+          <p th:text='${content.body}'>Page body</p>
+        </div>
+
+      </div>
+
+      <hr/>
+
+    <div th:replace="footer.thyme::footer"></div>
+    </body>
+</html>

--- a/src/test/resources/thymeleafTemplates/post.thyme
+++ b/src/test/resources/thymeleafTemplates/post.thyme
@@ -1,0 +1,20 @@
+<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+      <head th:replace="header.thyme::head"/>
+      <body>
+      <div th:replace="header.thyme::top"/>
+      <div class="row-fluid marketing">
+		<div class="span12">
+				<h2 th:text="${content.title}">Post title</h2>
+				<p class="post-date" th:text='${#dates.format(content.date,"dd MMMM yyyy")}'>Date</p>
+				<p th:text="${content.body}"></p>
+		</div>
+	</div>
+
+	<hr/>
+	
+    <div th:replace="footer.thyme::footer"></div>
+    </body>
+</html>

--- a/src/test/resources/thymeleafTemplates/tags.thyme
+++ b/src/test/resources/thymeleafTemplates/tags.thyme
@@ -1,0 +1,25 @@
+<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+      <head th:replace="header.thyme::head"/>
+      <body>
+      <div th:replace="header.thyme::top"/>
+
+	<div class="row-fluid marketing">
+		<div class="span12">
+			<h2>Tags</h2>
+			<div th:each="post : ${posts}" th:with='last_month=null' th:remove='tag'>
+                <h3 th:if='${last_month!=#dates.format(post.date,"MMMM yyyy")}' th:text='${#dates.format(post.date,"MMMM yyyy")}'>June 2014</h3>
+
+            	<h4><span th:text='${#dates.format(post.date,"dd MMMM")}' th:remove='tag'/> - <a th:href="${post.uri}" th:text='${post.title}' href="foo.html">Post title</a></h4>
+            	<span th:remove='all' th:with='last_month = ${#dates.format(post.date,"MMMM yyyy")}'/>
+            </div>
+		</div>
+	</div>
+
+	<hr/>
+
+    <div th:replace="footer.thyme::footer"></div>
+    </body>
+</html>


### PR DESCRIPTION
This pull request adds support for the Thymeleaf template engine.
- template file names _must_ end with .thyme
- ability to override the default HTML5 mode with template.<type>.thymeleaf.mode=<mode>
- does _NOT_ support lazy loaded models due to Thymeleaf limitations

Some remarks:
- I have done this to demonstrate how to add support for a new template engine
- I don't think this should be used for sites with lots of pages. Thymeleaf is kind of limited when it comes to custom models, and as such, doesn't allow loading lazily. This implies that the _whole_ database is loaded in memory for every page.
- I strongly suggest, if this PR is merged, that we start separating jbake-core from template engines/rendering engines by having submodules
