### PR TITLE
(GroovyTemplates) Use English Locale in the date formatter

### DIFF
--- a/src/test/resources/groovyTemplates/archive.gsp
+++ b/src/test/resources/groovyTemplates/archive.gsp
@@ -14,15 +14,15 @@
             <%def last_month=null;%>
             <%posts.each {post ->%>
 				<%if (last_month) {%>
-					<%if (post.date.format("MMMM yyyy") != last_month) {%>
-						<h3>${post.date.format("MMMM yyyy")}</h3>
+					<%if (new java.text.SimpleDateFormat("MMMM yyyy", Locale.ENGLISH).format(post.date) != last_month) {%>
+						<h3>${new java.text.SimpleDateFormat("MMMM yyyy", Locale.ENGLISH).format(post.date)}</h3>
 					<%}%>
 				<% } else { %>
-					<h3>${post.date.format("MMMM yyyy")}</h3>
+					<h3>${new java.text.SimpleDateFormat("MMMM yyyy", Locale.ENGLISH).format(post.date)}</h3>
 				<% }%>
 				
 				<h4>${post.date.format("dd MMMM")} - <a href="${post.uri}">${post.title}</a></h4>
-				<%last_month = post.date.format("MMMM yyyy")%>
+				<%last_month = new java.text.SimpleDateFormat("MMMM yyyy", Locale.ENGLISH).format(post.date)%>
 			<%}%>
 		</div>
 	</div>

--- a/src/test/resources/groovyTemplates/feed.gsp
+++ b/src/test/resources/groovyTemplates/feed.gsp
@@ -6,8 +6,8 @@
     <atom:link href="http://jonathanbullock.com/feed.xml" rel="self" type="application/rss+xml" />
     <description>My corner of the Internet</description>
     <language>en-gb</language>
-    <pubDate>${published_date.format("EEE, d MMM yyyy HH:mm:ss Z")}</pubDate>
-    <lastBuildDate>${published_date.format("EEE, d MMM yyyy HH:mm:ss Z")}</lastBuildDate>
+    <pubDate>${new java.text.SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z", Locale.ENGLISH).format(published_date)}</pubDate>
+    <lastBuildDate>${new java.text.SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z", Locale.ENGLISH).format(published_date)}</lastBuildDate>
 
     <%posts.each {post -> %>
     <item>

--- a/src/test/resources/groovyTemplates/index.gsp
+++ b/src/test/resources/groovyTemplates/index.gsp
@@ -12,7 +12,7 @@
 		<div class="span12">
 			<%posts[0..<2].each { post ->%>
 			<h4><a href="${post.uri}">${post.title}</a></h4>
-			<p>${post.date.format("dd MMMM yyyy")} - ${post.body.substring(0, 150)}...</p>
+			<p>${new java.text.SimpleDateFormat("dd MMMM yyyy", Locale.ENGLISH).format(post.date)} - ${post.body.substring(0, 150)}...</p>
 			<%}%>
 			<a href="/archive.html">Archive</a>
 		</div>

--- a/src/test/resources/groovyTemplates/post.gsp
+++ b/src/test/resources/groovyTemplates/post.gsp
@@ -3,7 +3,7 @@
       <div class="row-fluid marketing">
 		<div class="span12">
 				<h2>${content.title}</h2>
-				<p class="post-date">${content.date.format("dd MMMM yyyy")}</p>
+				<p class="post-date">${new java.text.SimpleDateFormat("dd MMMM yyyy", Locale.ENGLISH).format(content.date)}</p>
 				<p>${content.body}</p>	
 		</div>
 	</div>

--- a/src/test/resources/groovyTemplates/tags.gsp
+++ b/src/test/resources/groovyTemplates/tags.gsp
@@ -27,15 +27,15 @@
             <%def last_month=null;%>
 			<%tag_posts.each {post ->%>
 				<%if (last_month) {%>
-					<%if (post.date.format("MMMM yyyy") != last_month) {%>
-						<h3>${post.date.format("MMMM yyyy")}</h3>
+					<%if (new java.text.SimpleDateFormat("MMMM yyyy", Locale.ENGLISH).format(post.date) != last_month) {%>
+						<h3>${new java.text.SimpleDateFormat("MMMM yyyy", Locale.ENGLISH).format(post.date)}</h3>
 					<%}%>
 				<%} else {%>
-					<h3>${post.date.format("MMMM yyyy")}</h3>
+					<h3>${new java.text.SimpleDateFormat("MMMM yyyy", Locale.ENGLISH).format(post.date)}</h3>
 				<%}%>
 				
 				<h4>${post.date.format("dd MMMM")} - <a href="${post.uri}">${post.title}</a></h4>
-				<% last_month = post.date.format("MMMM yyyy")%>
+				<% last_month = new java.text.SimpleDateFormat("MMMM yyyy", Locale.ENGLISH).format(post.date)%>
 			<%}%>
 		</div>
 	</div>


### PR DESCRIPTION
The [function `Date#format(java.lang.String)`](http://docs.groovy-lang.org/latest/html/groovy-jdk/java/util/Date.html#format(java.lang.String)) used in the GroovyTemplates uses the system Locale to format the date. When the Date format uses `MMMM` or `MMM` the name (resp. the short name) of the month is used.

This make the JBake build platform dependent (for example: the locale configuration on my machine is German and it is English on my CI Server)

In my opinion, for those cases, the complete form of the formatter should be used:

    new java.text.SimpleDateFormat(<Pattern>, Locale.ENGLISH).format(<Date>)

This pull request makes the corresponding changes. If you prefer a different solution, I would be happy to implement it. Please provide some pointers in order for me to start.
