### PR TITLE
add interlinks plugin for markdown

### DIFF
--- a/src/main/java/org/jbake/app/Parser.java
+++ b/src/main/java/org/jbake/app/Parser.java
@@ -3,8 +3,11 @@ package org.jbake.app;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.io.IOUtils;
 import org.jbake.parser.Engines;
+import org.jbake.parser.MarkdownEngine;
 import org.jbake.parser.MarkupEngine;
 import org.jbake.parser.ParserContext;
+import org.jbake.plugins.ContentPlugin;
+import org.jbake.plugins.InterlinksContentPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,6 +104,14 @@ public class Parser {
 
         // generate default body
         processBody(fileContents, content);
+        
+		{
+			ContentPlugin interlinks = new InterlinksContentPlugin();
+
+			if (engine instanceof MarkdownEngine) {
+				interlinks.parseMarkdown(content, config);
+			}
+		}
 
         // eventually process body using specific engine
         if (engine.validate(context)) {

--- a/src/main/java/org/jbake/plugins/ContentPlugin.java
+++ b/src/main/java/org/jbake/plugins/ContentPlugin.java
@@ -1,0 +1,11 @@
+package org.jbake.plugins;
+
+import java.util.Map;
+
+import org.apache.commons.configuration.CompositeConfiguration;
+
+public interface ContentPlugin {
+	
+	public void parseMarkdown(Map<String, Object> content, CompositeConfiguration config) throws ContentPluginException;
+
+}

--- a/src/main/java/org/jbake/plugins/ContentPluginException.java
+++ b/src/main/java/org/jbake/plugins/ContentPluginException.java
@@ -1,0 +1,11 @@
+package org.jbake.plugins;
+
+public class ContentPluginException extends RuntimeException {
+
+	public ContentPluginException(String string) {
+		super(string);
+	}
+
+	private static final long	serialVersionUID	= 1L;
+
+}

--- a/src/main/java/org/jbake/plugins/InterlinksContentPlugin.java
+++ b/src/main/java/org/jbake/plugins/InterlinksContentPlugin.java
@@ -1,0 +1,49 @@
+package org.jbake.plugins;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.configuration.CompositeConfiguration;
+
+public class InterlinksContentPlugin implements ContentPlugin {
+
+	private Pattern				pattern;
+
+	public static final String	PLUGIN_INTERLINKS_PREFIX	= "interlinks.";
+
+	public InterlinksContentPlugin() {
+
+		pattern = Pattern.compile("\\((.+?)>\\)");
+	}
+
+	@Override
+	public void parseMarkdown(Map<String, Object> content, CompositeConfiguration config)
+			throws ContentPluginException {
+
+		String body = (String) content.get("body");
+
+		Matcher matcher = pattern.matcher(body);
+
+		StringBuffer sb = new StringBuffer();
+
+		while (matcher.find()) {
+
+			String interlinkName = matcher.group(1);
+
+			String link = config.getString(PLUGIN_INTERLINKS_PREFIX
+					+ interlinkName);
+
+			if (link == null) {
+				throw new ContentPluginException(
+						"Could not find interlinks link '" + interlinkName
+								+ "' in config file ");
+			}
+			matcher.appendReplacement(sb, "(" + link + ")");
+		}
+
+		matcher.appendTail(sb);
+
+		content.put("body", sb.toString());
+	}
+}

--- a/src/test/java/org/jbake/plugins/InterlinksContentPluginTest.java
+++ b/src/test/java/org/jbake/plugins/InterlinksContentPluginTest.java
@@ -1,0 +1,32 @@
+package org.jbake.plugins;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.junit.Test;
+
+public class InterlinksContentPluginTest {
+
+	@Test
+	public void test() throws ContentPluginException {
+
+		CompositeConfiguration config = new CompositeConfiguration();
+		config.addProperty("interlinks.coollink", "http://www.cool-link.org");
+
+		String mdContent = "This is a [cool link](coollink>) that links to this site.";
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("body", mdContent);
+
+		String expected = "This is a [cool link](http://www.cool-link.org) that links to this site.";
+
+		InterlinksContentPlugin plugin = new InterlinksContentPlugin();
+
+		plugin.parseMarkdown(map, config);
+
+		assertEquals(expected, map.get("body"));
+	}
+
+}


### PR DESCRIPTION
### Manage frequently used links in config file.

**Config example:**

```
interlinks.example=http://www.example.de
```

**Usage in markdown:**

```
[Normal boring link](http://www.example.com). 
But this is a [cool link](example>) that links to this site.
```

**generates:**

```
<a href="http://www.example.com">Normal boring link</a>. 
But this is a <a href="http://www.example.de">cool link</a> that links to this site.
```

Inspired bei interlinks plugin from pelican website generator.
