### PR TITLE
Fix rootpath when noExtensionUri is true

### DIFF
--- a/src/main/java/org/jbake/app/Crawler.java
+++ b/src/main/java/org/jbake/app/Crawler.java
@@ -192,7 +192,7 @@ public class Crawler {
     public String getPathToRoot(File sourceFile) {
     	File rootPath = new File(contentPath);
     	File parentPath = sourceFile.getParentFile();
-    	int parentCount = 0;
+    	int parentCount = config.getBoolean(Keys.URI_NO_EXTENSION) ? 1 : 0;
     	while (!parentPath.equals(rootPath)) {
     		parentPath = parentPath.getParentFile();
     		parentCount++;


### PR DESCRIPTION
The rootpath is not being set correctly when noExtensionUri is true.