### PR TITLE
Add optional tag-specific feeds

### DIFF
--- a/src/main/java/org/jbake/app/Renderer.java
+++ b/src/main/java/org/jbake/app/Renderer.java
@@ -245,6 +245,31 @@ public class Renderer {
                 LOGGER.error(sb.toString(), e);
                 errors.add(e.getMessage());
             }
+
+            if (config.getBoolean("render.tagfeeds", false)) {
+                File outputFile1 = new File(destination.getPath() + File.separator + tagPath + File.separator + tag + "-feed.xml");
+                StringBuilder sb1 = new StringBuilder();
+                sb1.append("Rendering feed [").append(outputFile1).append("]... ");
+                Map<String, Object> model1 = new HashMap<String, Object>();
+                model1.put("renderer", renderingEngine);
+                Map<String, Object> content = new HashMap<String, Object>();
+                content.put("type", "feed");
+                content.put("tags", Collections.singletonList(tag));
+                model1.put("content", content);
+
+                try {
+                    Writer out = createWriter(outputFile1);
+                    renderingEngine.renderDocument(model1, findTemplateName("tagfeed"), out);
+                    out.close();
+                    sb1.append("done!");
+                    LOGGER.info(sb1.toString());
+                } catch (Exception e) {
+                    sb1.append("failed!");
+                    LOGGER.error(sb1.toString(), e);
+                    throw new Exception("Failed to render feed. Cause: " + e.getMessage());
+                }
+
+            }
         }
         if (!errors.isEmpty()) {
         	StringBuilder sb = new StringBuilder();

--- a/src/main/resources/default.properties
+++ b/src/main/resources/default.properties
@@ -14,6 +14,8 @@ template.feed.file=feed.ftl
 template.archive.file=archive.ftl
 # filename of tag template file
 template.tag.file=tags.ftl
+# filename of tagfeed template file
+template.tagfeed.file=tagfeed.ftl
 # filename of sitemap template file
 template.sitemap.file=sitemap.ftl
 # filename of post template file
@@ -30,6 +32,8 @@ render.index=true
 index.file=index.html
 # render feed file?
 render.feed=true
+# render additional feed file per tag?
+render.tagfeeds=false
 # character encoding MIME name used for rendering.
 # use one of http://www.iana.org/assignments/character-sets/character-sets.xhtml
 render.encoding=UTF-8


### PR DESCRIPTION
This is useful for posting to 'planet' like feed aggregators, when an
author would like to have only a certain subset of posts aggregated.

For example, if a blog contains a mixture of Eclipse-related content,
and pictures of cats wearing silly hats; then only the posts tagged
with 'eclipse' should appear on http://planeteclipse.org/planet/

This requires a new template file. I've created ones for the
Freemarker ([here](https://github.com/jbake-org/jbake-example-project-freemarker/pull/10)) and Groovy ([here](https://github.com/jbake-org/jbake-example-project-groovy/pull/1)) example projects.
