### PR TITLE
Fixed use of wrong base directory for AsciiDoctor.

### DIFF
--- a/src/main/java/org/jbake/parser/AsciidoctorEngine.java
+++ b/src/main/java/org/jbake/parser/AsciidoctorEngine.java
@@ -142,7 +142,7 @@ public class AsciidoctorEngine extends MarkupEngine {
             final String name = iterator.next();
             options.setOption(name,  guessTypeByContent(optionsSubset.getString(name)));
         }
-        options.setBaseDir(context.getContentPath());
+        options.setBaseDir(context.getFile().getParent());
         options.setSafe(UNSAFE);
         return options;
     }


### PR DESCRIPTION
Fixed use of wrong base directory, which resulted in non-functional `include::[]` directives.
