### PR TITLE
shutdown orient database after bake has finished.

### DIFF
--- a/src/main/java/org/jbake/app/ContentStore.java
+++ b/src/main/java/org/jbake/app/ContentStore.java
@@ -23,6 +23,7 @@
  */
 package org.jbake.app;
 
+import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentPool;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
@@ -110,6 +111,11 @@ public class ContentStore {
     public void close() {
         db.close();
         DBUtil.closeDataStore();
+    }
+
+    public void shutdown() {
+
+        Orient.instance().shutdown();
     }
 
     public void drop() {

--- a/src/main/java/org/jbake/app/ContentStore.java
+++ b/src/main/java/org/jbake/app/ContentStore.java
@@ -60,6 +60,7 @@ public class ContentStore {
     private long limit = -1;
 
     public ContentStore(final String type, String name) {
+        startupIfEnginesAreMissing();
         db = new ODatabaseDocumentTx(type + ":" + name);
         boolean exists = db.exists();
         if (!exists) {
@@ -114,8 +115,15 @@ public class ContentStore {
     }
 
     public void shutdown() {
-
         Orient.instance().shutdown();
+    }
+
+    private void startupIfEnginesAreMissing() {
+        // If an instance of Orient was previously shutdown all engines are removed.
+        // We need to startup Orient again.
+        if ( Orient.instance().getEngines().size() == 0 ) {
+            Orient.instance().startup();
+        }
     }
 
     public void drop() {

--- a/src/main/java/org/jbake/app/DBUtil.java
+++ b/src/main/java/org/jbake/app/DBUtil.java
@@ -35,18 +35,6 @@ public class DBUtil {
         return result;
     }
 
-//    private static List<ODocument> query(ContentStore db, String query, Object... args) {
-//        return db.command(new OSQLSynchQuery<ODocument>(query)).execute(args);
-//    }
-//
-//    public static void update(ContentStore db, String query, Object... args) {
-//        db.command(new OCommandSQL(query)).execute(args);
-//    }
-//
-//    public static DocumentIterator fetchDocuments(ContentStore db, String query, Object... args) {
-//        return new DocumentIterator(query(db, query, args).iterator());
-//    }
-
     /**
      * Converts a DB list into a String array
      */

--- a/src/main/java/org/jbake/app/Oven.java
+++ b/src/main/java/org/jbake/app/Oven.java
@@ -1,25 +1,18 @@
 package org.jbake.app;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.ServiceLoader;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.orientechnologies.orient.core.record.impl.ODocument;
-
 import org.apache.commons.configuration.CompositeConfiguration;
-import org.apache.commons.configuration.ConfigurationException;
 import org.jbake.app.ConfigUtil.Keys;
 import org.jbake.model.DocumentTypes;
 import org.jbake.render.RenderingTool;
 import org.jbake.template.RenderingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * All the baking happens in the Oven!
@@ -174,7 +167,7 @@ public class Oven {
                 }
         } finally {
                 db.close();
-//                Orient.instance().shutdown();
+                db.shutdown();
         }
     }
 


### PR DESCRIPTION
Using a local storage cache with `db.store=local` throws an exception
rerunning the bake task.

```
:bake FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':bake'.
> Cannot open local storage 'cache' with mode=rw
```

See [stacktrace](https://gist.github.com/ancho/a031859dd4a04f497c91a12a51c09c7f).