### PR TITLE
Distribution size reduction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,10 +300,22 @@
 		</dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-templates</artifactId>
+            <version>${groovy.version}</version>
+            <optional>true</optional>
+		</dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-servlet</artifactId>
+            <version>${groovy.version}</version>
+            <optional>true</optional>
+		</dependency>
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>


### PR DESCRIPTION
I know that the main part of distribution is jruby-complete dependency and it cannot be omitted as I understand. But groovy-all is second most heavy-weight dependency and it is not necessary for jbake (do you need Swing  or JMX related classes that come with it?). I replace it with smaller parts (groovy, groovy-templates and groovy-servlet). I'm not sure but it seems to me that groovy-servlet could be omitted too.
