### PR TITLE
Support absolute paths for asset, content and template folders

### DIFF
--- a/src/main/java/org/jbake/app/Crawler.java
+++ b/src/main/java/org/jbake/app/Crawler.java
@@ -5,6 +5,7 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
 
 import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.io.FilenameUtils;
 import org.jbake.app.ConfigUtil.Keys;
 import org.jbake.model.DocumentStatus;
 import org.jbake.model.DocumentTypes;
@@ -41,7 +42,7 @@ public class Crawler {
     public Crawler(ContentStore db, File source, CompositeConfiguration config) {
         this.db = db;
         this.config = config;
-        this.contentPath = source.getPath() + separator + config.getString(ConfigUtil.Keys.CONTENT_FOLDER);
+        this.contentPath = FilenameUtils.concat(source.getAbsolutePath(), config.getString(ConfigUtil.Keys.CONTENT_FOLDER));
         this.parser = new Parser(config, contentPath);
     }
 

--- a/src/main/java/org/jbake/app/Oven.java
+++ b/src/main/java/org/jbake/app/Oven.java
@@ -15,6 +15,7 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 
 import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.io.FilenameUtils;
 import org.jbake.app.ConfigUtil.Keys;
 import org.jbake.model.DocumentTypes;
 import org.slf4j.Logger;
@@ -113,7 +114,7 @@ public class Oven {
 	}
 
         private File setupPathFromConfig(String key) {
-            return new File(source, config.getString(key));
+            return new File(FilenameUtils.concat(source.getAbsolutePath(), config.getString(key)));
         }
 
 	private File setupRequiredFolderFromConfig(final String key) {

--- a/src/main/java/org/jbake/app/Renderer.java
+++ b/src/main/java/org/jbake/app/Renderer.java
@@ -93,7 +93,7 @@ public class Renderer {
         } catch (Exception e) {
             sb.append("failed!");
             LOGGER.error(sb.toString(), e);
-            throw new Exception("Failed to render file. Cause: " + e.getMessage());
+            throw new Exception("Failed to render file " + outputFile.getAbsolutePath() + ". Cause: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/jbake/model/DocumentTypes.java
+++ b/src/main/java/org/jbake/model/DocumentTypes.java
@@ -14,7 +14,16 @@ import java.util.Set;
  */
 public class DocumentTypes {
 
-    private static final Set<String> DEFAULT_DOC_TYPES = new LinkedHashSet<String>(Arrays.asList("page", "post", "masterindex", "archive", "feed"));
+    private static final Set<String> DEFAULT_DOC_TYPES = new LinkedHashSet<String>();
+
+    static {
+        resetDocumentTypes();
+    }
+
+    public static void resetDocumentTypes() {
+        DEFAULT_DOC_TYPES.clear();
+        DEFAULT_DOC_TYPES.addAll(Arrays.asList("page", "post", "masterindex", "archive", "feed"));
+    }
 
     public static void addDocumentType(String docType) {
         DEFAULT_DOC_TYPES.add(docType);
@@ -23,4 +32,5 @@ public class DocumentTypes {
     public static String[] getDocumentTypes() {
         return DEFAULT_DOC_TYPES.toArray(new String[DEFAULT_DOC_TYPES.size()]);
     }
+
 }

--- a/src/test/java/org/jbake/app/AssetTest.java
+++ b/src/test/java/org/jbake/app/AssetTest.java
@@ -1,11 +1,14 @@
 package org.jbake.app;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Locale;
 
 import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.io.FileUtils;
 import org.jbake.app.ConfigUtil.Keys;
 import org.junit.Assert;
 import org.junit.Before;
@@ -18,17 +21,13 @@ public class AssetTest {
 	private CompositeConfiguration config;
 
 	@Before
-    public void setup() throws Exception, IOException, URISyntaxException {
+	public void setup() throws Exception, IOException, URISyntaxException {
 		config = ConfigUtil.load(new File(this.getClass().getResource("/").getFile()));
-        Assert.assertEquals(".html", config.getString(Keys.OUTPUT_EXTENSION));
-		readOnlyFolder.getRoot().setReadOnly();
+		Assert.assertEquals(".html", config.getString(Keys.OUTPUT_EXTENSION));
 	}
 
 	@Rule
 	public TemporaryFolder folder = new TemporaryFolder();
-
-	@Rule
-	public TemporaryFolder readOnlyFolder = new TemporaryFolder();
 
 	@Test
 	public void copy() throws Exception {
@@ -67,6 +66,7 @@ public class AssetTest {
 		config.setProperty(Keys.ASSET_IGNORE_HIDDEN, "true");
 		URL assetsUrl = this.getClass().getResource("/ignorables");
 		File assets = new File(assetsUrl.getFile());
+		hideAssets(assets);
 		Asset asset = new Asset(assets.getParentFile(), folder.getRoot(), config);
 		asset.copy(assets);
 
@@ -79,6 +79,24 @@ public class AssetTest {
 	}
 
 	/**
+	 * Hides the assets on windows that start with a dot (e.g. .test.txt but not test.txt) so File.isHidden() returns true for those files.
+	 */
+	private void hideAssets(File assets) throws IOException, InterruptedException {
+		if (isWindows()) {
+			final File[] hiddenFiles = assets.listFiles(new FilenameFilter() {
+				@Override
+				public boolean accept(File dir, String name) {
+					return name.startsWith(".");
+				}
+			});
+			for (File file : hiddenFiles) {
+				final Process process = Runtime.getRuntime().exec(new String[] {"attrib" , "+h", file.getAbsolutePath()});
+				process.waitFor();
+			}
+		}
+	}
+
+	/**
 	 * Primary intention is to extend test cases to increase coverage.
 	 *
 	 * @throws Exception
@@ -87,7 +105,10 @@ public class AssetTest {
 	public void testWriteProtected() throws Exception {
 		URL assetsUrl = this.getClass().getResource("/assets");
 		File assets = new File(assetsUrl.getFile());
-		Asset asset = new Asset(assets.getParentFile(), readOnlyFolder.getRoot(), config);
+		final File cssFile = new File(folder.newFolder("css"), "bootstrap.min.css");
+		FileUtils.touch(cssFile);
+		cssFile.setReadOnly();
+		Asset asset = new Asset(assets.getParentFile(), folder.getRoot(), config);
 		asset.copy(assets);
 
 		Assert.assertFalse("At least one error during copy expected", asset.getErrors().isEmpty());
@@ -103,7 +124,12 @@ public class AssetTest {
 		config.setProperty(Keys.ASSET_FOLDER, "non-existent");
 		URL assetsUrl = this.getClass().getResource("/");
 		File assets = new File(assetsUrl.getFile() + File.separatorChar + "non-existent");
-		Asset asset = new Asset(assets.getParentFile(), readOnlyFolder.getRoot(), config);
+		Asset asset = new Asset(assets.getParentFile(), folder.getRoot(), config);
 		asset.copy(assets);
+	}
+
+	private boolean isWindows() {
+		final String os = System.getProperty("os.name");
+		return os != null && os.toLowerCase(Locale.ENGLISH).contains("win");
 	}
 }

--- a/src/test/java/org/jbake/app/CrawlerTest.java
+++ b/src/test/java/org/jbake/app/CrawlerTest.java
@@ -1,6 +1,8 @@
 package org.jbake.app;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -8,24 +10,28 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
-import com.orientechnologies.orient.core.record.impl.ODocument;
-import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.jbake.app.ConfigUtil.Keys;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import com.orientechnologies.orient.core.Orient;
+import com.orientechnologies.orient.core.record.impl.ODocument;
 
 public class CrawlerTest {
     private CompositeConfiguration config;
     private ContentStore db;
     private File sourceFolder;
-	
+
+    @BeforeClass
+    public static void startup() {
+        Orient.instance().startup();
+    }
+
 	@Before
     public void setup() throws Exception, IOException, URISyntaxException {
         URL sourceUrl = this.getClass().getResource("/");

--- a/src/test/java/org/jbake/app/GroovyRendererTest.java
+++ b/src/test/java/org/jbake/app/GroovyRendererTest.java
@@ -2,7 +2,12 @@ package org.jbake.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Iterator;
+import java.util.Map;
 
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -11,17 +16,12 @@ import org.jbake.model.DocumentTypes;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Scanner;
+import com.orientechnologies.orient.core.Orient;
 
 public class GroovyRendererTest {
 
@@ -33,6 +33,11 @@ public class GroovyRendererTest {
     private File templateFolder;
     private CompositeConfiguration config;
     private ContentStore db;
+
+    @BeforeClass
+    public static void startup() {
+        Orient.instance().startup();
+    }
 
     @Before
     public void setup() throws Exception, IOException, URISyntaxException {

--- a/src/test/java/org/jbake/app/OvenTest.java
+++ b/src/test/java/org/jbake/app/OvenTest.java
@@ -1,0 +1,72 @@
+package org.jbake.app;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.jbake.app.ConfigUtil.Keys;
+import org.jbake.model.DocumentTypes;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.orientechnologies.orient.core.Orient;
+
+public class OvenTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @BeforeClass
+    public static void reset() {
+        DocumentTypes.resetDocumentTypes();
+    }
+
+    @Before
+    public void startup() {
+        Orient.instance().startup();
+    }
+
+    @Test
+    public void bakeWithRelativePaths() throws IOException, ConfigurationException {
+        final File source = new File(OvenTest.class.getResource("/").getFile());
+        final File destination = folder.newFolder("destination");
+        final CompositeConfiguration configuration = ConfigUtil.load(source);
+        configuration.setProperty(Keys.DESTINATION_FOLDER, destination.getAbsolutePath());
+
+        final Oven oven = new Oven(source, destination, configuration, true);
+        oven.setupPaths();
+        oven.bake();
+
+        assertThat("There shouldn't be any errors: " + oven.getErrors(), oven.getErrors().isEmpty());
+    }
+
+    @Test
+    public void bakeWithAbsolutePaths() throws IOException, ConfigurationException {
+        final File source = new File(OvenTest.class.getResource("/").getFile());
+        final File destination = folder.newFolder("destination");
+        final CompositeConfiguration configuration = ConfigUtil.load(source);
+        makeAbsolute(configuration, source, Keys.TEMPLATE_FOLDER);
+        makeAbsolute(configuration, source, Keys.CONTENT_FOLDER);
+        makeAbsolute(configuration, source, Keys.ASSET_FOLDER);
+        configuration.setProperty(Keys.DESTINATION_FOLDER, destination.getAbsolutePath());
+
+        final Oven oven = new Oven(source, destination, configuration, true);
+        oven.setupPaths();
+        oven.bake();
+
+        assertThat("There shouldn't be any errors: " + oven.getErrors(), oven.getErrors().isEmpty());
+    }
+
+    private void makeAbsolute(Configuration configuration, File source, String key) {
+        final File folder = new File(source, configuration.getString(key));
+        configuration.setProperty(key, folder.getAbsolutePath());
+    }
+
+}

--- a/src/test/java/org/jbake/app/RendererTest.java
+++ b/src/test/java/org/jbake/app/RendererTest.java
@@ -1,13 +1,8 @@
 package org.jbake.app;
 
-import org.jbake.app.ConfigUtil.Keys;
-import org.jbake.model.DocumentTypes;
-import org.junit.After;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-
-import static org.assertj.core.api.Assertions.*;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -15,11 +10,17 @@ import java.util.Map;
 
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.io.FileUtils;
+import org.jbake.app.ConfigUtil.Keys;
+import org.jbake.model.DocumentTypes;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import com.orientechnologies.orient.core.Orient;
 
 public class RendererTest {
 
@@ -31,6 +32,11 @@ public class RendererTest {
     private File templateFolder;
     private CompositeConfiguration config;
     private ContentStore db;
+
+    @BeforeClass
+    public static void startup() {
+        Orient.instance().startup();
+    }
 
     @Before
     public void setup() throws Exception, IOException, URISyntaxException {

--- a/src/test/java/org/jbake/app/ThymeleafRendererTest.java
+++ b/src/test/java/org/jbake/app/ThymeleafRendererTest.java
@@ -2,7 +2,12 @@ package org.jbake.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Iterator;
+import java.util.Map;
 
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -11,17 +16,12 @@ import org.jbake.model.DocumentTypes;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Scanner;
+import com.orientechnologies.orient.core.Orient;
 
 public class ThymeleafRendererTest {
 
@@ -33,6 +33,11 @@ public class ThymeleafRendererTest {
     private File templateFolder;
     private CompositeConfiguration config;
     private ContentStore db;
+
+    @BeforeClass
+    public static void startup() {
+        Orient.instance().startup();
+    }
 
     @Before
     public void setup() throws Exception, IOException, URISyntaxException {


### PR DESCRIPTION
These changes allow both relative and absolute paths for the configuration properties `asset.folder`, `content.folder` and `template.folder`.

This makes the configuration for the jbake-maven-plugin much more readable as you can use `<content.folder>${project.build.directory}/jbake/content</content.folder>` instead of something like `<content.folder>../../../target/jbake/content</content.folder>`.
