### PR TITLE
Ignore javadoc error on package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,9 @@
 	        </plugin>
 	        <plugin>
 	          <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
 	          <executions>
 	            <execution>
 	              <id>attach-javadocs</id>


### PR DESCRIPTION
Running
mvn clean package
[Log from master build](https://gist.github.com/lamvak/6726d6e07786755ec7c09b02bac259e8)
[Log from ignore_javadoc branch build](https://gist.github.com/lamvak/9f1b828c40f82c4cf95b2d56608e267a)

Of course, since javadoc is used for documentation, it would be better to just fix the issues. However this allows to build the package with current shape.
