### PR TITLE
Thymeleaf templates are plain HTML files, they should be named .html

### DIFF
--- a/src/main/resources/META-INF/org.jbake.parser.TemplateEngines.properties
+++ b/src/main/resources/META-INF/org.jbake.parser.TemplateEngines.properties
@@ -1,3 +1,3 @@
 org.jbake.template.FreemarkerTemplateEngine=ftl
 org.jbake.template.GroovyTemplateEngine=groovy,gsp,gxml
-org.jbake.template.ThymeleafTemplateEngine=thyme
+org.jbake.template.ThymeleafTemplateEngine=thyme,html


### PR DESCRIPTION
This is important for example when live editing (a plugin) in IntelliJ. This doesn't work with .thyme extension and the IntelliJ built-in debug webserver.