### PR TITLE
Exclude index.html from previousFileName and nextFileName values.

### DIFF
--- a/src/main/java/org/jbake/util/PagingHelper.java
+++ b/src/main/java/org/jbake/util/PagingHelper.java
@@ -17,7 +17,7 @@ public class PagingHelper {
 
     public String getNextFileName(int currentPageNumber, String fileName) {
         if (currentPageNumber < getNumberOfPages()) {
-            return (currentPageNumber + 1) + File.separator + fileName;
+            return (currentPageNumber + 1) + File.separator;
         } else {
             return null;
         }
@@ -29,10 +29,11 @@ public class PagingHelper {
             return null;
         } else {
             if ( currentPageNumber == 2 ) {
-                return fileName;
+            	// Returning to first page, return empty string which when prefixed with content.rootpath should get to root of the site.
+                return "";
             }
             else {
-                return (currentPageNumber - 1) + File.separator + fileName;
+                return (currentPageNumber - 1) + File.separator;
             }
         }
     }

--- a/src/test/java/org/jbake/app/template/FreemarkerTemplateEngineRenderingTest.java
+++ b/src/test/java/org/jbake/app/template/FreemarkerTemplateEngineRenderingTest.java
@@ -50,8 +50,8 @@ public class FreemarkerTemplateEngineRenderingTest extends AbstractTemplateEngin
         config.setProperty(Keys.POSTS_PER_PAGE, 1);
 
         outputStrings.put("index", Arrays.asList(
-                "index.html\">Previous</a>",
-                "3/index.html\">Next</a>",
+                "\">Previous</a>",
+                "3/\">Next</a>",
                 "2 of 3"
         ));
 

--- a/src/test/java/org/jbake/util/PagingHelperTest.java
+++ b/src/test/java/org/jbake/util/PagingHelperTest.java
@@ -27,7 +27,7 @@ public class PagingHelperTest {
 
         String previousFileName = helper.getPreviousFileName(2, "index.html");
 
-        Assert.assertThat("index.html", is( previousFileName) );
+        Assert.assertThat("", is( previousFileName) );
     }
 
     @Test
@@ -37,7 +37,7 @@ public class PagingHelperTest {
 
         String previousFileName = helper.getPreviousFileName(3, "index.html");
 
-        Assert.assertThat("2/index.html", is( previousFileName) );
+        Assert.assertThat("2/", is( previousFileName) );
 
     }
 
@@ -66,7 +66,7 @@ public class PagingHelperTest {
 
         String nextFileName = helper.getNextFileName(2, "index.html");
 
-        Assert.assertThat("3/index.html", is( nextFileName) );
+        Assert.assertThat("3/", is( nextFileName) );
 
     }
 }


### PR DESCRIPTION
When index is paginated, previousFileName and nextFileName values are
added to content model. These values were including index.html in it.
For example, nextFileName value on first page was "2/index.html". It is
better to have values just as "2/" or "3/" etc. Corresponding test cases
have also been updated.

@ancho @jonbullock, Please take a look at this.