### PR TITLE
Make the parsing metadata more flexible

### DIFF
--- a/src/main/java/org/jbake/app/Parser.java
+++ b/src/main/java/org/jbake/app/Parser.java
@@ -151,10 +151,10 @@ public class Parser {
         	}
             header.add(line);
             if (line.contains("=")) {
-                if (line.startsWith("type=")) {
+                if (line.matches("^type\\s*=.*")) {
                     typeFound = true;
                 }
-                if (line.startsWith("status=")) {
+                if (line.matches("^status\\s*=.*")) {
                     statusFound = true;
                 }
             }
@@ -175,13 +175,9 @@ public class Parser {
             }
         }
 
-//        if (!headerValid || !statusFound || !typeFound) {
-//            return false;
-//        }
-//        return true;
         return headerValid && statusFound && typeFound;
     }
-
+    
     /**
      * Process the header of the file.
      *
@@ -193,7 +189,7 @@ public class Parser {
             if (line.equals(END_OF_HEADER)) {
                 break;
             } else {
-                String[] parts = line.split("=",2);
+                String[] parts = line.split("\\s*=\\s*",2);
                 if (parts.length == 2) {
                     if (parts[0].equalsIgnoreCase("date")) {
                         DateFormat df = new SimpleDateFormat(config.getString(Keys.DATE_FORMAT));

--- a/src/main/java/org/jbake/app/Parser.java
+++ b/src/main/java/org/jbake/app/Parser.java
@@ -29,6 +29,10 @@ import java.util.Map;
  * @author Jonathan Bullock <jonbullock@gmail.com>
  */
 public class Parser {
+	
+	public static final String END_OF_HEADER = "~~~~~~";
+	public static final String EOL = "\n";
+	
     private final static Logger LOGGER = LoggerFactory.getLogger(Parser.class);
 
     private CompositeConfiguration config;
@@ -142,6 +146,9 @@ public class Parser {
         List<String> header = new ArrayList<String>();
 
         for (String line : contents) {
+        	if (line.trim().isEmpty()) {
+        		continue;
+        	}
             header.add(line);
             if (line.contains("=")) {
                 if (line.startsWith("type=")) {
@@ -151,7 +158,7 @@ public class Parser {
                     statusFound = true;
                 }
             }
-            if (line.equals("~~~~~~")) {
+            if (line.equals(END_OF_HEADER)) {
                 headerSeparatorFound = true;
                 header.remove(line);
                 break;
@@ -168,10 +175,11 @@ public class Parser {
             }
         }
 
-        if (!headerValid || !statusFound || !typeFound) {
-            return false;
-        }
-        return true;
+//        if (!headerValid || !statusFound || !typeFound) {
+//            return false;
+//        }
+//        return true;
+        return headerValid && statusFound && typeFound;
     }
 
     /**
@@ -182,7 +190,7 @@ public class Parser {
      */
     private void processHeader(List<String> contents, final Map<String, Object> content) {
         for (String line : contents) {
-            if (line.equals("~~~~~~")) {
+            if (line.equals(END_OF_HEADER)) {
                 break;
             } else {
                 String[] parts = line.split("=",2);
@@ -221,16 +229,16 @@ public class Parser {
         boolean inBody = false;
         for (String line : contents) {
             if (inBody) {
-                body.append(line).append("\n");
+                body.append(line).append(EOL);
             }
-            if (line.equals("~~~~~~")) {
+            if (line.equals(END_OF_HEADER)) {
                 inBody = true;
             }
         }
 
         if (body.length() == 0) {
             for (String line : contents) {
-                body.append(line).append("\n");
+                body.append(line).append(EOL);
             }
         }
         

--- a/src/test/java/org/jbake/app/ParserTest.java
+++ b/src/test/java/org/jbake/app/ParserTest.java
@@ -1,16 +1,25 @@
 package org.jbake.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.jbake.app.Parser.CONTINUED_LINE_STARTER;
 import static org.jbake.app.Parser.END_OF_HEADER;
 import static org.jbake.app.Parser.EOL;
+import static org.jbake.app.Parser.ContentBasicTags.body;
+import static org.jbake.app.Parser.ContentBasicTags.date;
+import static org.jbake.app.Parser.ContentBasicTags.status;
+import static org.jbake.app.Parser.ContentBasicTags.tags;
+import static org.jbake.app.Parser.ContentBasicTags.type;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,7 +46,8 @@ public class ParserTest {
 	private File validAsciiDocFileWithBlankFirstLineInHeader;
 	private File validAsciiDocFileWithEmptyRandomLineInHeader;
 	private File validAsciiDocFileWithBlankRandomLineInHeader;
-	private File  validAsciiDocFileWithSpacesAroundEqualInHeader;
+	private File validAsciiDocFileWithSpacesAroundEqualInHeader;
+	private File validAsciiDocFileWithContinuedLineInHeader;
 	
 	private String validHeader = "title=This is a Title = This is a valid Title" + EOL 
 			+ "status=draft" + EOL 
@@ -46,21 +56,39 @@ public class ParserTest {
 			+ END_OF_HEADER;
 	private String invalidHeader = "title=This is a Title" + EOL + END_OF_HEADER;
 	
-	private int rp = 2;
-	private int pos = validHeader.indexOf(EOL, rp);
+	private int rp = 2; // "random" number
+	private int pos = validHeader.indexOf(EOL, rp); // position where to insert a line
+	
+	private String validHeaderWithEmptyFirstLineContent = "This is a test with empty first line in header.";
 	private String validHeaderWithEmptyFirstLine = EOL + validHeader;
+	private String validHeaderWithBlankFirstLineContent = "This is a test with blank first line in header.";
 	private String validHeaderWithBlankFirstLine = "   " + EOL + validHeader;
+	private String validHeaderWithEmptyRandomLineContent = "This is a test with empty random line in header.";
 	private String validHeaderWithEmptyRandomLine = validHeader.substring(0, pos)
 			+ EOL + validHeader.substring(pos + 1);
+	private String validHeaderWithBlankRandomLineContent = "This is a test with blank random line in header.";
 	private String validHeaderWithBlankRandomLine = validHeader.substring(0, pos)
 			+ "   " + EOL + validHeader.substring(pos + 1);
 	
-	private String validHeaderWithSpacesAroundEqual = "title = This is a Title = This is a valid Title" + EOL 
+	private String continuedTitle = "This is a Title = This is a valid Title";
+	private String validHeaderWithSpacesAroundEqualContent = "This is a test with spaces around equals in header.";
+	private String validHeaderWithSpacesAroundEqual = "title = " + continuedTitle + EOL 
 			+ "status    =draft" + EOL 
 			+ "type=    post"+ EOL 
 			+ "date    =  2013-09-02"+ EOL 
 			+ END_OF_HEADER;
 	
+	private String validHeaderWithContinuedLineContent = "This is a test with continued line in header.";
+	private List<String> tagsSample = Arrays.asList(new String[] {"Concurso Público", "Database", "dbconsole", "oracle"});
+	private String tagsEntryValue = StringUtils.join(tagsSample, ",");
+	private String validHeaderWithContinuedLine = "title = " 
+	        + CONTINUED_LINE_STARTER + continuedTitle + EOL 
+			+ "status    =draft" + EOL 
+			+ "type=    post" + EOL 
+			+ "date    =  2013-09-02" + EOL 
+			+ "tags=" + EOL 
+			+ CONTINUED_LINE_STARTER + StringUtils.join(tagsSample, ',' + EOL + CONTINUED_LINE_STARTER) + EOL 
+			+ END_OF_HEADER;
 	
 	@Before
 	public void createSampleFile() throws Exception {
@@ -138,34 +166,40 @@ public class ParserTest {
 		out.println("----");
 		out.close();
 		
-		validAsciiDocFileWithEmptyFirstLineInHeader = folder.newFile("validwithemptyfirstlineinheader.ad");
+		validAsciiDocFileWithEmptyFirstLineInHeader = folder.newFile("validAsciiDocFileWithEmptyFirstLineInHeader.ad");
 		out = new PrintWriter(validAsciiDocFileWithEmptyFirstLineInHeader);
 		out.println(validHeaderWithEmptyFirstLine);
-		out.println("<p>This is a test with empty first line in header.</p>");
+		out.println("<p>" + validHeaderWithEmptyFirstLineContent + "</p>");
 		out.close();
 		
-		validAsciiDocFileWithBlankFirstLineInHeader = folder.newFile("validwithblankfirstlineinheader.ad");
+		validAsciiDocFileWithBlankFirstLineInHeader = folder.newFile("validAsciiDocFileWithBlankFirstLineInHeader.ad");
 		out = new PrintWriter(validAsciiDocFileWithBlankFirstLineInHeader);
 		out.println(validHeaderWithBlankFirstLine);
-		out.println("<p>This is a test with blank first line in header.</p>");
+		out.println("<p>" + validHeaderWithBlankFirstLineContent + "</p>");
 		out.close();
 		
-		validAsciiDocFileWithEmptyRandomLineInHeader = folder.newFile("validwithemptyrandomlineinheader.ad");
+		validAsciiDocFileWithEmptyRandomLineInHeader = folder.newFile("validAsciiDocFileWithEmptyRandomLineInHeader.ad");
 		out = new PrintWriter(validAsciiDocFileWithEmptyRandomLineInHeader);
 		out.println(validHeaderWithEmptyRandomLine);
-		out.println("<p>This is a test with empty random line in header.</p>");
+		out.println("<p>" + validHeaderWithEmptyRandomLineContent + "</p>");
 		out.close();
 		
-		validAsciiDocFileWithBlankRandomLineInHeader = folder.newFile("validwithblankrandomlineinheader.ad");		
+		validAsciiDocFileWithBlankRandomLineInHeader = folder.newFile("validAsciiDocFileWithBlankRandomLineInHeader.ad");		
 		out = new PrintWriter(validAsciiDocFileWithBlankRandomLineInHeader);
 		out.println(validHeaderWithBlankRandomLine);
-		out.println("<p>This is a test with blank random line in header.</p>");
+		out.println("<p>" + validHeaderWithBlankRandomLineContent + "</p>");
 		out.close();
 		
-		validAsciiDocFileWithSpacesAroundEqualInHeader = folder.newFile("validwithspacesaroundequalinheader.ad");		
+		validAsciiDocFileWithSpacesAroundEqualInHeader = folder.newFile("validAsciiDocFileWithSpacesAroundEqualInHeader.ad");		
 		out = new PrintWriter(validAsciiDocFileWithSpacesAroundEqualInHeader);
 		out.println(validHeaderWithSpacesAroundEqual);
-		out.println("<p>This is a test with spaces around equals in header.</p>");
+		out.println("<p>" + validHeaderWithSpacesAroundEqualContent + "</p>");
+		out.close();
+		
+		validAsciiDocFileWithContinuedLineInHeader = folder.newFile("validAsciiDocFileWithContinuedLineInHeader.ad");		
+		out = new PrintWriter(validAsciiDocFileWithContinuedLineInHeader);
+		out.println(validHeaderWithContinuedLine);
+		out.println("<p>" + validHeaderWithContinuedLineContent + "</p>");
 		out.close();
 		
 	}
@@ -174,12 +208,12 @@ public class ParserTest {
 	public void parseValidHTMLFile() {
 		Map<String, Object> map = parser.processFile(validHTMLFile);
 		Assert.assertNotNull(map);
-		Assert.assertEquals("draft", map.get("status"));
-		Assert.assertEquals("post", map.get("type"));
+		Assert.assertEquals("draft", map.get(status.name()));
+		Assert.assertEquals("post", map.get(type.name()));
 		Assert.assertEquals("This is a Title = This is a valid Title", map.get("title"));
-		Assert.assertNotNull(map.get("date"));
+		Assert.assertNotNull(map.get(date.name()));
 		Calendar cal = Calendar.getInstance();
-		cal.setTime((Date) map.get("date"));
+		cal.setTime((Date) map.get(date.name()));
 		Assert.assertEquals(8, cal.get(Calendar.MONTH));
 		Assert.assertEquals(2, cal.get(Calendar.DAY_OF_MONTH));
 		Assert.assertEquals(2013, cal.get(Calendar.YEAR));
@@ -196,12 +230,12 @@ public class ParserTest {
 	public void parseValidAsciiDocFile() {
 		Map<String, Object> map = parser.processFile(validAsciiDocFile);
 		Assert.assertNotNull(map);
-		Assert.assertEquals("draft", map.get("status"));
-		Assert.assertEquals("post", map.get("type"));
-		assertThat(map.get("body").toString())
+		Assert.assertEquals("draft", map.get(status.name()));
+		Assert.assertEquals("post", map.get(type.name()));
+		assertThat(map.get(body.name()).toString())
 			.contains("class=\"paragraph\"")
 			.contains("<p>JBake now supports AsciiDoc.</p>");
-//		Assert.assertEquals("<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>JBake now supports AsciiDoc.</p>\n</div>\n</div>\n</div>", map.get("body"));
+//		Assert.assertEquals("<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>JBake now supports AsciiDoc.</p>\n</div>\n</div>\n</div>", map.get(body.name()));
 	}
 	
 	@Test
@@ -216,12 +250,12 @@ public class ParserTest {
 		Map<String, Object> map = parser.processFile(validAsciiDocFileWithoutHeader);
 		Assert.assertNotNull(map);
 		Assert.assertEquals("Hello: AsciiDoc!", map.get("title"));
-		Assert.assertEquals("published", map.get("status"));
-		Assert.assertEquals("page", map.get("type"));
-		assertThat(map.get("body").toString())
+		Assert.assertEquals("published", map.get(status.name()));
+		Assert.assertEquals("page", map.get(type.name()));
+		assertThat(map.get(body.name()).toString())
 			.contains("class=\"paragraph\"")
 			.contains("<p>JBake now supports AsciiDoc.</p>");
-//		Assert.assertEquals("<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>JBake now supports AsciiDoc.</p>\n</div>\n</div>\n</div>", map.get("body"));
+//		Assert.assertEquals("<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>JBake now supports AsciiDoc.</p>\n</div>\n</div>\n</div>", map.get(body.name()));
 	}
 	
 	@Test
@@ -235,9 +269,9 @@ public class ParserTest {
 	public void parseValidAsciiDocFileWithExampleHeaderInContent() {
 		Map<String, Object> map = parser.processFile(validAsciiDocFileWithHeaderInContent);
 		Assert.assertNotNull(map);
-		Assert.assertEquals("published", map.get("status"));
-		Assert.assertEquals("page", map.get("type"));
-		assertThat(map.get("body").toString())
+		Assert.assertEquals("published", map.get(status.name()));
+		Assert.assertEquals("page", map.get(type.name()));
+		assertThat(map.get(body.name()).toString())
 			.contains("class=\"paragraph\"")
 			.contains("<p>JBake now supports AsciiDoc.</p>")
 			.contains("class=\"listingblock\"")
@@ -246,37 +280,58 @@ public class ParserTest {
 			.contains("title=Example Header")
 			.contains("date=2013-02-01")
 			.contains("tags=tag1, tag2");
-//		Assert.assertEquals("<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>JBake now supports AsciiDoc.</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>title=Example Header\ndate=2013-02-01\ntype=post\ntags=tag1, tag2\nstatus=published\n~~~~~~</pre>\n</div>\n</div>\n</div>\n</div>", map.get("body"));
+//		Assert.assertEquals("<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>JBake now supports AsciiDoc.</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>title=Example Header\ndate=2013-02-01\ntype=post\ntags=tag1, tag2\nstatus=published\n~~~~~~</pre>\n</div>\n</div>\n</div>\n</div>", map.get(body.name()));
 	}
 
 	@Test
 	public void parseValidAsciiDocFileWithEmptyFirstLineInHeader() {
 		Map<String, Object> map = parser.processFile(validAsciiDocFileWithEmptyFirstLineInHeader);
 		Assert.assertNotNull(map);
+		assertThat(map.get(body.name()).toString())
+			.contains(validHeaderWithEmptyFirstLineContent);
 	}
 	
 	@Test
 	public void parseValidAsciiDocFileWithBlankFirstLineInHeader() {
 		Map<String, Object> map = parser.processFile(validAsciiDocFileWithBlankFirstLineInHeader);
 		Assert.assertNotNull(map);
+		assertThat(map.get(body.name()).toString())
+			.contains(validHeaderWithBlankFirstLineContent);
 	}
 	
 	@Test
 	public void parseValidAsciiDocFileWithEmptyRandomLineInHeader() {
 		Map<String, Object> map = parser.processFile(validAsciiDocFileWithEmptyRandomLineInHeader);
 		Assert.assertNotNull(map);
+		assertThat(map.get(body.name()).toString())
+			.contains(validHeaderWithEmptyRandomLineContent);
 	}
 	
 	@Test
 	public void parseValidAsciiDocFileWithBlankRandomLineInHeader() {
 		Map<String, Object> map = parser.processFile(validAsciiDocFileWithBlankRandomLineInHeader);
 		Assert.assertNotNull(map);
+		assertThat(map.get(body.name()).toString())
+			.contains(validHeaderWithBlankRandomLineContent);
 	}
 	
 	@Test
 	public void parseValidAsciiDocFileWithSpacesAroundEqualInHeader() {
 		Map<String, Object> map = parser.processFile(validAsciiDocFileWithSpacesAroundEqualInHeader);
 		Assert.assertNotNull(map);
+		assertThat(map.get(body.name()).toString())
+			.contains(validHeaderWithSpacesAroundEqualContent);
+	}
+	
+	@Test
+	public void parseValidAsciiDocFileWithContinuedLineInHeader() {
+		Map<String, Object> map = parser.processFile(validAsciiDocFileWithContinuedLineInHeader);
+		Assert.assertNotNull(map);
+		Assert.assertEquals(continuedTitle, map.get("title"));
+		List<String> headerTagsValues = Arrays.asList((String[]) map.get(tags.name()));
+		Assert.assertEquals(tagsEntryValue, StringUtils.join(headerTagsValues, ","));
+		assertThat(map.get(body.name()).toString())
+			.contains(validHeaderWithContinuedLineContent);
 	}
 	
 }

--- a/src/test/java/org/jbake/app/ParserTest.java
+++ b/src/test/java/org/jbake/app/ParserTest.java
@@ -1,6 +1,8 @@
 package org.jbake.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.jbake.app.Parser.END_OF_HEADER;
+import static org.jbake.app.Parser.EOL;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -16,7 +18,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class ParserTest {
-
+	
 	@Rule
 	public TemporaryFolder folder = new TemporaryFolder();
 	
@@ -31,11 +33,26 @@ public class ParserTest {
 	private File validAsciiDocFileWithoutHeader;
 	private File invalidAsciiDocFileWithoutHeader;
 	private File validAsciiDocFileWithHeaderInContent;
+	private File validAsciiDocFileWithEmptyFirstLineInHeader;
+	private File validAsciiDocFileWithBlankFirstLineInHeader;
+	private File validAsciiDocFileWithEmptyRandomLineInHeader;
+	private File validAsciiDocFileWithBlankRandomLineInHeader;
 	
-	private String validHeader = "title=This is a Title = This is a valid Title\nstatus=draft\ntype=post\ndate=2013-09-02\n~~~~~~";
-	private String invalidHeader = "title=This is a Title\n~~~~~~";
-
-  
+	private String validHeader = "title=This is a Title = This is a valid Title" + EOL 
+			+ "status=draft" + EOL 
+			+ "type=post"+ EOL 
+			+ "date=2013-09-02"+ EOL 
+			+ END_OF_HEADER;
+	private String invalidHeader = "title=This is a Title" + EOL + END_OF_HEADER;
+	
+	private int rp = 2;
+	private int pos = validHeader.indexOf(EOL, rp);
+	private String validHeaderWithEmptyFirstLine = EOL + validHeader;
+	private String validHeaderWithBlankFirstLine = "   " + EOL + validHeader;
+	private String validHeaderWithEmptyRandomLine = validHeader.substring(0, pos)
+			+ EOL + validHeader.substring(pos + 1);
+	private String validHeaderWithBlankRandomLine = validHeader.substring(0, pos)
+			+ "   " + EOL + validHeader.substring(pos + 1);
 	
 	@Before
 	public void createSampleFile() throws Exception {
@@ -109,8 +126,32 @@ public class ParserTest {
 		out.println("type=post");
 		out.println("tags=tag1, tag2");
 		out.println("status=published");
-		out.println("~~~~~~");
+		out.println(END_OF_HEADER);
 		out.println("----");
+		out.close();
+		
+		validAsciiDocFileWithEmptyFirstLineInHeader = folder.newFile("validwithemptyfirstlineinheader.ad");
+		out = new PrintWriter(validAsciiDocFileWithEmptyFirstLineInHeader);
+		out.println(validHeaderWithEmptyFirstLine);
+		out.println("<p>This is a test with empty first line in header.</p>");
+		out.close();
+		
+		validAsciiDocFileWithBlankFirstLineInHeader = folder.newFile("validwithblankfirstlineinheader.ad");
+		out = new PrintWriter(validAsciiDocFileWithBlankFirstLineInHeader);
+		out.println(validHeaderWithBlankFirstLine);
+		out.println("<p>This is a test with blank first line in header.</p>");
+		out.close();
+		
+		validAsciiDocFileWithEmptyRandomLineInHeader = folder.newFile("validwithemptyrandomlineinheader.ad");
+		out = new PrintWriter(validAsciiDocFileWithEmptyRandomLineInHeader);
+		out.println(validHeaderWithEmptyRandomLine);
+		out.println("<p>This is a test with empty random line in header.</p>");
+		out.close();
+		
+		validAsciiDocFileWithBlankRandomLineInHeader = folder.newFile("validwithblankrandomlineinheader.ad");System.out.println("---#b> "+validHeaderWithBlankRandomLine.replaceAll(EOL, "EOL"));		
+		out = new PrintWriter(validAsciiDocFileWithBlankRandomLineInHeader);
+		out.println(validHeaderWithBlankRandomLine);
+		out.println("<p>This is a test with blank random line in header.</p>");
 		out.close();
 	}
 	
@@ -192,4 +233,29 @@ public class ParserTest {
 			.contains("tags=tag1, tag2");
 //		Assert.assertEquals("<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>JBake now supports AsciiDoc.</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>title=Example Header\ndate=2013-02-01\ntype=post\ntags=tag1, tag2\nstatus=published\n~~~~~~</pre>\n</div>\n</div>\n</div>\n</div>", map.get("body"));
 	}
+
+	@Test
+	public void parseValidAsciiDocFileWithEmptyFirstLineInHeader() {
+		Map<String, Object> map = parser.processFile(validAsciiDocFileWithEmptyFirstLineInHeader);
+		Assert.assertNotNull(map);
+	}
+	
+	@Test
+	public void parseValidAsciiDocFileWithBlankFirstLineInHeader() {
+		Map<String, Object> map = parser.processFile(validAsciiDocFileWithBlankFirstLineInHeader);
+		Assert.assertNotNull(map);
+	}
+	
+	@Test
+	public void parseValidAsciiDocFileWithEmptyRandomLineInHeader() {
+		Map<String, Object> map = parser.processFile(validAsciiDocFileWithEmptyRandomLineInHeader);
+		Assert.assertNotNull(map);
+	}
+	
+	@Test
+	public void parseValidAsciiDocFileWithBlankRandomLineInHeader() {
+		Map<String, Object> map = parser.processFile(validAsciiDocFileWithBlankRandomLineInHeader);
+		Assert.assertNotNull(map);
+	}
+	
 }

--- a/src/test/java/org/jbake/app/ParserTest.java
+++ b/src/test/java/org/jbake/app/ParserTest.java
@@ -37,6 +37,7 @@ public class ParserTest {
 	private File validAsciiDocFileWithBlankFirstLineInHeader;
 	private File validAsciiDocFileWithEmptyRandomLineInHeader;
 	private File validAsciiDocFileWithBlankRandomLineInHeader;
+	private File  validAsciiDocFileWithSpacesAroundEqualInHeader;
 	
 	private String validHeader = "title=This is a Title = This is a valid Title" + EOL 
 			+ "status=draft" + EOL 
@@ -53,6 +54,13 @@ public class ParserTest {
 			+ EOL + validHeader.substring(pos + 1);
 	private String validHeaderWithBlankRandomLine = validHeader.substring(0, pos)
 			+ "   " + EOL + validHeader.substring(pos + 1);
+	
+	private String validHeaderWithSpacesAroundEqual = "title = This is a Title = This is a valid Title" + EOL 
+			+ "status    =draft" + EOL 
+			+ "type=    post"+ EOL 
+			+ "date    =  2013-09-02"+ EOL 
+			+ END_OF_HEADER;
+	
 	
 	@Before
 	public void createSampleFile() throws Exception {
@@ -148,11 +156,18 @@ public class ParserTest {
 		out.println("<p>This is a test with empty random line in header.</p>");
 		out.close();
 		
-		validAsciiDocFileWithBlankRandomLineInHeader = folder.newFile("validwithblankrandomlineinheader.ad");System.out.println("---#b> "+validHeaderWithBlankRandomLine.replaceAll(EOL, "EOL"));		
+		validAsciiDocFileWithBlankRandomLineInHeader = folder.newFile("validwithblankrandomlineinheader.ad");		
 		out = new PrintWriter(validAsciiDocFileWithBlankRandomLineInHeader);
 		out.println(validHeaderWithBlankRandomLine);
 		out.println("<p>This is a test with blank random line in header.</p>");
 		out.close();
+		
+		validAsciiDocFileWithSpacesAroundEqualInHeader = folder.newFile("validwithspacesaroundequalinheader.ad");		
+		out = new PrintWriter(validAsciiDocFileWithSpacesAroundEqualInHeader);
+		out.println(validHeaderWithSpacesAroundEqual);
+		out.println("<p>This is a test with spaces around equals in header.</p>");
+		out.close();
+		
 	}
 	
 	@Test
@@ -255,6 +270,12 @@ public class ParserTest {
 	@Test
 	public void parseValidAsciiDocFileWithBlankRandomLineInHeader() {
 		Map<String, Object> map = parser.processFile(validAsciiDocFileWithBlankRandomLineInHeader);
+		Assert.assertNotNull(map);
+	}
+	
+	@Test
+	public void parseValidAsciiDocFileWithSpacesAroundEqualInHeader() {
+		Map<String, Object> map = parser.processFile(validAsciiDocFileWithSpacesAroundEqualInHeader);
 		Assert.assertNotNull(map);
 	}
 	


### PR DESCRIPTION
This request answers to the three enhancements suggested by [Make the parsing metadata more flexible(intelligent) #180](https://github.com/jbake-org/jbake/issues/180):
* Allow blank lines in header of content files
* Allow spaces around equal of a header entry
* Allow multi-lines value for header entry value  

About this last point: any line starting with 2 spaces will be concatenated with the previous line.
