### PR TITLE
Detailed errors with stack trace of the original problem

### DIFF
--- a/src/main/java/org/jbake/app/Asset.java
+++ b/src/main/java/org/jbake/app/Asset.java
@@ -26,7 +26,7 @@ public class Asset {
     private File source;
 	private File destination;
 	private CompositeConfiguration config;
-	private final List<String> errors = new LinkedList<String>();
+	private final List<Throwable> errors = new LinkedList<Throwable>();
 	private final boolean ignoreHidden;
 
 	/**
@@ -70,7 +70,7 @@ public class Asset {
 						sb.append("failed!");
 						LOGGER.error(sb.toString(), e);
 						e.printStackTrace();
-						errors.add(e.getMessage());
+						errors.add(e);
 					}
 				}
 
@@ -81,8 +81,8 @@ public class Asset {
 		}
 	}
 
-	public List<String> getErrors() {
-		return new ArrayList<String>(errors);
+	public List<Throwable> getErrors() {
+		return new ArrayList<Throwable>(errors);
 	}
 
 }

--- a/src/main/java/org/jbake/app/Oven.java
+++ b/src/main/java/org/jbake/app/Oven.java
@@ -40,7 +40,7 @@ public class Oven {
 	private File contentsPath;
 	private File assetsPath;
 	private boolean isClearCache;
-	private List<String> errors = new LinkedList<String>();
+	private List<Throwable> errors = new LinkedList<Throwable>();
 	private int renderedCount = 0;
 
     /**
@@ -157,7 +157,7 @@ public class Oven {
                                         renderer.render(DBUtil.documentToModel(document));
                                         renderedCount++;
                                 } catch (Exception e) {
-                                        errors.add(e.getMessage());
+                                        errors.add(e);
                                 }
                         }
                 }
@@ -167,7 +167,7 @@ public class Oven {
                         try {
                                 renderer.renderIndex(config.getString(Keys.INDEX_FILE));
                         } catch (Exception e) {
-                                errors.add(e.getMessage());
+                                errors.add(e);
                         }
                 }
 
@@ -176,7 +176,7 @@ public class Oven {
                         try {
                                 renderer.renderFeed(config.getString(Keys.FEED_FILE));
                         } catch (Exception e) {
-                                errors.add(e.getMessage());
+                                errors.add(e);
                         }
                 }
 
@@ -185,7 +185,7 @@ public class Oven {
                         try {
                                 renderer.renderSitemap(config.getString(Keys.SITEMAP_FILE));
                         } catch (Exception e) {
-                                errors.add(e.getMessage());
+                                errors.add(e);
                         }
                 }
 
@@ -194,7 +194,7 @@ public class Oven {
                         try {
                                 renderer.renderArchive(config.getString(Keys.ARCHIVE_FILE));
                         } catch (Exception e) {
-                                errors.add(e.getMessage());
+                                errors.add(e);
                         }
                 }
 
@@ -203,7 +203,7 @@ public class Oven {
                         try {
                                 renderer.renderTags(crawler.getTags(), config.getString(Keys.TAG_PATH));
                         } catch (Exception e) {
-                                errors.add(e.getMessage());
+                                errors.add(e);
                         }
                 }
 
@@ -277,8 +277,8 @@ public class Oven {
         }
     }
 
-	public List<String> getErrors() {
-		return new ArrayList<String>(errors);
+	public List<Throwable> getErrors() {
+		return new ArrayList<Throwable>(errors);
 	}
     
 }

--- a/src/main/java/org/jbake/app/Renderer.java
+++ b/src/main/java/org/jbake/app/Renderer.java
@@ -93,7 +93,7 @@ public class Renderer {
         } catch (Exception e) {
             sb.append("failed!");
             LOGGER.error(sb.toString(), e);
-            throw new Exception("Failed to render file. Cause: " + e.getMessage());
+            throw new Exception("Failed to render file. Cause: " + e.getMessage(), e);
         }
     }
 
@@ -129,7 +129,7 @@ public class Renderer {
         } catch (Exception e) {
             sb.append("failed!");
             LOGGER.error(sb.toString(), e);
-            throw new Exception("Failed to render index. Cause: " + e.getMessage());
+            throw new Exception("Failed to render index. Cause: " + e.getMessage(), e);
         }
     }
 
@@ -158,7 +158,7 @@ public class Renderer {
         } catch (Exception e) {
             sb.append("failed!");
             LOGGER.error(sb.toString(), e);
-            throw new Exception("Failed to render sitemap. Cause: " + e.getMessage());
+            throw new Exception("Failed to render sitemap. Cause: " + e.getMessage(), e);
         }
     }
 
@@ -185,7 +185,7 @@ public class Renderer {
         } catch (Exception e) {
             sb.append("failed!");
             LOGGER.error(sb.toString(), e);
-            throw new Exception("Failed to render feed. Cause: " + e.getMessage());
+            throw new Exception("Failed to render feed. Cause: " + e.getMessage(), e);
         }
     }
 
@@ -212,7 +212,7 @@ public class Renderer {
         } catch (Exception e) {
             sb.append("failed!");
             LOGGER.error(sb.toString(), e);
-            throw new Exception("Failed to render archive. Cause: " + e.getMessage());
+            throw new Exception("Failed to render archive. Cause: " + e.getMessage(), e);
         }
     }
 
@@ -224,7 +224,7 @@ public class Renderer {
      * @throws Exception 
      */
     public void renderTags(Set<String> tags, String tagPath) throws Exception {
-    	final List<String> errors = new LinkedList<String>();
+    	final List<Throwable> errors = new LinkedList<Throwable>();
         for (String tag : tags) {
             Map<String, Object> model = new HashMap<String, Object>();
             model.put("renderer", renderingEngine);
@@ -246,16 +246,16 @@ public class Renderer {
             } catch (Exception e) {
                 sb.append("failed!");
                 LOGGER.error(sb.toString(), e);
-                errors.add(e.getMessage());
+                errors.add(e);
             }
         }
         if (!errors.isEmpty()) {
         	StringBuilder sb = new StringBuilder();
         	sb.append("Failed to render tags. Cause(s):");
-        	for(String error: errors) {
-        		sb.append("\n" + error);
+        	for(Throwable error: errors) {
+        		sb.append("\n" + error.getMessage());
         	}
-        	throw new Exception(sb.toString());
+        	throw new Exception(sb.toString(), errors.get(0));
         }
     }
     

--- a/src/main/java/org/jbake/launcher/Main.java
+++ b/src/main/java/org/jbake/launcher/Main.java
@@ -49,17 +49,17 @@ public class Main {
 		oven.setupPaths();
 		oven.bake();
 
-		final List<String> errors = oven.getErrors();
+		final List<Throwable> errors = oven.getErrors();
 		if (!errors.isEmpty()) {
 			final StringBuilder msg = new StringBuilder();
 			// TODO: decide, if we want the all errors here
 			msg.append(MessageFormat.format("JBake failed with {0} errors:\n", errors.size()));
 			int errNr = 1;
-			for (final String error : errors) {
-				msg.append(MessageFormat.format("{0}. {1}\n", errNr, error));
+			for (final Throwable error : errors) {
+				msg.append(MessageFormat.format("{0}. {1}\n", errNr, error.getMessage()));
 				++errNr;
 			}
-			throw new JBakeException(msg.toString());
+			throw new JBakeException(msg.toString(), errors.get(0));
 		}
 	}
 


### PR DESCRIPTION
If jbake crashes with an exception, no detailed stack traces are reported. If  exceptions are thrown e.g. during rendering, these exceptions are caught and their messages are recorded. Afterwards, a fresh exception is thrown with all aggregated messages concatenated - so far so good. The problem is that the new exception has no linked cause making debugging a nightmare. It would be better to not record the messages but the exceptions themselves, build the new exception message from their messages, but at least link the first cause as cause of the new exception.

Besides that, it is good practice to link wrapped exceptions to their cause. Whenever one has the pattern 

```java
} catch (AException ex) {
   throw new BException("...");
}
```
this should be re-written as 
```java
} catch (AException ex) {
   throw new BException("...", ex);
}
```