### PR TITLE
WIP: Rework commandline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -31,7 +32,7 @@
 		<connection>scm:git:git@github.com:jbake-org/jbake.git</connection>
 		<developerConnection>scm:git:https://github.com/jbake-org/jbake.git</developerConnection>
 	</scm>
-	
+
 	<issueManagement>
 		<system>GitHub Issues</system>
 		<url>https://github.com/jbake-org/jbake/issues</url>
@@ -63,22 +64,22 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<timestamp>${maven.build.timestamp}</timestamp>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ssa</maven.build.timestamp.format>
-		
+
 		<asciidoctor.java.version>0.1.4</asciidoctor.java.version>
 		<commons.io.version>2.4</commons.io.version>
 		<commons.configuration.version>1.9</commons.configuration.version>
-		<args4j.version>2.0.23</args4j.version>
 		<freemarker.version>2.3.20</freemarker.version>
 		<junit.version>4.10</junit.version>
 		<pegdown.version>1.4.2</pegdown.version>
 		<jetty.version>8.1.12.v20130726</jetty.version>
-        <orientdb.version>1.6.2</orientdb.version>
-        <groovy.version>2.3.4</groovy.version>
-        <slf4j.version>1.7.5</slf4j.version>
-        <logback.version>1.0.9</logback.version>
-        <assertj.version>1.6.0</assertj.version>
-        <thymeleaf.version>2.1.3.RELEASE</thymeleaf.version>
-    </properties>
+		<orientdb.version>1.6.2</orientdb.version>
+		<groovy.version>2.3.4</groovy.version>
+		<slf4j.version>1.7.5</slf4j.version>
+		<logback.version>1.0.9</logback.version>
+		<assertj.version>1.6.0</assertj.version>
+		<thymeleaf.version>2.1.3.RELEASE</thymeleaf.version>
+		<cmdoption.version>0.3.2</cmdoption.version>
+	</properties>
 
 	<build>
 		<finalName>${project.artifactId}</finalName>
@@ -153,8 +154,8 @@
 							<packageName>org.jbake.launcher</packageName>
 						</manifest>
 						<manifestEntries>
-                        	<Class-Path>lib/</Class-Path>
-                    	</manifestEntries>
+							<Class-Path>lib/</Class-Path>
+						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>
@@ -255,8 +256,8 @@
 						</configuration>
 					</execution>
 				</executions>
-        	</plugin>
-        	<plugin>
+			</plugin>
+			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.6.3.201306030806</version>
@@ -298,26 +299,21 @@
 			<version>${commons.configuration.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>args4j</groupId>
-			<artifactId>args4j</artifactId>
-			<version>${args4j.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
 			<version>${freemarker.version}</version>
-            <optional>true</optional>
+			<optional>true</optional>
 		</dependency>
-        <dependency>
-            <groupId>com.orientechnologies</groupId>
-            <artifactId>orient-commons</artifactId>
-            <version>${orientdb.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.orientechnologies</groupId>
-            <artifactId>orientdb-core</artifactId>
-            <version>${orientdb.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>com.orientechnologies</groupId>
+			<artifactId>orient-commons</artifactId>
+			<version>${orientdb.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.orientechnologies</groupId>
+			<artifactId>orientdb-core</artifactId>
+			<version>${orientdb.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>
@@ -331,60 +327,62 @@
 			<version>${assertj.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- <dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.21</version>
-		</dependency> -->
+		<!-- <dependency> <groupId>mysql</groupId> <artifactId>mysql-connector-java</artifactId> 
+			<version>5.1.21</version> </dependency> -->
 		<dependency>
 			<groupId>org.pegdown</groupId>
 			<artifactId>pegdown</artifactId>
 			<version>${pegdown.version}</version>
-            <optional>true</optional>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.asciidoctor</groupId>
 			<artifactId>asciidoctor-java-integration</artifactId>
 			<version>${asciidoctor.java.version}</version>
-            <optional>true</optional>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
 			<version>${jetty.version}</version>
-            <optional>true</optional>
+			<optional>true</optional>
 		</dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.thymeleaf</groupId>
-            <artifactId>thymeleaf</artifactId>
-            <version>${thymeleaf.version}</version>
-            <optional>true</optional>
-        </dependency>
+		<dependency>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy-all</artifactId>
+			<version>${groovy.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.thymeleaf</groupId>
+			<artifactId>thymeleaf</artifactId>
+			<version>${thymeleaf.version}</version>
+			<optional>true</optional>
+		</dependency>
 		<!-- sl4j Logging -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>de.tototec</groupId>
+			<artifactId>de.tototec.cmdoption</artifactId>
+			<version>${cmdoption.version}</version>
+		</dependency>
 
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-            <optional>true</optional>
-        </dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>${logback.version}</version>
+			<optional>true</optional>
+		</dependency>
 
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
-            <optional>true</optional>
-        </dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<version>${logback.version}</version>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/org/jbake/launcher/JBakeException.java
+++ b/src/main/java/org/jbake/launcher/JBakeException.java
@@ -1,0 +1,15 @@
+package org.jbake.launcher;
+
+public class JBakeException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public JBakeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public JBakeException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/org/jbake/launcher/LaunchOptions.java
+++ b/src/main/java/org/jbake/launcher/LaunchOptions.java
@@ -1,34 +1,34 @@
 package org.jbake.launcher;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
-import org.kohsuke.args4j.Argument;
-import org.kohsuke.args4j.Option;
+import de.tototec.cmdoption.CmdOption;
 
 public class LaunchOptions {
-	@Argument(index = 0, usage = "source folder of site content (with templates and assets), if not supplied will default to current directory", metaVar = "<source>")
+	@CmdOption(names = { "--source" }, args = { "<source>" }, description = "source folder of site content (with templates and assets), if not supplied will default to current directory")
 	private String source;
-	
-	@Argument(index = 1, usage = "destination folder for output, if not supplied will default to a folder called \"output\" in the current directory", metaVar = "<destination>")
+
+	@CmdOption(names = { "--destination", "-d" }, args = { "<destination>" }, description = "destination folder for output, if not supplied will default to a folder called \"output\" in the current directory")
 	private String destination;
-	
-	@Option(name = "-b", aliases = {"--bake"}, usage="start baking (this is the default action if no option is supplied)")
+
+	@CmdOption(names = { "--bake", "-b" }, description = "start baking (this is the default action if no option is supplied)")
 	private boolean bake;
-	
-	@Option(name = "-i", aliases = {"--init"}, usage="initialises required folder structure with default templates")
+
+	@CmdOption(names = { "--init", "-i" }, description = "initialises required folder structure with default templates")
 	private boolean init;
-	
-	@Option(name = "-s", aliases = {"--server"}, usage="runs HTTP server to serve out baked site, if no <value> is supplied will default to a folder called \"output\" in the current directory")
+
+	@CmdOption(names = { "--server", "-s" }, description = "runs HTTP server to serve out baked site, if no <value> is supplied will default to a folder called \"output\" in the current directory")
 	private boolean runServer;
-	
-	@Option(name = "-h", aliases = {"--help"}, usage="prints this message")
+
+	@CmdOption(names = { "--help", "-h" }, description = "prints this message", isHelp = true)
 	private boolean helpNeeded;
 
-    @Option(name = "--reset", usage="clears the local cache, enforcing rendering from scratch")
-    private boolean clearCache;
-    
+	@CmdOption(names = { "--reset" }, description = "clears the local cache, enforcing rendering from scratch")
+	private boolean clearCache;
+
+	@CmdOption(names = { "--verbose", "-v" }, description = "be more verbose")
+	private boolean verbose;
+
 	public File getSource() {
 		if (source != null) {
 			return new File(source);
@@ -36,7 +36,7 @@ public class LaunchOptions {
 			return new File(".");
 		}
 	}
-	
+
 	public String getSourceValue() {
 		return source;
 	}
@@ -47,9 +47,9 @@ public class LaunchOptions {
 		} else {
 			return null;
 		}
-		
+
 	}
-	
+
 	public String getDestinationValue() {
 		return destination;
 	}
@@ -57,20 +57,24 @@ public class LaunchOptions {
 	public boolean isHelpNeeded() {
 		return helpNeeded;
 	}
-	
+
 	public boolean isRunServer() {
 		return runServer;
 	}
-	
+
 	public boolean isInit() {
 		return init;
 	}
 
-    public boolean isClearCache() {
-        return clearCache;
-    }
+	public boolean isClearCache() {
+		return clearCache;
+	}
 
-    public boolean isBake() {
+	public boolean isVerbose() {
+		return verbose;
+	}
+
+	public boolean isBake() {
 		return bake || !(isHelpNeeded() || isRunServer() || isInit());
 	}
 }

--- a/src/test/java/org/jbake/launcher/LaunchOptionsTest.java
+++ b/src/test/java/org/jbake/launcher/LaunchOptionsTest.java
@@ -1,71 +1,75 @@
 package org.jbake.launcher;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
-import static org.assertj.core.api.Assertions.*;
+
 import junit.framework.Assert;
+
 import org.junit.Test;
-import org.kohsuke.args4j.CmdLineParser;
+
+import de.tototec.cmdoption.CmdlineParser;
 
 public class LaunchOptionsTest {
 
 	@Test
 	public void showHelp() throws Exception {
-		String[] args = {"-h"};
+		String[] args = { "-h" };
 		LaunchOptions res = new LaunchOptions();
-		CmdLineParser parser = new CmdLineParser(res);
-		parser.parseArgument(args);
-		
+		CmdlineParser parser = new CmdlineParser(res);
+		parser.parse(args);
+
 		Assert.assertTrue(res.isHelpNeeded());
 	}
-	
+
 	@Test
 	public void runServer() throws Exception {
-		String[] args = {"-s"};
+		String[] args = { "-s" };
 		LaunchOptions res = new LaunchOptions();
-		CmdLineParser parser = new CmdLineParser(res);
-		parser.parseArgument(args);
-		
+		CmdlineParser parser = new CmdlineParser(res);
+		parser.parse(args);
+
 		Assert.assertTrue(res.isRunServer());
 	}
-	
+
 	@Test
 	public void runServerWithFolder() throws Exception {
-		String[] args = {"-s", "/tmp"};
+		String[] args = { "-s", "--source", "/tmp" };
 		LaunchOptions res = new LaunchOptions();
-		CmdLineParser parser = new CmdLineParser(res);
-		parser.parseArgument(args);
-		
+		CmdlineParser parser = new CmdlineParser(res);
+		parser.parse(args);
+
 		Assert.assertTrue(res.isRunServer());
 		assertThat(res.getSource()).isEqualTo(new File("/tmp"));
 	}
-	
+
 	@Test
 	public void init() throws Exception {
-		String[] args = {"-i"};
+		String[] args = { "-i" };
 		LaunchOptions res = new LaunchOptions();
-		CmdLineParser parser = new CmdLineParser(res);
-		parser.parseArgument(args);
-		
+		CmdlineParser parser = new CmdlineParser(res);
+		parser.parse(args);
+
 		Assert.assertTrue(res.isInit());
 	}
-	
+
 	@Test
 	public void bake() throws Exception {
-		String[] args = {"-b"};
+		String[] args = { "-b" };
 		LaunchOptions res = new LaunchOptions();
-		CmdLineParser parser = new CmdLineParser(res);
-		parser.parseArgument(args);
-		
+		CmdlineParser parser = new CmdlineParser(res);
+		parser.parse(args);
+
 		Assert.assertTrue(res.isBake());
 	}
-	
+
 	@Test
 	public void bakeNoArgs() throws Exception {
 		String[] args = {};
 		LaunchOptions res = new LaunchOptions();
-		CmdLineParser parser = new CmdLineParser(res);
-		parser.parseArgument(args);
-		
+		CmdlineParser parser = new CmdlineParser(res);
+		parser.parse(args);
+
 		Assert.assertFalse(res.isHelpNeeded());
 		Assert.assertFalse(res.isRunServer());
 		Assert.assertFalse(res.isInit());
@@ -73,14 +77,14 @@ public class LaunchOptionsTest {
 		Assert.assertEquals(".", res.getSource().getPath());
 		Assert.assertEquals(null, res.getDestination());
 	}
-	
+
 	@Test
 	public void bakeWithArgs() throws Exception {
-		String[] args = {"/tmp/source", "/tmp/destination"};
+		String[] args = { "--source", "/tmp/source", "--destination", "/tmp/destination" };
 		LaunchOptions res = new LaunchOptions();
-		CmdLineParser parser = new CmdLineParser(res);
-		parser.parseArgument(args);
-		
+		CmdlineParser parser = new CmdlineParser(res);
+		parser.parse(args);
+
 		Assert.assertFalse(res.isHelpNeeded());
 		Assert.assertFalse(res.isRunServer());
 		Assert.assertFalse(res.isInit());


### PR DESCRIPTION
This pull reqest replaces the cmdline parser with CmdOption. I also started to eliminate System.exit() calls from various places. This makes it easier to run JBake as library. The command line parser is used to populate the configuration. With that configuration an instance of the Main class is created. Calls to it's non-static methods will not call System.exit() but will throw a JBakeException in case of an error.

I removed the printUsage() method from Main, as this is now completely rendered by CmdOption. Please note, that is very easy to provide translated versions of it. If you are interested in it, I could create a German translation for it.

WDYT?