### PR TITLE
Locate output directory in project dir by default

### DIFF
--- a/src/main/java/org/jbake/app/Oven.java
+++ b/src/main/java/org/jbake/app/Oven.java
@@ -74,7 +74,7 @@ public class Oven {
 
     private void ensureDestination() throws Exception {
         if (null == destination) {
-            destination = new File(config.getString("destination.folder"));
+            destination = new File(source, config.getString("destination.folder"));
         }
         if (!destination.exists()) {
             destination.mkdirs();


### PR DESCRIPTION
With this change we can do something like this:

```
mkdir /tmp/foo
jbake -i /tmp/foo
jbake /tmp/foo
jbake -s /tmp/foo/output
```

All command from one place.

Other way (generate site inplace)

```
mkdir /tmp/foo
jbake -i /tmp/foo
jbake /tmp/foo target
jbake -s target
```

No more `cd` commands
