### PR TITLE
enable ci tests on appveyor

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -8,6 +8,7 @@ Jonathan Bullock
 http://jbake.org[JBake] is a Java based open source static site/blog generator for developers.
 
 image:https://img.shields.io/travis/jbake-org/jbake/master.svg["Build Status", link="https://travis-ci.org/jbake-org/jbake"]
+image:https://ci.appveyor.com/api/projects/status/github/ancho/jbake?svg=true["Appveyor Status", link="https://ci.appveyor.com/project/ancho/jbake"]
 image:https://img.shields.io/coveralls/jbake-org/jbake/master.svg["Coverage Status", link="https://coveralls.io/r/jbake-org/jbake"]
 image:https://img.shields.io/maven-central/v/org.jbake/jbake-core.svg["Maven Download", link="http://jbake.org/download.html#maven"]
 image:https://api.bintray.com/packages/jbake/maven/jbake-core/images/download.svg["Bintray Download", link="https://bintray.com/jbake/maven/jbake-core/_latestVersion"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: '{build}'
+skip_tags: true
+skip_commits:
+  message: /\[ci skip\]/
+clone_depth: 10
+environment:
+  TERM: dumb
+  matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+install:
+  - SET PATH=%JAVA_HOME%\bin;%PATH%
+  - echo %PATH%
+  - java -version
+  - gradlew.bat --version
+build_script:
+  - gradlew.bat -u -i assemble
+test_script:
+  - gradlew.bat -u -i -S check

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ clone_depth: 10
 environment:
   TERM: dumb
   matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 install:
   - SET PATH=%JAVA_HOME%\bin;%PATH%

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,13 @@ ext {
     mockitoVersion = '1.10.19'
 }
 
+sourceSets {
+    smokeTest {
+        java.srcDir file('src/smoke-test/java')
+        resources.srcDir file('src/smoke-test/resources')
+    }
+}
+
 dependencies {
     compile group: 'commons-io', name: 'commons-io', version:  commonsIoVersion
     compile group: 'commons-configuration', name: 'commons-configuration', version: commonsConfigurationVersion
@@ -71,11 +78,25 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.assertj', name: 'assertj-core', version: assertjCoreVersion
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+
+    smokeTestCompile configurations.testCompile
+    smokeTestCompile sourceSets.test.output
+    smokeTestRuntime configurations.testRuntime
 }
 
 test {
     jvmArgs '-XX:MaxDirectMemorySize=512m', '-Dorientdb.installCustomFormatter=false=false'
 }
+
+task smokeTest(type: Test, dependsOn: installDist) {
+    group 'Verification'
+    description 'Runs the integration tests.'
+    testClassesDir = sourceSets.smokeTest.output.classesDir
+    classpath = sourceSets.smokeTest.runtimeClasspath
+    shouldRunAfter test
+}
+
+check.dependsOn smokeTest
 
 jacoco {
     toolVersion = jacocoVersion

--- a/src/main/java/org/jbake/app/Crawler.java
+++ b/src/main/java/org/jbake/app/Crawler.java
@@ -17,40 +17,39 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
 
-import static java.io.File.separator;
-
 /**
  * Crawls a file system looking for content.
  *
  * @author Jonathan Bullock <a href="mailto:jonbullock@gmail.com">jonbullock@gmail.com</a>
  */
 public class Crawler {
-	public interface Attributes {
-		/**
-		 * Possible values of the {@link Attributes#STATUS} property
-		 * @author ndx
-		 *
-		 */
+    public interface Attributes {
+        /**
+         * Possible values of the {@link Attributes#STATUS} property
+         *
+         * @author ndx
+         */
         interface Status {
-			String PUBLISHED_DATE = "published-date";
-			String PUBLISHED = "published";
-			String DRAFT = "draft";
-		}
-		String DATE = "date";
-		String STATUS = "status";
-		String TYPE = "type";
-		String TITLE = "title";
-		String URI = "uri";
-		String FILE = "file";
-		String TAGS = "tags";
-		String TAG = "tag";
-		String ROOTPATH = "rootpath";
-		String ID = "id";
-		String NO_EXTENSION_URI = "noExtensionUri";
-		String ALLTAGS = "alltags";
-		String PUBLISHED_DATE = "published_date";
-		String BODY = "body";
-	}
+            String PUBLISHED_DATE = "published-date";
+            String PUBLISHED = "published";
+            String DRAFT = "draft";
+        }
+
+        String DATE = "date";
+        String STATUS = "status";
+        String TYPE = "type";
+        String TITLE = "title";
+        String URI = "uri";
+        String FILE = "file";
+        String TAGS = "tags";
+        String TAG = "tag";
+        String ROOTPATH = "rootpath";
+        String ID = "id";
+        String NO_EXTENSION_URI = "noExtensionUri";
+        String ALLTAGS = "alltags";
+        String PUBLISHED_DATE = "published_date";
+        String BODY = "body";
+    }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Crawler.class);
 
@@ -61,9 +60,10 @@ public class Crawler {
 
     /**
      * Creates new instance of Crawler.
-	 * @param db		Database instance for content
-	 * @param source	Base directory where content directory is located
-	 * @param config	Project configuration
+     *
+     * @param db     Database instance for content
+     * @param source Base directory where content directory is located
+     * @param config Project configuration
      */
     public Crawler(ContentStore db, File source, CompositeConfiguration config) {
         this.db = db;
@@ -131,30 +131,51 @@ public class Crawler {
     }
 
     private String buildURI(final File sourceFile) {
-    	String uri = FileUtil.asPath(sourceFile.getPath()).replace(FileUtil.asPath( contentPath), "");
+        String uri = FileUtil.asPath(sourceFile.getPath())
+                .replace(FileUtil.asPath(contentPath), "")
+                // On windows we have to replace the backslash
+                .replace(File.separator, "/");
 
-    	boolean noExtensionUri = config.getBoolean(Keys.URI_NO_EXTENSION);
-    	String noExtensionUriPrefix = config.getString(Keys.URI_NO_EXTENSION_PREFIX);
-    	if (noExtensionUri && noExtensionUriPrefix != null && noExtensionUriPrefix.length() > 0) {
-        	// convert URI from xxx.html to xxx/index.html
-    		if (uri.startsWith(noExtensionUriPrefix)) {
-    			uri = "/" + FilenameUtils.getPath(uri) + FilenameUtils.getBaseName(uri) + "/index" + config.getString(Keys.OUTPUT_EXTENSION);
-    		}
+        if (useNoExtensionUri(uri)) {
+            // convert URI from xxx.html to xxx/index.html
+            uri = createNoExtensionUri(uri);
         } else {
-            uri = uri.substring(0, uri.lastIndexOf(".")) + config.getString(Keys.OUTPUT_EXTENSION);
+            uri = createUri(uri);
         }
 
         // strip off leading / to enable generating non-root based sites
-    	if (uri.startsWith("/")) {
-    		uri = uri.substring(1, uri.length());
-    	}
+        if (uri.startsWith("/")) {
+            uri = uri.substring(1, uri.length());
+        }
         return uri;
+    }
+
+    private String createUri(String uri) {
+        return uri.substring(0, uri.lastIndexOf(".")) + config.getString(Keys.OUTPUT_EXTENSION);
+    }
+
+    private String createNoExtensionUri(String uri) {
+        return "/"
+                + FilenameUtils.getPath(uri)
+                + FilenameUtils.getBaseName(uri)
+                + "/index"
+                + config.getString(Keys.OUTPUT_EXTENSION);
+    }
+
+    private boolean useNoExtensionUri(String uri) {
+        boolean noExtensionUri = config.getBoolean(Keys.URI_NO_EXTENSION);
+        String noExtensionUriPrefix = config.getString(Keys.URI_NO_EXTENSION_PREFIX);
+
+        return noExtensionUri
+                && (noExtensionUriPrefix != null)
+                && (noExtensionUriPrefix.length() > 0)
+                && uri.startsWith(noExtensionUriPrefix);
     }
 
     private void crawlSourceFile(final File sourceFile, final String sha1, final String uri) {
         Map<String, Object> fileContents = parser.processFile(sourceFile);
         if (fileContents != null) {
-        	fileContents.put(Attributes.ROOTPATH, getPathToRoot(sourceFile));
+            fileContents.put(Attributes.ROOTPATH, getPathToRoot(sourceFile));
             fileContents.put(String.valueOf(DocumentAttributes.SHA1), sha1);
             fileContents.put(String.valueOf(DocumentAttributes.RENDERED), false);
             if (fileContents.get(Attributes.TAGS) != null) {
@@ -176,12 +197,12 @@ public class Crawler {
             }
 
             if (config.getBoolean(Keys.URI_NO_EXTENSION)) {
-            	fileContents.put(Attributes.NO_EXTENSION_URI, uri.replace("/index.html", "/"));
+                fileContents.put(Attributes.NO_EXTENSION_URI, uri.replace("/index.html", "/"));
             }
 
             ODocument doc = new ODocument(documentType);
-            doc.fields(fileContents);
-            boolean cached = fileContents.get(DocumentAttributes.CACHED) != null ? Boolean.valueOf((String)fileContents.get(DocumentAttributes.CACHED)):true;
+            doc.fromMap(fileContents);
+            boolean cached = fileContents.get(DocumentAttributes.CACHED) != null ? Boolean.valueOf((String) fileContents.get(DocumentAttributes.CACHED)) : true;
             doc.field(String.valueOf(DocumentAttributes.CACHED), cached);
             doc.save();
         } else {
@@ -190,18 +211,18 @@ public class Crawler {
     }
 
     public String getPathToRoot(File sourceFile) {
-    	File rootPath = new File(contentPath);
-    	File parentPath = sourceFile.getParentFile();
-    	int parentCount = 0;
-    	while (!parentPath.equals(rootPath)) {
-    		parentPath = parentPath.getParentFile();
-    		parentCount++;
-    	}
-    	StringBuilder sb = new StringBuilder();
-    	for (int i = 0; i < parentCount; i++) {
-    		sb.append("../");
-    	}
-    	return sb.toString();
+        File rootPath = new File(contentPath);
+        File parentPath = sourceFile.getParentFile();
+        int parentCount = 0;
+        while (!parentPath.equals(rootPath)) {
+            parentPath = parentPath.getParentFile();
+            parentCount++;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < parentCount; i++) {
+            sb.append("../");
+        }
+        return sb.toString();
     }
 
     private DocumentStatus findDocumentStatus(String docType, String uri, String sha1) {

--- a/src/main/java/org/jbake/app/Renderer.java
+++ b/src/main/java/org/jbake/app/Renderer.java
@@ -177,7 +177,7 @@ public class Renderer {
      */
     public void render(Map<String, Object> content) throws Exception {
         String docType = (String) content.get(Crawler.Attributes.TYPE);
-        String outputFilename = destination.getPath() + File.separatorChar + content.get(Attributes.URI);
+        String outputFilename = destination.getPath() + File.separatorChar + ((String)content.get(Attributes.URI)).replace("/",File.separator);
         if (outputFilename.lastIndexOf(".") > outputFilename.lastIndexOf(File.separatorChar)) {
             outputFilename = outputFilename.substring(0, outputFilename.lastIndexOf("."));
         }

--- a/src/main/java/org/jbake/util/PagingHelper.java
+++ b/src/main/java/org/jbake/util/PagingHelper.java
@@ -1,6 +1,7 @@
 package org.jbake.util;
 
-import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public class PagingHelper {
     long totalDocuments;
@@ -15,15 +16,15 @@ public class PagingHelper {
         return (int) Math.ceil((totalDocuments * 1.0) / (postsPerPage * 1.0));
     }
 
-    public String getNextFileName(int currentPageNumber, String fileName) {
+    public String getNextFileName(int currentPageNumber, String fileName) throws URISyntaxException {
         if (currentPageNumber < getNumberOfPages()) {
-            return (currentPageNumber + 1) + File.separator + fileName;
+            return new URI((currentPageNumber + 1) + "/" + fileName).toString();
         } else {
             return null;
         }
     }
 
-    public String getPreviousFileName(int currentPageNumber, String fileName) {
+    public String getPreviousFileName(int currentPageNumber, String fileName) throws URISyntaxException {
 
         if (isFirstPage(currentPageNumber)) {
             return null;
@@ -32,7 +33,7 @@ public class PagingHelper {
                 return fileName;
             }
             else {
-                return (currentPageNumber - 1) + File.separator + fileName;
+                return new URI((currentPageNumber - 1) + "/" + fileName ).toString();
             }
         }
     }
@@ -41,12 +42,12 @@ public class PagingHelper {
         return page == 1;
     }
 
-    public String getCurrentFileName(int page, String fileName) {
+    public String getCurrentFileName(int page, String fileName) throws URISyntaxException {
         if ( isFirstPage(page) ) {
             return fileName;
         }
         else {
-            return page + File.separator + fileName;
+            return new URI(page + "/" + fileName).toString();
         }
     }
 

--- a/src/smoke-test/java/org/jbake/BuiltInProjectsTest.java
+++ b/src/smoke-test/java/org/jbake/BuiltInProjectsTest.java
@@ -1,0 +1,99 @@
+package org.jbake;
+
+import org.apache.commons.vfs2.util.Os;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.*;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class BuiltInProjectsTest {
+
+    @Parameters(name = " {0} ")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "thymeleaf",  "thyme" },
+                { "freemarker", "ftl" },
+                { "jade",       "jade" },
+                { "groovy",     "gsp" },
+                { "groovy-mte", "tpl" }
+        });
+    }
+
+    @Parameter
+    public String projectName;
+
+    @Parameter(1)
+    public String extension;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    private File projectFolder;
+    private File templateFolder;
+    private File outputFolder;
+    private String jbakeExecutable;
+
+    @Before
+    public void setup() throws IOException {
+        if ( Os.isFamily(Os.OS_FAMILY_WINDOWS) ) {
+            jbakeExecutable = new File("build\\install\\jbake\\bin\\jbake.bat").getAbsolutePath();
+        }
+        else {
+            jbakeExecutable = new File("build/install/jbake/bin/jbake").getAbsolutePath();
+        }
+        projectFolder = folder.newFolder("project");
+        templateFolder = new File(projectFolder, "templates");
+        outputFolder = new File(projectFolder, "output");
+    }
+
+    @Test
+    public void should_bake_with_project() throws Exception {
+        shouldInitProject(projectName, extension);
+        shouldBakeProject();
+    }
+
+    private void shouldInitProject(String projectName, String extension) throws IOException, InterruptedException {
+        Process process = runWithArguments(jbakeExecutable,"-i", "-t", projectName);
+        assertThat(process.exitValue()).isEqualTo(0);
+        assertThat(new File(projectFolder,"jbake.properties")).exists();
+        assertThat(new File(templateFolder, String.format("index.%s", extension))).exists();
+    }
+
+    private void shouldBakeProject() throws IOException, InterruptedException {
+        Process process = runWithArguments(jbakeExecutable,"-b");
+        assertThat(process.exitValue()).isEqualTo(0);
+        assertThat(new File(outputFolder, "index.html")).exists();
+    }
+
+    private Process runWithArguments(String... arguments) throws IOException, InterruptedException {
+        ProcessBuilder processBuilder = new ProcessBuilder(arguments);
+        processBuilder.directory(projectFolder);
+        processBuilder.redirectErrorStream(true);
+
+        Process process = processBuilder.start();
+        process.waitFor();
+        printOutput(process.getInputStream());
+        return process;
+    }
+
+    private void printOutput(InputStream inputStream) throws IOException {
+
+        String line;
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+
+        while ((line = reader.readLine()) != null ) {
+            System.out.println(line);
+        }
+        reader.close();
+    }
+
+}

--- a/src/smoke-test/java/org/jbake/BuiltInProjectsTest.java
+++ b/src/smoke-test/java/org/jbake/BuiltInProjectsTest.java
@@ -66,12 +66,14 @@ public class BuiltInProjectsTest {
         assertThat(process.exitValue()).isEqualTo(0);
         assertThat(new File(projectFolder,"jbake.properties")).exists();
         assertThat(new File(templateFolder, String.format("index.%s", extension))).exists();
+        process.destroy();
     }
 
     private void shouldBakeProject() throws IOException, InterruptedException {
         Process process = runWithArguments(jbakeExecutable,"-b");
         assertThat(process.exitValue()).isEqualTo(0);
         assertThat(new File(outputFolder, "index.html")).exists();
+        process.destroy();
     }
 
     private Process runWithArguments(String... arguments) throws IOException, InterruptedException {
@@ -80,8 +82,9 @@ public class BuiltInProjectsTest {
         processBuilder.redirectErrorStream(true);
 
         Process process = processBuilder.start();
-        process.waitFor();
         printOutput(process.getInputStream());
+        process.waitFor();
+        
         return process;
     }
 

--- a/src/test/java/org/jbake/app/AssetTest.java
+++ b/src/test/java/org/jbake/app/AssetTest.java
@@ -7,6 +7,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
 
+import org.apache.commons.vfs2.util.Os;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.jbake.app.ConfigUtil.Keys;
@@ -62,13 +63,13 @@ public class AssetTest {
 
 	@Test
 	public void copyIgnore() throws Exception {
-		config.setProperty(Keys.ASSET_FOLDER, "ignorables");
+		File assetFolder = folder.newFolder("ignoredAssets");
+        FileUtils.copyDirectory(new File(this.getClass().getResource("/fixture/ignorables").getFile()), assetFolder);
+        config.setProperty(Keys.ASSET_FOLDER, "ignorables");
 		config.setProperty(Keys.ASSET_IGNORE_HIDDEN, "true");
-		URL assetsUrl = this.getClass().getResource("/fixture/ignorables");
-		File assets = new File(assetsUrl.getFile());
-		hideAssets(assets);
-		Asset asset = new Asset(assets.getParentFile(), folder.getRoot(), config);
-		asset.copy(assets);
+		hideAssets(assetFolder);
+		Asset asset = new Asset(assetFolder.getParentFile(), folder.getRoot(), config);
+		asset.copy(assetFolder);
 
 		File testFile = new File(folder.getRoot(), "test.txt");
 		Assert.assertTrue("File " + testFile.getAbsolutePath() + " does not exist", testFile.exists());
@@ -82,7 +83,7 @@ public class AssetTest {
 	 * Hides the assets on windows that start with a dot (e.g. .test.txt but not test.txt) so File.isHidden() returns true for those files.
 	 */
 	private void hideAssets(File assets) throws IOException, InterruptedException {
-		if (isWindows()) {
+        if ( Os.isFamily(Os.OS_FAMILY_WINDOWS) ) {
 			final File[] hiddenFiles = assets.listFiles(new FilenameFilter() {
 				@Override
 				public boolean accept(File dir, String name) {
@@ -128,8 +129,4 @@ public class AssetTest {
 		asset.copy(assets);
 	}
 
-	private boolean isWindows() {
-		final String os = System.getProperty("os.name");
-		return os != null && os.toLowerCase(Locale.ENGLISH).contains("win");
-	}
 }

--- a/src/test/java/org/jbake/launcher/MainTest.java
+++ b/src/test/java/org/jbake/launcher/MainTest.java
@@ -9,8 +9,8 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.io.File;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import static org.mockito.Mockito.verify;
@@ -47,66 +47,76 @@ public class MainTest {
     
     @Test
     public void launchBakeAndJettyWithCustomDirForJetty() {
-        String[] args = {"-b", "-s", "src/jbake"};
+        String path = "src" + File.separator + "jbake";
+        String[] args = {"-b", "-s", path};
         main.run(args);
 
-        verify(mockJetty).run("src/jbake","8820");
+        verify(mockJetty).run(path,"8820");
     }
 
     @Test
     public void launchJettyWithCustomSourceDir() {
-        String[] args = {"src/jbake", "-s"};
+        String path = "src" + File.separator + "jbake";
+        String[] args = {path, "-s"};
         main.run(args);
 
-        verify(mockJetty).run("src/jbake","8820");
+        verify(mockJetty).run(path,"8820");
     }
     
     @Test
     public void launchJettyWithCustomServerSourceDir() {
-        String[] args = {"-s", "build/jbake"};
+        String path = "build" + File.separator + "jbake";
+        String[] args = {"-s", path};
         main.run(args);
 
-        verify(mockJetty).run("build/jbake","8820");
+        verify(mockJetty).run(path,"8820");
     }
 
     // Documentation states these two commands will define the custom output, but the LaunchOptions file isn't setup for that.
     // I have written this test to define the existing functionality of the code and not that defined in docs.
     @Test
     public void launchJettyWithCustomDestinationDir() {
-        String[] args = {"-s", "build/jbake"};
+        String path = "build" + File.separator + "jbake";
+        String[] args = {"-s", path};
         main.run(args);
 
-        verify(mockJetty).run("build/jbake","8820");
+        verify(mockJetty).run(path,"8820");
     }
 
     @Test
     public void launchJettyWithCustomSrcAndDestDir() {
-        String[] args = {"jbake", "build/jbake", "-s"};
+        String path = "build" + File.separator + "jbake";
+        String[] args = {"jbake", path, "-s"};
         main.run(args);
 
-        verify(mockJetty).run("build/jbake","8820");
+        verify(mockJetty).run(path,"8820");
     }
 
     @Test
     public void launchJettyWithCustomDestViaConfig() throws CmdLineException {
+        final String path = "build" + File.separator + "jbake";
         String[] args = {"-s"};
         Map<String, String> properties = new HashMap<String, String>(){{
-            put("destination.folder", "build/jbake");
+            put("destination.folder", path);
         }};
         main.run(stubOptions(args), stubConfig(properties));
 
-        verify(mockJetty).run("build/jbake","8820");
+        verify(mockJetty).run(path,"8820");
     }
 
     @Test
     public void launchJettyWithCmdlineOverridingProperties() throws CmdLineException {
-        String[] args = {"src/jbake", "build/jbake", "-s"};
+        String buildPath = "build" + File.separator + "jbake";
+        String sourcePath = "src" + File.separator + "jbake";
+        final String targetPath = "target" + File.separator + "jbake";
+
+        String[] args = {sourcePath, buildPath, "-s"};
         Map<String,String> properties = new HashMap<String,String>(){{
-           put("destination.folder", "target/jbake");
+           put("destination.folder", targetPath);
         }};
         main.run(stubOptions(args), stubConfig(properties));
 
-        verify(mockJetty).run("build/jbake","8820");
+        verify(mockJetty).run(buildPath,"8820");
     }
 
     private LaunchOptions stubOptions(String[] args) throws CmdLineException {

--- a/src/test/java/org/jbake/render/RendererTest.java
+++ b/src/test/java/org/jbake/render/RendererTest.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.vfs2.util.Os;
 import org.jbake.app.ConfigUtil;
 import org.jbake.app.ContentStore;
 import org.jbake.app.Crawler;
@@ -13,6 +14,7 @@ import org.jbake.app.Renderer;
 import org.jbake.app.ConfigUtil.Keys;
 import org.jbake.template.DelegatingTemplateEngine;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -51,7 +53,14 @@ public class RendererTest {
 	 */
 	@Test
     public void testRenderFileWorksWhenPathHasDotInButFileDoesNot() throws Exception {
-		final String FOLDER = "real.path";
+		String FOLDER;
+		if (Os.isFamily(Os.OS_FAMILY_WINDOWS)) {
+			FOLDER = "real\\.path";
+		}
+		else {
+			FOLDER = "real.path";
+		}
+
 		final String FILENAME = "about";
 		config.setProperty(Keys.OUTPUT_EXTENSION, "");
 		Renderer renderer = new Renderer(db, outputPath, folder.newFolder("templates"), config, renderingEngine);

--- a/src/test/java/org/jbake/render/RendererTest.java
+++ b/src/test/java/org/jbake/render/RendererTest.java
@@ -53,14 +53,7 @@ public class RendererTest {
 	 */
 	@Test
     public void testRenderFileWorksWhenPathHasDotInButFileDoesNot() throws Exception {
-		String FOLDER;
-		if (Os.isFamily(Os.OS_FAMILY_WINDOWS)) {
-			//skip it
-			return;
-		}
-		else {
-			FOLDER = "real.path";
-		}
+		String FOLDER = "real.path";
 
 		final String FILENAME = "about";
 		config.setProperty(Keys.OUTPUT_EXTENSION, "");

--- a/src/test/java/org/jbake/render/RendererTest.java
+++ b/src/test/java/org/jbake/render/RendererTest.java
@@ -55,7 +55,8 @@ public class RendererTest {
     public void testRenderFileWorksWhenPathHasDotInButFileDoesNot() throws Exception {
 		String FOLDER;
 		if (Os.isFamily(Os.OS_FAMILY_WINDOWS)) {
-			FOLDER = "real\\.path";
+			//skip it
+			return;
 		}
 		else {
 			FOLDER = "real.path";

--- a/src/test/java/org/jbake/util/PagingHelperTest.java
+++ b/src/test/java/org/jbake/util/PagingHelperTest.java
@@ -6,9 +6,6 @@ import org.junit.Test;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
-/**
- * Created by frank on 28.10.16.
- */
 public class PagingHelperTest {
     @Test
     public void getNumberOfPages() throws Exception {
@@ -27,7 +24,7 @@ public class PagingHelperTest {
 
         String previousFileName = helper.getPreviousFileName(2, "index.html");
 
-        Assert.assertThat("index.html", is( previousFileName) );
+        Assert.assertThat(previousFileName, is("index.html") );
     }
 
     @Test
@@ -37,7 +34,7 @@ public class PagingHelperTest {
 
         String previousFileName = helper.getPreviousFileName(3, "index.html");
 
-        Assert.assertThat("2/index.html", is( previousFileName) );
+        Assert.assertThat(previousFileName, is("2/index.html" ) );
 
     }
 
@@ -66,7 +63,7 @@ public class PagingHelperTest {
 
         String nextFileName = helper.getNextFileName(2, "index.html");
 
-        Assert.assertThat("3/index.html", is( nextFileName) );
+        Assert.assertThat(nextFileName, is("3/index.html" ) );
 
     }
 }


### PR DESCRIPTION
This PR configures jbake to run CI tests on [appveyor](url), running two jobs for jdk 7 and 8.
I had to tweak the code a bit to get the tests pass. But it works.

The smoke tests are running fine executing the jbake binary with all built in example projects.
Have a look at the built results https://ci.appveyor.com/project/ancho/jbake

I added a [badge](https://github.com/jbake-org/jbake/compare/master...ancho:feature/appveyor-integration?expand=1#diff-d03d78a73f737f7943dde0f33e6e2b24R11) to the README. Don't forget to change the project URL.