### PR TITLE
pickup jars in distribution lib directory and add asciidoctorj-diagram as a distribution dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'com.github.ben-manes.versions'  version '0.14.0'
 }
 
+
 if( JavaVersion.current().java7Compatible ) {
     apply plugin: 'com.github.kt3k.coveralls'
     apply plugin: 'com.jfrog.bintray'
@@ -27,7 +28,8 @@ repositories {
 }
 
 ext {
-    asciidoctorjVersion = '1.5.4.1'
+    asciidoctorjVersion = '1.5.5'
+    asciidoctorjDiagramVersion = '1.5.4'
     commonsIoVersion = '2.5'
     commonsConfigurationVersion = '1.10'
     commonsLangVersion = '3.4'
@@ -46,6 +48,12 @@ ext {
     jsonSimpleVersion = '1.1.1'
     jade4jVersion = '1.2.5'
     mockitoVersion = '1.10.19'
+}
+
+configurations {
+    dist
+
+    runtime.extendsFrom dist
 }
 
 dependencies {
@@ -68,6 +76,9 @@ dependencies {
     compile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
     compile group: 'ch.qos.logback', name: 'logback-core', version: logbackVersion
     compile group: 'de.neuland-bfi', name: 'jade4j', version: jade4jVersion
+
+    dist group: 'org.asciidoctor', name: 'asciidoctorj-diagram', version: asciidoctorjDiagramVersion
+
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.assertj', name: 'assertj-core', version: assertjCoreVersion
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion

--- a/gradle/application.gradle
+++ b/gradle/application.gradle
@@ -37,30 +37,31 @@ processResources {
 }
 
 
-task cloneProjectExampleRepositories() {
-    group = "distribution"
-    description "Clone jbake example project repositories"
-
-    outputs.dir examplesBase
-
-    doLast {
-        exampleRepositories.each { name, repository ->
-            Grgit.clone(dir: "$examplesBase/$name", uri: repository)
-        }
-    }
-}
 
 //create Zip Task for each repository
 exampleRepositories.each { name, repository ->
 
-    task "${name}Zip"(type: Zip, dependsOn: cloneProjectExampleRepositories) {
+    task "clone_${name}Repository"() {
+        group = "distribution"
+        description "Clone jbake ${name} example project repositories"
+
+        def repositoryName = "$examplesBase/$name"
+
+        outputs.dir repositoryName
+
+        doLast {
+            Grgit.clone(dir: repositoryName, uri: repository)
+        }
+    }
+
+    task "${name}Zip"(type: Zip) {
         group "distribution"
         description "Zip $name repository"
 
         baseName = name
         archiveName = "${baseName}.zip"
 
-        from "$examplesBase/$baseName"
+        from project.tasks.getByName("clone_${name}Repository").outputs
         exclude 'README.md'
         exclude 'LICENSE'
         exclude '.git'
@@ -82,7 +83,20 @@ distributions {
 
 startScripts {
     defaultJvmOpts = ['-XX:MaxDirectMemorySize=512m']
-    classpath += files('lib/logging')
+    classpath = files("lib","logging")
+
+    /**
+     * The startScripts produces scripts that contain `$APP_HOME/lib/lib` in the classpath
+     * so we need to tweak it a bit to be able to add the whole lib directory to the classpath :|
+     *
+     * See https://stackoverflow.com/questions/10518603/adding-classpath-entries-using-gradles-application-plugin
+     */
+    doLast {
+        def windowsScriptFile = file getWindowsScript()
+        def unixScriptFile = file getUnixScript()
+        windowsScriptFile.text = windowsScriptFile.text.replace('%APP_HOME%\\lib\\lib', '%APP_HOME%\\lib\\*')
+        unixScriptFile.text = unixScriptFile.text.replace('$APP_HOME/lib/lib', '$APP_HOME/lib/*')
+    }
 }
 
 distZip {

--- a/gradle/application.gradle
+++ b/gradle/application.gradle
@@ -38,12 +38,12 @@ processResources {
 
 
 
-//create Zip Task for each repository
+//create clone and Zip Task for each repository
 exampleRepositories.each { name, repository ->
 
     task "clone_${name}Repository"() {
         group = "distribution"
-        description "Clone jbake ${name} example project repositories"
+        description "Clone jbake ${name} example project repository"
 
         def repositoryName = "$examplesBase/$name"
 


### PR DESCRIPTION
* adds lib/* to the application classpath ( #230 )
* bumped asciidoctorj to 1.5.5
* added asciidoctorj-diagram 1.5.4 as distribution dependency

While I was working on including the lib directory, I was curious how to add library dependencies to the distribution only. So I added a new configuration called `dist` with asciidoctorj-diagram as an experiment.

That way people do not need to download the library manually but it isn't a dependency of jbake-core.

Addresses a part of #381. Not native but with asciidoctor.
