### PR TITLE
include example-project groovy-mte (Groovy MarkupTemplateEngine)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,17 +149,28 @@
                         </configuration>
                     </execution>
                     <execution>
-						<id>checkout-example-project-jade</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>checkout</goal>
-						</goals>
-						<configuration>
-							<checkoutDirectory>${project.build.directory}/example-project-jade</checkoutDirectory>
-							<!-- TODO: Move this project to jbake repo -->
-							<connectionUrl>scm:git:git://github.com/mariuszs/jbake-example-project-jade.git</connectionUrl>
-						</configuration>
-					</execution>
+                        <id>checkout-example-project-jade</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>checkout</goal>
+                        </goals>
+                        <configuration>
+                            <checkoutDirectory>${project.build.directory}/example-project-jade</checkoutDirectory>
+                            <!-- TODO: Move this project to jbake repo -->
+                            <connectionUrl>scm:git:git://github.com/mariuszs/jbake-example-project-jade.git</connectionUrl>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>checkout-example-project-groovy-mte</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>checkout</goal>
+                        </goals>
+                        <configuration>
+                            <checkoutDirectory>${project.build.directory}/example-project-groovy-mte</checkoutDirectory>
+                            <connectionUrl>scm:git:git://github.com/jbake-org/jbake-example-project-groovy-mte.git</connectionUrl>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -276,6 +287,21 @@
 							<attach>false</attach>
 						</configuration>
 					</execution>
+                    <execution>
+                        <id>zip-example-project-groovy-mte</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>example_project_groovy-mte</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>src/main/assembly/assembly-example-project-groovy-mte.xml</descriptor>
+                            </descriptors>
+                            <attach>false</attach>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>make-assembly</id>
                         <phase>package</phase>
@@ -481,14 +507,14 @@
             <version>${logback.version}</version>
             <optional>true</optional>
         </dependency>
-        
+
         <!-- <dependency>
             <groupId>com.mitchellbosecke</groupId>
             <artifactId>pebble</artifactId>
             <version>${pebble.version}</version>
             <optional>true</optional>
         </dependency> -->
-        
+
 		<dependency>
     		<groupId>org.apache.commons</groupId>
     		<artifactId>commons-vfs2</artifactId>

--- a/src/main/assembly/assembly-example-project-groovy-mte.xml
+++ b/src/main/assembly/assembly-example-project-groovy-mte.xml
@@ -1,0 +1,19 @@
+<assembly>
+	<id>base</id>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<!-- Generates a zip package containing the needed files -->
+	<formats>
+		<format>zip</format>
+	</formats>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.directory}/example-project-groovy-mte/</directory>
+			<outputDirectory>/</outputDirectory>
+			<excludes>
+				<exclude>.git</exclude>
+				<exclude>README.md</exclude>
+				<exclude>LICENSE</exclude>
+			</excludes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/src/main/java/org/jbake/app/Oven.java
+++ b/src/main/java/org/jbake/app/Oven.java
@@ -16,6 +16,7 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 
 import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.configuration.ConfigurationException;
 import org.jbake.app.ConfigUtil.Keys;
 import org.jbake.model.DocumentTypes;
 import org.jbake.render.RenderingTool;
@@ -141,7 +142,7 @@ public class Oven {
 
                 // process source content
                 Crawler crawler = new Crawler(db, source, config);
-                crawler.crawl(contentsPath);                
+                crawler.crawl(contentsPath);
                 LOGGER.info("Content detected:");
                 for (String docType : DocumentTypes.getDocumentTypes()) {
                 	int count = crawler.getDocumentCount(docType);
@@ -149,9 +150,9 @@ public class Oven {
                 		LOGGER.info("Parsed {} files of type: {}", count, docType);
             		}
                 }
-                
+
                 Renderer renderer = new Renderer(db, destination, templatesPath, config);
-                
+
                 for(RenderingTool tool : ServiceLoader.load(RenderingTool.class)) {
                 	try {
                 		renderedCount += tool.render(renderer, db, destination, templatesPath, config);
@@ -233,5 +234,5 @@ public class Oven {
 	public List<String> getErrors() {
 		return new ArrayList<String>(errors);
 	}
-    
+
 }

--- a/src/main/resources/default.properties
+++ b/src/main/resources/default.properties
@@ -62,6 +62,8 @@ server.port=8820
 example.project.freemarker=example_project_freemarker.zip
 # zip file containing example project structure using groovy templates
 example.project.groovy=example_project_groovy.zip
+# zip file containing example project structure using groovy markup templates
+example.project.groovy-mte=example_project_groovy-mte.zip
 # zip file containing example project structure using thymeleaf templates
 example.project.thymeleaf=example_project_thymeleaf.zip
 # zip file containing example project structure using jade templates


### PR DESCRIPTION
Added an assembly description for the groovy-mte example project and the necessary executions.

Run ```jbake -i -t groovy-mte``` to initialize a new Project.

Closes #244 