### PR TITLE
Implemented Categories Support

### DIFF
--- a/src/main/java/org/jbake/app/ConfigUtil.java
+++ b/src/main/java/org/jbake/app/ConfigUtil.java
@@ -152,6 +152,11 @@ public class ConfigUtil {
 		static final String RENDER_TAGS = "render.tags";
 		
 		/**
+		 * Flag indicating if category files should be generated
+		 */
+		static final String RENDER_CATEGORIES = "render.categories";
+		
+		/**
 		 * Port used when running Jetty server
 		 */
 		static final String SERVER_PORT = "server.port";
@@ -200,6 +205,26 @@ public class ConfigUtil {
 		 * How many posts per page on index
 		 */
 		static final String POSTS_PER_PAGE = "index.posts_per_page";
+		
+		/**
+		 * Should Category generation and usage be enabled? Default is true. Posts without categories will be marked as 'Uncategorized'. Default category can be changed with {#link #CATEGORY_DEFAULT}.
+		 */
+		static final String CATEGORIES_ENABLE = "categories.enable";
+		
+		/**
+		 * Default Category for posts when {@link CATEGORIES_ENABLE} is {@code true} and no category is specified for post.
+		 */
+		static final String CATEGORY_DEFAULT = "category.default";
+		
+		/**
+		 * Tags output path, used only when {@link #RENDER_CATEGORIES} is true
+		 */
+		static final String CATEGORY_PATH = "categories.path";
+		
+		/**
+		 * Should Categories be sanitized for space?
+		 */
+		static final String CATEGORY_SANITIZE = "categories.sanitize";
 	}
 
 	private final static Logger LOGGER = LoggerFactory.getLogger(ConfigUtil.class);

--- a/src/main/java/org/jbake/app/ContentStore.java
+++ b/src/main/java/org/jbake/app/ContentStore.java
@@ -133,6 +133,10 @@ public class ContentStore {
         return query("select * from post where status='published' and ? in tags order by date desc", tag);
     }
 
+    public List<ODocument> getPublishedPostsByCategories(String category) {
+        return query("select * from post where status='published' and ? in categories order by date desc", category);
+    }
+    
     public List<ODocument> getPublishedPages() {
         return getPublishedContent("page");
     }
@@ -153,6 +157,10 @@ public class ContentStore {
         return query(query + " order by date desc");
     }
 
+    public List<ODocument> getAllCategoriesFromPublishedPosts() {
+        return query("select categories from post where status='published'");
+    }
+    
     public List<ODocument> getAllTagsFromPublishedPosts() {
         return query("select tags from post where status='published'");
     }
@@ -203,6 +211,16 @@ public class ContentStore {
 	    for (ODocument document : docs) {
 	        String[] tags = DBUtil.toStringArray(document.field("tags"));
 	        Collections.addAll(result, tags);
+	    }
+	    return result;
+    }
+    
+    public Set<String> getCategories() {
+    	List<ODocument> docs = this.getAllCategoriesFromPublishedPosts();
+	    Set<String> result = new HashSet<String>();
+	    for (ODocument document : docs) {
+	        String[] categories = DBUtil.toStringArray(document.field("categories"));
+	        Collections.addAll(result, categories);
 	    }
 	    return result;
     }

--- a/src/main/java/org/jbake/app/Crawler.java
+++ b/src/main/java/org/jbake/app/Crawler.java
@@ -56,6 +56,8 @@ public class Crawler {
 		static final String ROOTPATH = "rootpath";
 		static final String ID = "id";
 		static final String NO_EXTENSION_URI = "noExtensionUri";
+		static final String CATEGORIES = "categories";
+		static final String CATEGORY = "category";
 		
 	}
     private static final Logger LOGGER = LoggerFactory.getLogger(Crawler.class);

--- a/src/main/java/org/jbake/app/Renderer.java
+++ b/src/main/java/org/jbake/app/Renderer.java
@@ -370,10 +370,15 @@ public class Renderer {
                 map.put(Attributes.ROOTPATH, "../");
                 model.put("content", map);
 
-            	String pathCategory = category.trim().replace(" ", "-") + config.getString(Keys.OUTPUT_EXTENSION);
-            	File path = new File(destination.getPath() + File.separator + categoriesPath + File.separator + pathCategory);
+            	String pathCategory = category.trim().replace(" ", "-");
+            	String uri = File.separator + categoriesPath + File.separator + pathCategory;
+            	uri = getValidExtensionUri(uri,config);
+            	File path = new File(destination.getPath() + uri);
+            	
             	render(new ModelRenderingConfig(path, Attributes.CATEGORY, model, findTemplateName(Attributes.CATEGORY)));
-            	generatedCategories.put(category, pathCategory);
+            	
+            	//For categories listing, remove the index.html to generate /categories/categoryName/ instead of /categories/categoryName/index.html
+            	generatedCategories.put(category, uri.replace("/index.html", "/"));
                 renderedCount++;
             } catch (Exception e) {
                 errors.add(e.getCause().getMessage());
@@ -406,6 +411,24 @@ public class Renderer {
         	return renderedCount;
         }
     }
+    
+    /**
+     * If uri.noExtension is set to true then generate extension less uri. This method is to be used where uri.noExtension.prefix doesn't matter like categories, tags etc. 
+     * @param uri
+     * @param config
+     * @return
+     */
+    public static String getValidExtensionUri(String uri, CompositeConfiguration config){
+    	boolean noExtensionUri = config.getBoolean(Keys.URI_NO_EXTENSION);
+    	
+    	if (noExtensionUri) {
+    		uri = uri + "/index" + config.getString(Keys.OUTPUT_EXTENSION);
+        } else {
+            uri = uri + config.getString(Keys.OUTPUT_EXTENSION);
+        }
+    	return uri;
+    }
+
     
     /**
      * Builds simple map of values, which are exposed when rendering index/archive/sitemap/feed/tags.

--- a/src/main/java/org/jbake/render/CategoriesRenderer.java
+++ b/src/main/java/org/jbake/render/CategoriesRenderer.java
@@ -1,0 +1,33 @@
+package org.jbake.render;
+
+import java.io.File;
+
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.jbake.app.ConfigUtil.Keys;
+import org.jbake.app.ContentStore;
+import org.jbake.app.Renderer;
+import org.jbake.template.RenderingException;
+
+/**
+ * 
+ * This class renders Post Categories.
+ * 
+ * @author Manik Magar <manik.magar@gmail.com>
+ *
+ */
+public class CategoriesRenderer implements RenderingTool {
+
+	@Override
+	public int render(Renderer renderer, ContentStore db, File destination, File templatesPath, CompositeConfiguration config) throws RenderingException {
+		if (config.getBoolean(Keys.RENDER_CATEGORIES)) {
+			try {
+				return renderer.renderCategories(db.getCategories(), config.getString(Keys.CATEGORY_PATH));
+			} catch (Exception e) {
+				throw new RenderingException(e);
+			}
+		} else {
+			return 0;
+		}
+	}
+
+}

--- a/src/main/java/org/jbake/template/model/AllCategoriesExtractor.java
+++ b/src/main/java/org/jbake/template/model/AllCategoriesExtractor.java
@@ -1,0 +1,36 @@
+package org.jbake.template.model;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jbake.app.ContentStore;
+import org.jbake.app.Crawler;
+import org.jbake.app.DBUtil;
+import org.jbake.template.ModelExtractor;
+
+import com.orientechnologies.orient.core.record.impl.ODocument;
+
+/**
+ * 
+ * This extractor model will list of categories from all published content.
+ * 
+ * @author Manik MAgar <manik.magar@gmail.com>
+ *
+ */
+public class AllCategoriesExtractor implements ModelExtractor<Set<String>> {
+
+	@Override
+	public Set<String> get(ContentStore db, Map model, String key) {
+        List<ODocument> query = db.getAllCategoriesFromPublishedPosts();
+        Set<String> result = new HashSet<String>();
+        for (ODocument document : query) {
+            String[] categories = DBUtil.toStringArray(document.field(Crawler.Attributes.CATEGORIES));
+            Collections.addAll(result, categories);
+        }
+        return result;
+	}
+
+}

--- a/src/main/java/org/jbake/template/model/CategoryPostsExtractor.java
+++ b/src/main/java/org/jbake/template/model/CategoryPostsExtractor.java
@@ -1,0 +1,25 @@
+package org.jbake.template.model;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jbake.app.ContentStore;
+import org.jbake.app.Crawler;
+import org.jbake.app.DocumentList;
+import org.jbake.template.ModelExtractor;
+
+import com.orientechnologies.orient.core.record.impl.ODocument;
+
+public class CategoryPostsExtractor implements ModelExtractor<DocumentList> {
+
+	@Override
+	public DocumentList get(ContentStore db, Map model, String key) {
+        String category = null;
+		if (model.get(Crawler.Attributes.CATEGORY) != null) {
+			category = model.get(Crawler.Attributes.CATEGORY).toString();
+		}
+        List<ODocument> query = db.getPublishedPostsByCategories(category);
+        return DocumentList.wrap(query.iterator());
+	}
+
+}

--- a/src/main/resources/META-INF/org.jbake.template.ModelExtractors.properties
+++ b/src/main/resources/META-INF/org.jbake.template.ModelExtractors.properties
@@ -7,3 +7,5 @@ org.jbake.template.model.TypedDocumentsExtractor=pages,posts,indexs,archives,fee
 org.jbake.template.model.PublishedDateExtractor=published_date
 org.jbake.template.model.DBExtractor=db
 org.jbake.template.model.TagPostsExtractor=tag_posts
+org.jbake.template.model.CategoryPostsExtractor=category_posts
+org.jbake.template.model.AllCategoriesExtractor=all_categories

--- a/src/main/resources/META-INF/services/org.jbake.render.RenderingTool
+++ b/src/main/resources/META-INF/services/org.jbake.render.RenderingTool
@@ -5,3 +5,4 @@ org.jbake.render.IndexRenderer
 org.jbake.render.SitemapRenderer
 org.jbake.render.TagsRenderer
 #org.jbake.render.DatesRenderer
+org.jbake.render.CategoriesRenderer

--- a/src/main/resources/default.properties
+++ b/src/main/resources/default.properties
@@ -20,6 +20,10 @@ template.sitemap.file=sitemap.ftl
 template.post.file=post.ftl
 # filename of page template file
 template.page.file=page.ftl
+# filename of page template file
+template.category.file=category.ftl
+# file name of page template for {site.url}/categories
+template.categories.file=categories.ftl
 # folder that contains all content files
 content.folder=content
 # folder that contains all asset files
@@ -89,3 +93,14 @@ db.path=cache
 uri.noExtension=false
 # Set to a prefix path (starting with a slash) for which to generate extension-less URI's (i.e. a folder with index.html in)
 uri.noExtension.prefix=
+#Enable usage of categories. If disabled then nothing related to categories is processed or generated.
+categories.enable=true
+# Should categories pages be genetated
+render.categories=true
+#What should be the default category when no categories are specified for post and categories are enabled.
+category.default=Uncategorized
+# where to generate category pages
+categories.path=categories
+# Should spaces be replaced with hyphens 
+categories.sanitize=false
+

--- a/src/test/java/org/jbake/app/template/AbstractTemplateEngineRenderingTest.java
+++ b/src/test/java/org/jbake/app/template/AbstractTemplateEngineRenderingTest.java
@@ -246,4 +246,9 @@ public abstract class AbstractTemplateEngineRenderingTest {
         return outputStrings.get(type);
         
     }
+    
+    @Test
+    public void renderCategories() throws Exception {
+      
+    }
 }

--- a/src/test/java/org/jbake/app/template/FreemarkerTemplateEngineRenderingTest.java
+++ b/src/test/java/org/jbake/app/template/FreemarkerTemplateEngineRenderingTest.java
@@ -61,6 +61,8 @@ public class FreemarkerTemplateEngineRenderingTest extends AbstractTemplateEngin
         outputStrings.put("sitemap", Arrays.asList("blog/2013/second-post.html",
         	"blog/2012/first-post.html",
         	"papers/published-paper.html"));
+        outputStrings.put("categories", Arrays.asList("blog/2012/first-post.html"));
+        outputStrings.put("categories_index", Arrays.asList("<a href=\"Technology.html\"/>"));
     }
 
     @Test
@@ -78,4 +80,28 @@ public class FreemarkerTemplateEngineRenderingTest extends AbstractTemplateEngin
         assertThat(output2).contains("<a href=\"blog/2012/first-post.html\">");
 	}
 
+    @Test
+    @Override
+    public void renderCategories() throws Exception {
+        Crawler crawler = new Crawler(db, sourceFolder, config);
+        crawler.crawl(new File(sourceFolder.getPath() + File.separator + "content"));
+        Renderer renderer = new Renderer(db, destinationFolder, templateFolder, config);
+        renderer.renderCategories(db.getCategories(), "categories");
+
+        // verify
+        File outputFile = new File(destinationFolder + File.separator + "categories" + File.separator + "Technology.html");
+        Assert.assertTrue(outputFile.exists());
+        String output = FileUtils.readFileToString(outputFile);
+        for (String string : outputStrings.get("categories")) {
+            assertThat(output).contains(string);
+        }
+        
+        // verify index.html file
+        File indexFile = new File(destinationFolder + File.separator + "categories" + File.separator + "index.html");
+        Assert.assertTrue(indexFile.exists());
+        String indexData = FileUtils.readFileToString(indexFile);
+        for (String string : outputStrings.get("categories_index")) {
+            assertThat(indexData).contains(string);
+        }
+    }
 }

--- a/src/test/java/org/jbake/app/template/FreemarkerTemplateEngineRenderingTest.java
+++ b/src/test/java/org/jbake/app/template/FreemarkerTemplateEngineRenderingTest.java
@@ -62,7 +62,9 @@ public class FreemarkerTemplateEngineRenderingTest extends AbstractTemplateEngin
         	"blog/2012/first-post.html",
         	"papers/published-paper.html"));
         outputStrings.put("categories", Arrays.asList("blog/2012/first-post.html"));
-        outputStrings.put("categories_index", Arrays.asList("<a href=\"Technology.html\"/>"));
+        outputStrings.put("categories_noextension", Arrays.asList("blog/2012/first-post"));
+        outputStrings.put("categories_index_noextension", Arrays.asList("<a href=\"/categories/Technology/\"/>"));
+        outputStrings.put("categories_index", Arrays.asList("<a href=\"/categories/Technology.html\"/>"));
     }
 
     @Test
@@ -81,8 +83,34 @@ public class FreemarkerTemplateEngineRenderingTest extends AbstractTemplateEngin
 	}
 
     @Test
+    public void renderCategoriesNoExtension() throws Exception {
+    	config.setProperty(Keys.URI_NO_EXTENSION, true);
+    	config.setProperty(Keys.URI_NO_EXTENSION_PREFIX, "blog");
+        Crawler crawler = new Crawler(db, sourceFolder, config);
+        crawler.crawl(new File(sourceFolder.getPath() + File.separator + "content"));
+        Renderer renderer = new Renderer(db, destinationFolder, templateFolder, config);
+        renderer.renderCategories(db.getCategories(), "categories");
+
+        // verify
+        File outputFile = new File(destinationFolder + File.separator + "categories" + File.separator + "Technology" + File.separator + "index.html");
+        Assert.assertTrue(outputFile.exists());
+        String output = FileUtils.readFileToString(outputFile);
+        for (String string : outputStrings.get("categories_noextension")) {
+            assertThat(output).contains(string);
+        }
+        
+        // verify index.html file
+        File indexFile = new File(destinationFolder + File.separator + "categories" + File.separator + "index.html");
+        Assert.assertTrue(indexFile.exists());
+        String indexData = FileUtils.readFileToString(indexFile);
+        for (String string : outputStrings.get("categories_index_noextension")) {
+            assertThat(indexData).contains(string);
+        }
+    }
+    @Test
     @Override
     public void renderCategories() throws Exception {
+    	config.setProperty(Keys.URI_NO_EXTENSION, false);
         Crawler crawler = new Crawler(db, sourceFolder, config);
         crawler.crawl(new File(sourceFolder.getPath() + File.separator + "content"));
         Renderer renderer = new Renderer(db, destinationFolder, templateFolder, config);

--- a/src/test/java/org/jbake/app/template/GroovyTemplateEngineRenderingTest.java
+++ b/src/test/java/org/jbake/app/template/GroovyTemplateEngineRenderingTest.java
@@ -23,7 +23,16 @@
  */
 package org.jbake.app.template;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
 import java.util.Arrays;
+
+import org.apache.commons.io.FileUtils;
+import org.jbake.app.Crawler;
+import org.jbake.app.Renderer;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  *
@@ -56,6 +65,33 @@ public class GroovyTemplateEngineRenderingTest extends AbstractTemplateEngineRen
         outputStrings.put("sitemap", Arrays.asList("blog/2013/second-post.html",
         	"blog/2012/first-post.html",
         	"papers/published-paper.html"));
+        outputStrings.put("categories", Arrays.asList("/blog/2012/first-post.html"));
+        outputStrings.put("categories_index", Arrays.asList("<a href=\"Technology.html\"/>"));
     }
+    
+  @Test
+  @Override
+  public void renderCategories() throws Exception {
+      Crawler crawler = new Crawler(db, sourceFolder, config);
+      crawler.crawl(new File(sourceFolder.getPath() + File.separator + "content"));
+      Renderer renderer = new Renderer(db, destinationFolder, templateFolder, config);
+      renderer.renderCategories(db.getCategories(), "categories");
+
+      // verify
+      File outputFile = new File(destinationFolder + File.separator + "categories" + File.separator + "Technology.html");
+      Assert.assertTrue(outputFile.exists());
+      String output = FileUtils.readFileToString(outputFile);
+      for (String string : outputStrings.get("categories")) {
+          assertThat(output).contains(string);
+      }
+      
+      // verify index.html file
+      File indexFile = new File(destinationFolder + File.separator + "categories" + File.separator + "index.html");
+      Assert.assertTrue(indexFile.exists());
+      String indexData = FileUtils.readFileToString(indexFile);
+      for (String string : outputStrings.get("categories_index")) {
+          assertThat(indexData).contains(string);
+      }
+  }
 
 }

--- a/src/test/java/org/jbake/app/template/GroovyTemplateEngineRenderingTest.java
+++ b/src/test/java/org/jbake/app/template/GroovyTemplateEngineRenderingTest.java
@@ -66,7 +66,7 @@ public class GroovyTemplateEngineRenderingTest extends AbstractTemplateEngineRen
         	"blog/2012/first-post.html",
         	"papers/published-paper.html"));
         outputStrings.put("categories", Arrays.asList("/blog/2012/first-post.html"));
-        outputStrings.put("categories_index", Arrays.asList("<a href=\"Technology.html\"/>"));
+        outputStrings.put("categories_index", Arrays.asList("<a href=\"/categories/Technology.html\"/>"));
     }
     
   @Test

--- a/src/test/resources/content/blog/2012/first-post.html
+++ b/src/test/resources/content/blog/2012/first-post.html
@@ -3,6 +3,7 @@ date=2012-02-27
 type=post
 tags=blog
 status=published
+categories=Technology
 ~~~~~~
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque vel diam purus. Curabitur ut nisi lacus. 

--- a/src/test/resources/freemarkerTemplates/categories.ftl
+++ b/src/test/resources/freemarkerTemplates/categories.ftl
@@ -1,0 +1,15 @@
+<#include "header.ftl">
+
+	<#include "menu.ftl">
+	
+	<div class="page-header">
+		<h1>All Categories</h1>
+	</div>
+	
+		<ul>
+		<#list content.categories?keys as category>
+			<li><a href="${content.categories[category]}"/>${category}</a></li>
+		</#list>
+		</ul>
+	
+<#include "footer.ftl">

--- a/src/test/resources/freemarkerTemplates/category.ftl
+++ b/src/test/resources/freemarkerTemplates/category.ftl
@@ -1,0 +1,27 @@
+<#include "header.ftl">
+
+	<#include "menu.ftl">
+	
+	<div class="page-header">
+		<h1>Category: ${category}</h1>
+	</div>
+	
+	
+		<#list category_posts as post>
+		<#if (last_month)??>
+			<#if post.date?string("MMMM yyyy") != last_month>
+				
+				<h4>${post.date?string("MMMM yyyy")}</h4>
+				<ul>
+			</#if>
+		<#else>
+			<h4>${post.date?string("MMMM yyyy")}</h4>
+			<ul>
+		</#if>
+		
+		<li>${post.date?string("dd")} - <a href="${post.uri}">${post.title}</a></li>
+		<#assign last_month = post.date?string("MMMM yyyy")>
+		</#list>
+		</ul>
+	
+<#include "footer.ftl">

--- a/src/test/resources/groovyTemplates/categories.gsp
+++ b/src/test/resources/groovyTemplates/categories.gsp
@@ -1,0 +1,14 @@
+<%include 'header.gsp'%>
+
+	<div class="page-header">
+		<h1>All Categories</h1>
+	</div>
+	<div class="category-posts">
+		<ul>
+		<%content.categories.each {category,path ->%>
+			<li><a href="${path}"/>${category}</a></li>
+		<%}%>
+		</ul>
+		</div>
+
+<%include "footer.gsp"%>

--- a/src/test/resources/groovyTemplates/category.gsp
+++ b/src/test/resources/groovyTemplates/category.gsp
@@ -1,0 +1,27 @@
+<%include 'header.gsp'%>
+
+	<div class="page-header">
+		<h1>Category: ${category}</h1>
+	</div>
+	<div class="category-posts">
+	<!--<ul>-->
+		<%def last_month=null;%>
+		<%category_posts.each {post ->%>
+		<%if (last_month) {%>
+			<%if (post.date.format("MMMM yyyy") != last_month) {%>
+				</ul>
+				<h4>${post.date.format("MMMM yyyy")}</h4>
+				<ul>
+			<%}%>
+		<%} else {%>
+			<h4>${post.date.format("MMMM yyyy")}</h4>
+			<ul>
+		<%}%>
+
+		<li>${post.date.format("dd")} - <a href="${content.rootpath}${post.uri}">${post.title}</a></li>
+		<% last_month = post.date.format("MMMM yyyy")%>
+		<%}%>
+	</ul>
+		</div>
+
+<%include "footer.gsp"%>


### PR DESCRIPTION
Implemented Categories Support for Posts.

### Categories configuration controls - 

- `template.category.file=category.ftl` _(This is for rendering individual category page)_
- `template.categories.file=categories.ftl` _(This is for rendering all categories list page to prevent directory listing on {site.host}/categories/ url._
- `categories.enable=true`
- `render.categories=true`
- `category.default=Uncategorized`
- `categories.path=categories`
- `categories.sanitize=false`

### Adding categories in content
Add an attribute `categories=Category1, Category2`
- If `categories.enable` is not false and no categories are provided for post then `category.default` is applied to post.
- First category is also available with `primary_category` key in model.
- If `categories.enable` is false and categories are still provided in content, then those are ignored with a warning in log.

### Accessing categories in templates
- `all_categories` - All categories from all published content. This variable is available on templates.
- `category_posts` - On a single category page `template.category.file`, this variable is available and provides access to posts marked with category being displayed on page.


### Extensionless Support
If `uri.noExtension` is set to `true` then all category pages are rendered without extension.

### Test cases
Appropriate test cases have been added under `src/test/java` with its resources under `src/test/resources`.

