### PR TITLE
Add document navigator data model

### DIFF
--- a/src/main/java/org/jbake/app/ContentStore.java
+++ b/src/main/java/org/jbake/app/ContentStore.java
@@ -183,7 +183,7 @@ public class ContentStore {
     }
 
     public DocumentList getUnrenderedContent(String docType) {
-        return query("select * from " + docType + " where rendered=false");
+        return query("select * from " + docType + " where rendered=false order by date desc");
     }
 
     public void deleteContent(String docType, String uri) {

--- a/src/main/java/org/jbake/render/DocumentsRenderer.java
+++ b/src/main/java/org/jbake/render/DocumentsRenderer.java
@@ -44,12 +44,12 @@ public class DocumentsRenderer implements RenderingTool {
 						Map<String, Object> tempNext = documentList.get(index + 1);
 						document.put("previousContent", getContentForNav(tempNext));
 					}
-
+					
+					nextDocument = document;
+					
 					renderer.render(document);
 					renderedCount++;
 
-					nextDocument = document;
-					
 				} catch (Exception e) {
 					errors.add(e.getMessage());
 				}

--- a/src/main/java/org/jbake/render/DocumentsRenderer.java
+++ b/src/main/java/org/jbake/render/DocumentsRenderer.java
@@ -1,43 +1,84 @@
 package org.jbake.render;
 
+import java.io.File;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.ContentStore;
+import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.DocumentList;
 import org.jbake.app.Renderer;
 import org.jbake.model.DocumentTypes;
 import org.jbake.template.RenderingException;
 
-import java.io.File;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
 public class DocumentsRenderer implements RenderingTool {
 
-    @Override
-    public int render(Renderer renderer, ContentStore db, File destination, File templatesPath, CompositeConfiguration config) throws RenderingException {
-        int renderedCount = 0;
-        final List<String> errors = new LinkedList<String>();
-        for (String docType : DocumentTypes.getDocumentTypes()) {
-            DocumentList documentList = db.getUnrenderedContent(docType);
-            for (Map<String, Object> page : documentList) {
-                try {
-                    renderer.render(page);
-                    renderedCount++;
-                } catch (Exception e) {
-                    errors.add(e.getMessage());
-                }
-            }
-        }
-        if (!errors.isEmpty()) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("Failed to render documents. Cause(s):");
-            for (String error : errors) {
-                sb.append("\n").append(error);
-            }
-            throw new RenderingException(sb.toString());
-        } else {
-            return renderedCount;
-        }
-    }
+	@Override
+	public int render(Renderer renderer, ContentStore db, File destination, File templatesPath,
+			CompositeConfiguration config) throws RenderingException {
+		int renderedCount = 0;
+		final List<String> errors = new LinkedList<String>();
+		for (String docType : DocumentTypes.getDocumentTypes()) {
+			DocumentList documentList = db.getUnrenderedContent(docType);
+			
+			if(documentList == null) continue;
+
+			int index = 0;
+
+			Map<String, Object> nextDocument = null;
+
+			while (index < documentList.size()) {
+				try {
+					Map<String, Object> document = documentList.get(index);
+					document.put("nextContent", null);
+					document.put("previousContent", null);
+					
+					if (index > 0) {
+						document.put("nextContent", getContentForNav(nextDocument));
+					}
+
+					if (index < documentList.size() - 1) {
+						Map<String, Object> tempNext = documentList.get(index + 1);
+						document.put("previousContent", getContentForNav(tempNext));
+					}
+					
+					nextDocument = document;
+					
+					renderer.render(document);
+					renderedCount++;
+
+				} catch (Exception e) {
+					errors.add(e.getMessage());
+				}
+
+				index++;
+			}
+		}
+		if (!errors.isEmpty()) {
+			StringBuilder sb = new StringBuilder();
+			sb.append("Failed to render documents. Cause(s):");
+			for (String error : errors) {
+				sb.append("\n").append(error);
+			}
+			throw new RenderingException(sb.toString());
+		} else {
+			return renderedCount;
+		}
+	}
+
+	/**
+	 * Creates a simple content model to use in individual post navigations.
+	 * @param document
+	 * @return
+	 */
+	private Map<String, Object> getContentForNav(Map<String, Object> document) {
+		Map<String, Object> navDocument = new HashMap<String, Object>();
+		navDocument.put(Attributes.NO_EXTENSION_URI, document.get(Attributes.NO_EXTENSION_URI));
+		navDocument.put(Attributes.URI, document.get(Attributes.URI));
+		navDocument.put(Attributes.TITLE, document.get(Attributes.TITLE));
+		return navDocument;
+	}
 }

--- a/src/test/java/org/jbake/render/DocumentsRendererTest.java
+++ b/src/test/java/org/jbake/render/DocumentsRendererTest.java
@@ -4,15 +4,21 @@ import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.ContentStore;
 import org.jbake.app.DocumentList;
 import org.jbake.app.Renderer;
+import org.jbake.app.Crawler.Attributes;
 import org.jbake.model.DocumentTypes;
 import org.jbake.template.RenderingException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyMap;
@@ -30,9 +36,15 @@ public class DocumentsRendererTest {
     private DocumentList emptyDocumentList;
     private File destinationFile;
     private File templatePath;
+    
+    @Captor
+    private ArgumentCaptor<Map<String, Object>> argument;
 
     @Before
     public void setUp() throws Exception {
+    	
+    	MockitoAnnotations.initMocks(this);
+    	
         documentsRenderer = new DocumentsRenderer();
 
         db = mock(ContentStore.class);
@@ -103,8 +115,68 @@ public class DocumentsRendererTest {
         // then
         assertThat(renderResponse).isEqualTo(2);
     }
+    
+    @Test
+    public void shouldContainPostNavigation()  throws Exception{
+    	DocumentTypes.addDocumentType("customType");
+    	
+    	String first = "First Document";
+    	String second = "Second Document";
+    	String third = "Third Document";
+    	String fourth = "Fourth Document";
+    	
+    	DocumentList documents = new DocumentList();
+    	documents.add(simpleDocument(fourth));
+    	documents.add(simpleDocument(third));
+    	documents.add(simpleDocument(second));
+    	documents.add(simpleDocument(first));
+    	
+    	when(db.getUnrenderedContent("customType")).thenReturn(documents);
+    	
+    	int renderResponse = documentsRenderer.render(renderer,db,destinationFile,templatePath,configuration);
+    	
+    	Map<String, Object> fourthDoc = simpleDocument(fourth);
+    	fourthDoc.put("previousContent", simpleDocument(third));
+    	fourthDoc.put("nextContent", null);
+   
+    	Map<String, Object> thirdDoc = simpleDocument(third);
+    	thirdDoc.put("nextContent", simpleDocument(fourth));
+    	thirdDoc.put("previousContent", simpleDocument(second));
+    	
+    	Map<String, Object> secondDoc = simpleDocument(second);
+    	secondDoc.put("nextContent", simpleDocument(third));
+    	secondDoc.put("previousContent", simpleDocument(first));
+    	
+    	Map<String, Object> firstDoc = simpleDocument(first);
+    	firstDoc.put("nextContent", simpleDocument(second));
+    	firstDoc.put("previousContent", null);
+    	
+    	verify(renderer,times(4)).render(argument.capture());
+    	
+    	List<Map<String, Object>> maps = argument.getAllValues();
+    	
+    	assertThat(maps).contains(fourthDoc);
+    	
+    	assertThat(maps).contains(thirdDoc);
+    	
+    	assertThat(maps).contains(secondDoc);
+    	
+    	assertThat(maps).contains(firstDoc);
+    	
+    	assertThat(renderResponse).isEqualTo(4);
+    }
 
     private HashMap<String, Object> emptyDocument() {
         return new HashMap<String,Object>();
     }
+    
+    private Map<String, Object> simpleDocument(String title) {
+    	Map<String, Object> simpleDoc = new HashMap<String, Object>();
+    	String uri = title.replace(" ", "_");
+    	simpleDoc.put(Attributes.NO_EXTENSION_URI, uri);
+    	simpleDoc.put(Attributes.URI, uri);
+    	simpleDoc.put(Attributes.TITLE, title);;
+		return simpleDoc;
+    }
+    
 }


### PR DESCRIPTION
This updates adds nextContent and previousContent data model in every document. This will allow the render previous post and next post type navigation on post/document page.

See the nav links at the bottom of below screenshot. Templates can use this as - 

```
<ul class="actions pagination">
  	
  		<#if (post.previousContent)??> 
        <li><a href="${content.rootpath}${post.previousContent.noExtensionUri!post.previousContent.uri}" 
                class="button big previous">${content.previousContent.title}</a></li>
         </#if>
       <#if (post.nextContent)??> 
        <li><a href="${content.rootpath}${post.nextContent.noExtensionUri!post.nextContent.uri}" 
                class="button big next">${content.nextContent.title}</a></li>
        </#if>
	
</ul>
```
<img width="1436" alt="doc_nav" src="https://cloud.githubusercontent.com/assets/877286/26072837/05c18962-397b-11e7-9ae9-e52c7ce7a709.png">
