### PR TITLE
Closes #205 - added jul-to-slf4j bridge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,13 @@
 			<version>${slf4j.version}</version>
 		</dependency>
 
-        <dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jul-to-slf4j</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
+
+		<dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>

--- a/src/main/java/org/jbake/launcher/Main.java
+++ b/src/main/java/org/jbake/launcher/Main.java
@@ -14,6 +14,7 @@ import org.jbake.app.JBakeException;
 import org.jbake.app.Oven;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 /**
  * Launcher for JBake.
@@ -33,6 +34,8 @@ public class Main {
 	 */
 	public static void main(final String[] args) {
 		try {
+			installLegacyLoggingBridge();
+
 			new Main().run(args);
 		} catch (final JBakeException e) {
 			System.err.println(e.getMessage());
@@ -42,6 +45,11 @@ public class Main {
 			System.err.println("An unexpected error occurred: " + e.getMessage());
 			System.exit(2);
 		}
+	}
+
+	private static void installLegacyLoggingBridge() {
+		SLF4JBridgeHandler.removeHandlersForRootLogger();
+		SLF4JBridgeHandler.install();
 	}
 
 	private void bake(final LaunchOptions options, final CompositeConfiguration config) {


### PR DESCRIPTION
OrientDB uses java.util.logging.
The bridge routes the log messages from jul to slf4j.
See http://www.slf4j.org/legacy.html