### PR TITLE
Create files and metadata from the command line

### DIFF
--- a/src/main/java/org/jbake/app/creator/FileCreator.java
+++ b/src/main/java/org/jbake/app/creator/FileCreator.java
@@ -1,0 +1,9 @@
+package org.jbake.app.creator;
+
+import java.util.List;
+
+public interface FileCreator {
+    boolean accepts(String fileName);
+    List<String> obtainMetadata();
+    String getSeparator();
+}

--- a/src/main/java/org/jbake/app/creator/FileCreators.java
+++ b/src/main/java/org/jbake/app/creator/FileCreators.java
@@ -1,0 +1,42 @@
+package org.jbake.app.creator;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import java.util.Scanner;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileCreators {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileCreators.class);
+
+    public static void create(String fileName) {
+        MarkdownFileCreator markdownFileCreator = new MarkdownFileCreator(new Scanner(System.in));
+
+        if (markdownFileCreator.accepts(fileName)) {
+            List<String> metadataLines = markdownFileCreator.obtainMetadata();
+            File newFile = new File(fileName);
+
+            FileWriter writer = null;
+            try {
+                writer = new FileWriter(newFile);
+
+                for (String metadataLine : metadataLines) {
+                    writer.write(metadataLine);
+                    writer.write("\n");
+                }
+
+                writer.write(markdownFileCreator.getSeparator());
+                writer.write("\n\n");
+            } catch (IOException e) {
+                LOGGER.error("Could not create a new file", e);
+            } finally {
+                IOUtils.closeQuietly(writer);
+            }
+        }
+    }
+}

--- a/src/main/java/org/jbake/app/creator/FileMetadata.java
+++ b/src/main/java/org/jbake/app/creator/FileMetadata.java
@@ -1,0 +1,70 @@
+package org.jbake.app.creator;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.apache.commons.lang.StringUtils;
+
+public class FileMetadata {
+
+    private final String type;
+    private final String status;
+    private String title;
+    private String date;
+    private String tags;
+
+    public FileMetadata(String type, String status) {
+        this.type = StringUtils.defaultIfBlank(type, "post");
+        this.status = StringUtils.defaultIfBlank(status, "draft");
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public boolean hasTitle() {
+        return StringUtils.isNotBlank(getTitle());
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public boolean hasDate() {
+        return date != null;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        if (StringUtils.isBlank(date)) {
+            this.date = null;
+        } else if (date.equals("today")) {
+            this.date = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+        } else {
+            this.date = date;
+        }
+    }
+
+    public boolean hasTags() {
+        return StringUtils.isNotBlank(getTags());
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
+}

--- a/src/main/java/org/jbake/app/creator/MarkdownFileCreator.java
+++ b/src/main/java/org/jbake/app/creator/MarkdownFileCreator.java
@@ -1,0 +1,68 @@
+package org.jbake.app.creator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+public class MarkdownFileCreator implements FileCreator {
+
+    private final Scanner scanner;
+
+    public MarkdownFileCreator(Scanner scanner) {
+        this.scanner = scanner;
+    }
+
+    @Override
+    public List<String> obtainMetadata() {
+        System.out.println("This will create a new file in the current directory.\n");
+        System.out.println("Each metadata item may have a list of pre-defined options.\n"
+                + "The starred option is the default.\n"
+                + "If there is no starred option, this metadata item is optional.\n");
+
+        System.out.print("Status: (draft* / published / published-date) ");
+        String status = scanner.nextLine();
+
+        System.out.print("Type: (post* / page) ");
+        String type = scanner.nextLine();
+
+        System.out.print("Title: ");
+        String title = scanner.nextLine();
+
+        System.out.print("Date: (today / yyyy-MM-dd) ");
+        String date = scanner.nextLine();
+
+        System.out.print("Tags: ");
+        String tags = scanner.nextLine();
+
+        FileMetadata fileMetadata = new FileMetadata(type, status);
+        fileMetadata.setDate(date);
+        fileMetadata.setTitle(title);
+        fileMetadata.setTags(tags);
+
+        ArrayList<String> metadata = new ArrayList<String>();
+
+        if (fileMetadata.hasTitle()) {
+            metadata.add("title=" + fileMetadata.getTitle());
+        }
+        if (fileMetadata.hasDate()) {
+            metadata.add("date=" + fileMetadata.getDate());
+        }
+        metadata.add("type=" + fileMetadata.getType());
+        if (fileMetadata.hasTags()) {
+            metadata.add("tags=" + fileMetadata.getTags());
+        }
+        metadata.add("status=" + fileMetadata.getStatus());
+
+        return metadata;
+    }
+
+    @Override
+    public boolean accepts(String fileName) {
+        return fileName.endsWith(".md");
+    }
+
+    @Override
+    public String getSeparator() {
+        return "~~~~~~";
+    }
+}

--- a/src/main/java/org/jbake/launcher/LaunchOptions.java
+++ b/src/main/java/org/jbake/launcher/LaunchOptions.java
@@ -1,7 +1,8 @@
 package org.jbake.launcher;
 
 import java.io.File;
- 
+
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.Option;
 
@@ -11,21 +12,24 @@ public class LaunchOptions {
 
 	@Argument(index = 1, usage = "destination folder for output, if not supplied will default to a folder called \"output\" in the current working directory", metaVar = "destination_folder")
 	private File destination = null;
-	
+
 	@Option(name = "-b", aliases = {"--bake"}, usage="start baking")
 	private boolean bake;
-	
+
 	@Option(name = "-i", aliases = {"--init"}, usage="initialises required folder structure with default templates")
 	private boolean init;
-	
+
 	@Option(name = "-s", aliases = {"--server"}, usage="runs HTTP server to serve out destination folder")
 	private boolean runServer;
-	
+
 	@Option(name = "-h", aliases = {"--help"}, usage="prints this message")
 	private boolean helpNeeded;
 
     @Option(name = "--reset", usage="clears the local cache, enforcing rendering from scratch")
     private boolean clearCache;
+
+    @Option(name = "-c", aliases = {"--create"}, usage = "create a new file in the current directory")
+    private String createFileName;
 
 	public File getSource() {
 		return source;
@@ -38,11 +42,11 @@ public class LaunchOptions {
 	public boolean isHelpNeeded() {
 		return helpNeeded;
 	}
-	
+
 	public boolean isRunServer() {
 		return runServer;
 	}
-	
+
 	public boolean isInit() {
 		return init;
 	}
@@ -52,6 +56,14 @@ public class LaunchOptions {
     }
 
     public boolean isBake() {
-		return bake || !(isHelpNeeded() || isRunServer() || isInit());
+		return bake || !(isHelpNeeded() || isRunServer() || isInit() || isCreate());
 	}
+
+    public boolean isCreate() {
+        return StringUtils.isNotBlank(createFileName);
+    }
+
+    public String getCreatedFileName() {
+        return createFileName;
+    }
 }

--- a/src/main/java/org/jbake/launcher/Main.java
+++ b/src/main/java/org/jbake/launcher/Main.java
@@ -10,28 +10,29 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.jbake.app.ConfigUtil;
 import org.jbake.app.FileUtil;
 import org.jbake.app.Oven;
+import org.jbake.app.creator.FileCreators;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 
 /**
  * Launcher for JBake.
- * 
+ *
  * @author Jonathan Bullock <jonbullock@gmail.com>
  *
  */
 public class Main {
 
 	private final String USAGE_PREFIX = "Usage: jbake";
-	
+
 	/**
 	 * Runs the app with the given arguments.
-	 * 
+	 *
 	 * @param args
 	 */
 	public static void main(String[] args) {
 		new Main().run(args);
 	}
-	
+
 	private void bake(LaunchOptions options) {
 		try {
 			Oven oven = new Oven(options.getSource(), options.getDestination(), options.isClearCache());
@@ -64,14 +65,18 @@ public class Main {
 			e.printStackTrace();
 			System.exit(1);
 		}
-		
+
 		System.out.println("JBake " + config.getString("version") + " (" + config.getString("build.timestamp") + ") [http://jbake.org]");
 		System.out.println();
-		
+
 		if (res.isHelpNeeded()) {
 			printUsage(res);
 		}
-		
+
+		if (res.isCreate()) {
+		    create(res);
+		}
+
 		if(res.isBake()) {
 			bake(res);
 		}
@@ -79,7 +84,7 @@ public class Main {
 		if (res.isInit()) {
 			initStructure(config);
 		}
-		
+
 		if (res.isRunServer()) {
 			if (res.getSource().getPath().equals(".")) {
 				// use the default destination folder
@@ -88,9 +93,10 @@ public class Main {
 				runServer(res.getSource().getPath(), config.getString("server.port"));
 			}
 		}
-		
+
 	}
-	private LaunchOptions parseArguments(String[] args) {
+
+    private LaunchOptions parseArguments(String[] args) {
 		LaunchOptions res = new LaunchOptions();
 		CmdLineParser parser = new CmdLineParser(res);
 
@@ -114,11 +120,15 @@ public class Main {
 		System.exit(0);
 	}
 
+	private void create(LaunchOptions res) {
+	    FileCreators.create(res.getCreatedFileName());
+	}
+
 	private void runServer(String path, String port) {
 		JettyServer.run(path, port);
 		System.exit(0);
 	}
-	
+
 	private void initStructure(CompositeConfiguration config) {
 		Init init = new Init(config);
 		try {

--- a/src/test/java/org/jbake/app/creator/CreatedFileTest.java
+++ b/src/test/java/org/jbake/app/creator/CreatedFileTest.java
@@ -1,0 +1,15 @@
+package org.jbake.app.creator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CreatedFileTest {
+
+    @Test
+    public void provideDefaultValuesForTypeAndStatus() throws Exception {
+        FileMetadata createdFile = new FileMetadata("", "");
+
+        Assert.assertEquals("post", createdFile.getType());
+        Assert.assertEquals("draft", createdFile.getStatus());
+    }
+}

--- a/src/test/java/org/jbake/app/creator/MarkdownFileCreatorTest.java
+++ b/src/test/java/org/jbake/app/creator/MarkdownFileCreatorTest.java
@@ -1,0 +1,39 @@
+package org.jbake.app.creator;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Scanner;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class MarkdownFileCreatorTest {
+
+    @Test
+    public void useAllCustomValues() throws Exception {
+        MarkdownFileCreator fileCreator = new MarkdownFileCreator(new Scanner("published\npage\nMy Title\n2014-02-01\ntag1 tagTwo"));
+
+        List<String> metadata = fileCreator.obtainMetadata();
+
+        Assertions.assertThat(metadata).containsExactly("title=My Title", "date=2014-02-01", "type=page", "tags=tag1 tagTwo", "status=published");
+    }
+
+    @Test
+    public void useAllDefaultValues() throws Exception {
+        MarkdownFileCreator fileCreator = new MarkdownFileCreator(new Scanner("\n\n\n\n\n"));
+
+        List<String> metadata = fileCreator.obtainMetadata();
+
+        Assertions.assertThat(metadata).containsExactly("type=post", "status=draft");
+    }
+
+    @Test
+    public void useTodayShortcut() throws Exception {
+        MarkdownFileCreator fileCreator = new MarkdownFileCreator(new Scanner("\n\n\ntoday\n\n"));
+
+        List<String> metadata = fileCreator.obtainMetadata();
+
+        Assertions.assertThat(metadata).contains("date=" + new SimpleDateFormat("yyyy-MM-dd").format(new Date()));
+    }
+}

--- a/src/test/java/org/jbake/launcher/LaunchOptionsTest.java
+++ b/src/test/java/org/jbake/launcher/LaunchOptionsTest.java
@@ -1,8 +1,11 @@
 package org.jbake.launcher;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
-import static org.assertj.core.api.Assertions.*;
+
 import junit.framework.Assert;
+
 import org.junit.Test;
 import org.kohsuke.args4j.CmdLineParser;
 
@@ -14,58 +17,58 @@ public class LaunchOptionsTest {
 		LaunchOptions res = new LaunchOptions();
 		CmdLineParser parser = new CmdLineParser(res);
 		parser.parseArgument(args);
-		
+
 		Assert.assertTrue(res.isHelpNeeded());
 	}
-	
+
 	@Test
 	public void runServer() throws Exception {
 		String[] args = {"-s"};
 		LaunchOptions res = new LaunchOptions();
 		CmdLineParser parser = new CmdLineParser(res);
 		parser.parseArgument(args);
-		
+
 		Assert.assertTrue(res.isRunServer());
 	}
-	
+
 	@Test
 	public void runServerWithFolder() throws Exception {
 		String[] args = {"-s", "/tmp"};
 		LaunchOptions res = new LaunchOptions();
 		CmdLineParser parser = new CmdLineParser(res);
 		parser.parseArgument(args);
-		
+
 		Assert.assertTrue(res.isRunServer());
 		assertThat(res.getSource()).isEqualTo(new File("/tmp"));
 	}
-	
+
 	@Test
 	public void init() throws Exception {
 		String[] args = {"-i"};
 		LaunchOptions res = new LaunchOptions();
 		CmdLineParser parser = new CmdLineParser(res);
 		parser.parseArgument(args);
-		
+
 		Assert.assertTrue(res.isInit());
 	}
-	
+
 	@Test
 	public void bake() throws Exception {
 		String[] args = {"-b"};
 		LaunchOptions res = new LaunchOptions();
 		CmdLineParser parser = new CmdLineParser(res);
 		parser.parseArgument(args);
-		
+
 		Assert.assertTrue(res.isBake());
 	}
-	
+
 	@Test
 	public void bakeNoArgs() throws Exception {
 		String[] args = {};
 		LaunchOptions res = new LaunchOptions();
 		CmdLineParser parser = new CmdLineParser(res);
 		parser.parseArgument(args);
-		
+
 		Assert.assertFalse(res.isHelpNeeded());
 		Assert.assertFalse(res.isRunServer());
 		Assert.assertFalse(res.isInit());
@@ -73,14 +76,14 @@ public class LaunchOptionsTest {
 		Assert.assertEquals(".", res.getSource().getPath());
 		Assert.assertEquals(null, res.getDestination());
 	}
-	
+
 	@Test
 	public void bakeWithArgs() throws Exception {
 		String[] args = {"/tmp/source", "/tmp/destination"};
 		LaunchOptions res = new LaunchOptions();
 		CmdLineParser parser = new CmdLineParser(res);
 		parser.parseArgument(args);
-		
+
 		Assert.assertFalse(res.isHelpNeeded());
 		Assert.assertFalse(res.isRunServer());
 		Assert.assertFalse(res.isInit());
@@ -88,4 +91,16 @@ public class LaunchOptionsTest {
 		assertThat(res.getSource()).isEqualTo(new File("/tmp/source"));
 		assertThat(res.getDestination()).isEqualTo(new File("/tmp/destination"));
 	}
+
+	@Test
+    public void create() throws Exception {
+        String[] args = {"-c", "post.md"};
+        LaunchOptions res = new LaunchOptions();
+        CmdLineParser parser = new CmdLineParser(res);
+        parser.parseArgument(args);
+
+        Assert.assertTrue("--create should be true", res.isCreate());
+        Assert.assertFalse("--bake should be false", res.isBake());
+        Assert.assertEquals("post.md", res.getCreatedFileName());
+    }
 }


### PR DESCRIPTION
I always have trouble remembering the correct metadata when creating a new file and how many tildes are in the separator.

`jbake -c my-post.md` creates a file called my-post.md in the current directory. It then gathers metadata, similar to `npm init`.

This is not quite complete yet (e.g., no asciidoc support). If @jonbullock thinks there's a good chance of integrating this feature, I'll add asciidoc, some more unit tests and whatever else is necessary.
