### PR TITLE
Add support for symbolically linked launcher

### DIFF
--- a/src/main/scripts/jbake
+++ b/src/main/scripts/jbake
@@ -1,5 +1,11 @@
 #!/bin/bash
-EXEC_LOC="`dirname "$0"`"
+
+P=$(realpath $0)
+if [ 0 -ne $? ]; then
+  P=$0
+fi
+
+EXEC_LOC="`dirname "$P"`"
 EXEC_PARENT="`dirname $EXEC_LOC`"
 
 CYGWIN=false;


### PR DESCRIPTION
useful when one plans to develop and release locally via maven package from one's fork; i.e.

$ ls -l ~/bin/jbake 
lrwxrwxrwx 1 user group 49 Okt 20 15:22 /home/user/bin/jbake -> /home/user/workspace/rels/jbake-2.5.0/bin/jbake
$ tail ~/.bashrc -n1
export PATH="${PATH}:${HOME}/bin"
