### PR TITLE
Extensionless URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 		<commons.configuration.version>1.9</commons.configuration.version>
 		<args4j.version>2.0.23</args4j.version>
 		<freemarker.version>2.3.19</freemarker.version>
-		<junit.version>4.10</junit.version>
+		<junit.version>4.11</junit.version>
 		<pegdown.version>1.4.2</pegdown.version>
 		<jetty.version>8.1.12.v20130726</jetty.version>
         <orientdb.version>1.6.2</orientdb.version>

--- a/src/main/java/org/jbake/app/ConfigUtil.java
+++ b/src/main/java/org/jbake/app/ConfigUtil.java
@@ -1,10 +1,10 @@
 package org.jbake.app;
 
+import java.io.File;
+
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
-
-import java.io.File;
 
 /**
  * Provides Configuration related functions.
@@ -14,6 +14,7 @@ import java.io.File;
 public class ConfigUtil {
 
     public final static String DATE_FORMAT = "date.format";
+    public final static String URI_NO_EXTENSION = "uri.noExtension";
 
     public static CompositeConfiguration load(File source) throws ConfigurationException {
         CompositeConfiguration config = new CompositeConfiguration();

--- a/src/main/resources/default.properties
+++ b/src/main/resources/default.properties
@@ -71,3 +71,5 @@ markdown.extensions=HARDWRAPS,AUTOLINKS,FENCED_CODE_BLOCKS,DEFINITIONS
 db.store=memory
 # database path
 db.path=cache
+# Set to a path (starting with a slash) for which to generate a folder and index.html
+uri.noExtension=false

--- a/src/test/java/org/jbake/app/CrawlerTest.java
+++ b/src/test/java/org/jbake/app/CrawlerTest.java
@@ -1,33 +1,95 @@
 package org.jbake.app;
 
+import static org.junit.Assert.assertThat;
+
 import java.io.File;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
-import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.io.FilenameUtils;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+
 public class CrawlerTest {
-	
+
+    private final ODatabaseDocumentTx db = DBUtil.createDB("memory", "documents");
+
+    @After
+    public void after() {
+        db.drop();
+        db.close();
+    }
+
 	@Test
 	public void crawl() throws ConfigurationException {
 		CompositeConfiguration config = ConfigUtil.load(new File(this.getClass().getResource("/").getFile()));
 		Assert.assertEquals(".html", config.getString("output.extension"));
-				
+
 		URL contentUrl = this.getClass().getResource("/");
 		File content = new File(contentUrl.getFile());
 		Assert.assertTrue(content.exists());
-        ODatabaseDocumentTx db = DBUtil.createDB("memory", "documents");
-        try {
-            Crawler crawler = new Crawler(db, content, config);
-            crawler.crawl(new File(content.getPath() + File.separator + "content"));
+		Crawler crawler = new Crawler(db, content, config);
+		crawler.crawl(new File(content.getPath() + File.separator + "content"));
 
-            Assert.assertEquals(2, crawler.getPostCount());
-            Assert.assertEquals(3, crawler.getPageCount());
-        } finally {
-            db.close();
-        }
+		Assert.assertEquals(2, crawler.getPostCount());
+		Assert.assertEquals(3, crawler.getPageCount());
     }
+
+	@Test
+	public void renderWithPrettyUrls() throws Exception {
+	    Map<String, Object> testProperties = new HashMap<String, Object>();
+	    testProperties.put(ConfigUtil.URI_NO_EXTENSION, "/blog");
+
+	    CompositeConfiguration config = new CompositeConfiguration();
+	    config.addConfiguration(new MapConfiguration(testProperties));
+	    config.addConfiguration(ConfigUtil.load(new File(this.getClass().getResource("/").getFile())));
+
+	    URL contentUrl = this.getClass().getResource("/");
+	    File content = new File(contentUrl.getFile());
+	    Crawler crawler = new Crawler(db, content, config);
+	    crawler.crawl(new File(content.getPath() + File.separator + "content"));
+
+	    Assert.assertEquals(2, crawler.getPostCount());
+	    Assert.assertEquals(3, crawler.getPageCount());
+	    DocumentIterator documents = DBUtil.fetchDocuments(db, "select * from post");
+	    while (documents.hasNext()) {
+	        Map<String, Object> model = documents.next();
+	        String noExtensionUri = "/blog/\\d{4}/" + FilenameUtils.getBaseName((String) model.get("file")) + "/";
+
+	        assertThat(model.get("noExtensionUri"), RegexMatcher.matches(noExtensionUri));
+            assertThat(model.get("uri"), RegexMatcher.matches(noExtensionUri + "index\\.html"));
+	    }
+	}
+
+	private static class RegexMatcher extends BaseMatcher<Object> {
+	    private final String regex;
+
+	    public RegexMatcher(String regex){
+	        this.regex = regex;
+	    }
+
+	    @Override
+        public boolean matches(Object o){
+	        return ((String)o).matches(regex);
+
+	    }
+
+	    @Override
+        public void describeTo(Description description){
+	        description.appendText("matches regex: " + regex);
+	    }
+
+	    public static RegexMatcher matches(String regex){
+	        return new RegexMatcher(regex);
+	    }
+	}
 }


### PR DESCRIPTION
New property `uri.noExtension` allows the user to specify a root folder for which "extensionless" URLs will be created. In practice, the file name is used as a folder and the actual file is generated as index.html inside that folder. `uri.noExtension` defaults to `false`, which does nothing.

For example:

If `uri.noExtension` is set to `/blog`, then after baking, the file `/blog/2014/03/26/post.md` would become `/output/blog/2014/03/26/post/index.html` and the URL would be `<DOMAIN>/blog/2014/03/26/post`.