### PR TITLE
Localization POC

### DIFF
--- a/src/main/java/org/jbake/app/LocaleUtil.java
+++ b/src/main/java/org/jbake/app/LocaleUtil.java
@@ -1,0 +1,52 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package org.jbake.app;
+
+import java.io.File;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides locale utilities
+ * 
+ * @author asemelit
+ */
+public class LocaleUtil {
+    private final static Logger LOGGER = LoggerFactory.getLogger(LocaleUtil.class);
+    
+    public final static String LOCALE_SEPARATOR = "_";
+    
+    public static String getPathLocalePart(String locale) {
+        return locale != null ? "/" + locale : "";
+    }
+    
+    public static String getLocaleSuffix(String locale) {
+        return locale != null ? locale + LOCALE_SEPARATOR : "";
+    }
+
+    public static String stripLocaleSuffix(String stringToStrip, String locale) {
+        LOGGER.info("Stripping {} from {}", getLocaleSuffix(locale), stringToStrip);
+        return locale != null ? stringToStrip.replace(getLocaleSuffix(locale), "") : stringToStrip;
+    }
+    
+    public static String getLocaleFromDocType(String docType) {
+        return docType.contains(LOCALE_SEPARATOR) ? docType.substring(0, docType.indexOf(LOCALE_SEPARATOR)) : null ; //assuming convention for locales like en_;ru_ etc. prefix of a docType
+    }
+
+    public static String getLocaleFromUri(String uri) {
+        LOGGER.info("Looking for locale candidate in {}", uri);
+        if (uri.contains(LOCALE_SEPARATOR)) {
+            int lastBackSlash = uri.lastIndexOf("/") + 1;
+            int firstLocaleSeparator = uri.indexOf(LOCALE_SEPARATOR, lastBackSlash);
+            return firstLocaleSeparator > -1 ? uri.substring(lastBackSlash, firstLocaleSeparator) : null ; //assuming convention for locales like en_;ru_ etc. prefix of a docType
+        }
+        else {
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/org/jbake/app/Renderer.java
+++ b/src/main/java/org/jbake/app/Renderer.java
@@ -48,15 +48,17 @@ public class Renderer {
     private String findTemplateName(String docType) {
         return config.getString("template."+docType+".file");
     }
-
+    
     /**
      * Render the supplied content to a file.
      *
      * @param content The content to renderDocument
      * @throws Exception
      */
+    
     public void render(Map<String, Object> content) throws Exception {
 //		String outputFilename = (new File((String)content.get("file")).getPath().replace(source.getPath()+File.separator+"content", destination.getPath()));
+        String docType = (String) content.get("type");
         String outputFilename = destination.getPath() + (String) content.get("uri");
         outputFilename = outputFilename.substring(0, outputFilename.lastIndexOf("."));
 
@@ -82,7 +84,7 @@ public class Renderer {
         model.put("renderer", renderingEngine);
 
         try {
-            String docType = (String) content.get("type");
+            
             Writer out = createWriter(outputFile);
             renderingEngine.renderDocument(model, findTemplateName(docType), out);
             out.close();
@@ -111,16 +113,21 @@ public class Renderer {
      * @throws Exception 
      */
     public void renderIndex(String indexFile) throws Exception {
-        File outputFile = new File(destination.getPath() + File.separator + indexFile);
+        renderIndex(indexFile, null);
+    }
+    
+    public void renderIndex(String indexFile, String locale) throws Exception {
+        File outputFile = new File(destination.getPath() + LocaleUtil.getPathLocalePart(locale) + File.separator + indexFile);
+        String docType = LocaleUtil.getLocaleSuffix(locale) + "index";
         StringBuilder sb = new StringBuilder();
         sb.append("Rendering index [").append(outputFile).append("]...");
         Map<String, Object> model = new HashMap<String, Object>();
         model.put("renderer", renderingEngine);
-        model.put("content", Collections.singletonMap("type","index"));
+        model.put("content", Collections.singletonMap("type", docType));
 
         try {
             Writer out = createWriter(outputFile);
-            renderingEngine.renderDocument(model, findTemplateName("index"), out);
+            renderingEngine.renderDocument(model, findTemplateName(docType), out);
             out.close();
             sb.append("done!");
             LOGGER.info(sb.toString());
@@ -165,16 +172,21 @@ public class Renderer {
      * @throws Exception 
      */
     public void renderFeed(String feedFile) throws Exception {
-        File outputFile = new File(destination.getPath() + File.separator + feedFile);
+        renderFeed(feedFile, null);
+    }
+    
+    public void renderFeed(String feedFile, String locale) throws Exception {
+        File outputFile = new File(destination.getPath() + LocaleUtil.getPathLocalePart(locale) + File.separator + feedFile);
+        String docType = LocaleUtil.getLocaleSuffix(locale) + "feed";
         StringBuilder sb = new StringBuilder();
         sb.append("Rendering feed [").append(outputFile).append("]... ");
         Map<String, Object> model = new HashMap<String, Object>();
         model.put("renderer", renderingEngine);
-        model.put("content", Collections.singletonMap("type","feed"));
+        model.put("content", Collections.singletonMap("type",docType));
 
         try {
             Writer out = createWriter(outputFile);
-            renderingEngine.renderDocument(model, findTemplateName("feed"), out);
+            renderingEngine.renderDocument(model, findTemplateName(docType), out);
             out.close();
             sb.append("done!");
             LOGGER.info(sb.toString());
@@ -192,16 +204,21 @@ public class Renderer {
      * @throws Exception 
      */
     public void renderArchive(String archiveFile) throws Exception {
-        File outputFile = new File(destination.getPath() + File.separator + archiveFile);
+        renderArchive(archiveFile, null);
+    }
+    
+    public void renderArchive(String archiveFile, String locale) throws Exception {
+        File outputFile = new File(destination.getPath() + LocaleUtil.getPathLocalePart(locale) + File.separator + archiveFile);
+        String docType = LocaleUtil.getLocaleSuffix(locale) + "archive";
         StringBuilder sb = new StringBuilder();
         sb.append("Rendering archive [").append(outputFile).append("]... ");
         Map<String, Object> model = new HashMap<String, Object>();
         model.put("renderer", renderingEngine);
-        model.put("content", Collections.singletonMap("type","archive"));
+        model.put("content", Collections.singletonMap("type",docType));
 
         try {
             Writer out = createWriter(outputFile);
-            renderingEngine.renderDocument(model, findTemplateName("archive"), out);
+            renderingEngine.renderDocument(model, findTemplateName(docType), out);
             out.close();
             sb.append("done!");
             LOGGER.info(sb.toString());

--- a/src/main/java/org/jbake/model/DocumentTypes.java
+++ b/src/main/java/org/jbake/model/DocumentTypes.java
@@ -20,6 +20,10 @@ public class DocumentTypes {
         DEFAULT_DOC_TYPES.add(docType);
     }
 
+    public static boolean hasDocumentType(String docType) {
+        return DEFAULT_DOC_TYPES.contains(docType);
+    }
+    
     public static String[] getDocumentTypes() {
         return DEFAULT_DOC_TYPES.toArray(new String[DEFAULT_DOC_TYPES.size()]);
     }

--- a/src/main/java/org/jbake/model/LocaleTypes.java
+++ b/src/main/java/org/jbake/model/LocaleTypes.java
@@ -1,0 +1,59 @@
+package org.jbake.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Utility class used to determine the list of locale types. Default is just one existing locale.
+ * <p/>
+ * Additional document types are added at runtime based on the types found in the configuration.
+ *
+ * @author asemelit
+ */
+public class LocaleTypes {
+
+    private static final Map<String, Set<String>> DEFAULT_LOC_TYPES = new HashMap<String, Set<String>>(); //empty by default
+
+    public static void addLocale(String locale, Set<String> docTypeSet) {
+        if (hasLocale(locale)) {
+            DEFAULT_LOC_TYPES.get(locale).addAll(docTypeSet);
+        }
+        else {
+            DEFAULT_LOC_TYPES.put(locale, docTypeSet);
+        }
+    }
+
+    public static String[] getLocales() {       
+        return DEFAULT_LOC_TYPES.keySet().toArray(new String[DEFAULT_LOC_TYPES.size()]);
+    }
+    
+    public static boolean hasLocale(String locale) {
+        return DEFAULT_LOC_TYPES.containsKey(locale);
+    }
+
+    public static boolean hasLocalizedType(String locale, String docType) {
+        return DEFAULT_LOC_TYPES.containsKey(locale) ? DEFAULT_LOC_TYPES.get(locale).contains(docType) : false;
+    }
+
+    
+    public static String[] getLocalizedDocTypes(String locale) {
+        if (hasLocale(locale)) {
+            return DEFAULT_LOC_TYPES.get(locale).toArray(new String[DEFAULT_LOC_TYPES.size()]);
+        }
+        else {
+            return new String[0];
+        }
+    }
+    
+    public static String[] getLocalesForType(String docType) {
+        ArrayList<String> result = new ArrayList<String>();
+        for (Map.Entry<String, Set<String>> localeMapping : DEFAULT_LOC_TYPES.entrySet()) {
+            if (localeMapping.getValue().contains(docType)) {
+                result.add(localeMapping.getKey());
+            }
+        }
+        return result.toArray(new String[result.size()]);
+    }
+}

--- a/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
+++ b/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -61,7 +62,19 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
     @Override
     public void renderDocument(final Map<String, Object> model, final String templateName, final Writer writer) throws RenderingException {
         try {
-            Template template = templateCfg.getTemplate(templateName);
+            Template template = null;
+            if (templateName.contains("_")) {
+                String locale = templateName.substring(templateName.lastIndexOf("_"));
+                Locale resolvedLocale = Locale.forLanguageTag(locale);
+                if (resolvedLocale != null) {
+                    template = templateCfg.getTemplate(templateName, resolvedLocale);
+                }
+            }
+            
+            if (template == null) {
+                template = templateCfg.getTemplate(templateName); //using default
+            }
+            
             template.process(new LazyLoadingModel(model, db), writer);
         } catch (IOException e) {
             throw new RenderingException(e);

--- a/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
+++ b/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
@@ -124,6 +124,10 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
                 if ((docType+"s").equals(key)) {
                     return new SimpleSequence(DocumentList.wrap(DBUtil.query(db, "select * from "+docType+" order by date desc").iterator()));
                 }
+                if (("published_"+docType+"s").equals(key)) {
+                    List<ODocument> query = db.query(new OSQLSynchQuery<ODocument>("select * from "+docType+" where status='published' order by date desc"));
+                    return new SimpleSequence(DocumentList.wrap(query.iterator()));
+                }
             }
             if ("tag_posts".equals(key)) {
                 String tag = eagerModel.get("tag").toString();


### PR DESCRIPTION
Hello there,

While I've been playing around with JBake, I just thought may be a localization feature could be useful?

The idea is: localized pages during the build are being put to a separate folder. Since the pages are static it is the cheapest and straight-forward option. Switching between the localized/original is to be operated by URL manipulation in javascript. E.g. the following transformation will occur:

```
src\jbake\content\blog\2014\jbake_locale.md -> \blog\2014\jbake_locale.html (original)
src\jbake\content\blog\2014\en_jbake_locale.md -> \en\blog\2014\jbake_locale.html (localized)
```

Overall convention is the following:
- Localized post file name should differ from original only by _localeId__ prefix (in my case **en_**)
- Add the localized templates into jbake.properties
- Localized template name should start from _localeId__ (in my case **en_**)
- Keep the _localeId__ in mind when populating links and includes inside of the templates

If none are supplied - no localization, falls back to the usual transformation.

If the idea is all right, I'll extend the current POC to all other template engines etc.

P.S. working blog [sources](https://github.com/bashnesnos/blog) and live [example](http://bashnesnos.github.io/blog/en/)
