### PR TITLE
Last modification date as alternative to date header

### DIFF
--- a/src/main/java/org/jbake/app/Parser.java
+++ b/src/main/java/org/jbake/app/Parser.java
@@ -86,6 +86,10 @@ public class Parser {
         // then read engine specific headers
         engine.processHeader(context);
         
+        if (content.get("date") == null) {
+        	content.put("date", new Date(file.lastModified()));
+        }
+        
         if (config.getString(Keys.DEFAULT_STATUS) != null) {
         	// default status has been set
         	if (content.get("status") == null) {


### PR DESCRIPTION
Use date of last modification of source file, if no "date" header is given in the file meta data. For regular pages (not blog posts), this simplifies the task of having an up-to-date "date" on the page. The page date is simply taken from the file time-stamp of the file system.