### PR TITLE
Tag pages are created for documents of type post only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.jbake</groupId>
 	<artifactId>jbake-core</artifactId>
-	<version>2.5.0</version>
+	<version>2.5.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
     <name>jbake</name>

--- a/src/main/java/org/jbake/app/ContentStore.java
+++ b/src/main/java/org/jbake/app/ContentStore.java
@@ -139,6 +139,15 @@ public class ContentStore {
         return query("select * from post where status='published' and ? in tags order by date desc", tag);
     }
 
+    public DocumentList getPublishedDocumentsByTag(String tag) {
+        final DocumentList documents = new DocumentList();
+        for (final String docType : DocumentTypes.getDocumentTypes()) {
+            DocumentList documentsByTag = query("select * from " + docType + " where status='published' and ? in tags order by date desc", tag);
+            documents.addAll(documentsByTag);
+        }
+        return documents;
+    }
+
     public DocumentList getPublishedPages() {
         return getPublishedContent("page");
     }

--- a/src/main/java/org/jbake/app/Renderer.java
+++ b/src/main/java/org/jbake/app/Renderer.java
@@ -317,7 +317,7 @@ public class Renderer {
     public int renderTags(String tagPath) throws Exception {
     	int renderedCount = 0;
     	final List<Throwable> errors = new LinkedList<Throwable>();
-        for (String tag : db.getTags()) {
+        for (String tag : db.getAllTags()) {
             try {
             	Map<String, Object> model = new HashMap<String, Object>();
             	model.put("renderer", renderingEngine);

--- a/src/main/java/org/jbake/template/model/TaggedDocumentsExtractor.java
+++ b/src/main/java/org/jbake/template/model/TaggedDocumentsExtractor.java
@@ -1,0 +1,22 @@
+package org.jbake.template.model;
+
+import java.util.Map;
+
+import org.jbake.app.ContentStore;
+import org.jbake.app.Crawler;
+import org.jbake.app.DocumentList;
+import org.jbake.template.ModelExtractor;
+
+public class TaggedDocumentsExtractor implements ModelExtractor<DocumentList> {
+
+    @Override
+    public DocumentList get(ContentStore db, Map model, String key) {
+        String tag = null;
+        if (model.get(Crawler.Attributes.TAG) != null) {
+            tag = model.get(Crawler.Attributes.TAG).toString();
+        }
+        // fetch the tagged documents from db
+        return db.getPublishedDocumentsByTag(tag);
+    }
+
+}

--- a/src/main/resources/META-INF/org.jbake.template.ModelExtractors.properties
+++ b/src/main/resources/META-INF/org.jbake.template.ModelExtractors.properties
@@ -7,3 +7,4 @@ org.jbake.template.model.TypedDocumentsExtractor=pages,posts,indexs,archives,fee
 org.jbake.template.model.PublishedDateExtractor=published_date
 org.jbake.template.model.DBExtractor=db
 org.jbake.template.model.TagPostsExtractor=tag_posts
+org.jbake.template.model.TaggedDocumentsExtractor=tagged_documents


### PR DESCRIPTION
`org.jbake.app.Renderer#renderTags(String)` calls `ContentStore#getTags()` where it should call `ContentStore#getAllTags()` (IMHO), see #266 @jonbullock, WDYT?