### PR TITLE
Fixes #389

### DIFF
--- a/src/main/java/org/jbake/app/ContentStore.java
+++ b/src/main/java/org/jbake/app/ContentStore.java
@@ -134,13 +134,16 @@ public class ContentStore {
 
     public DocumentList getDocumentStatus(String docType, String uri) {
         return query("select sha1,rendered from " + docType + " where sourceuri=?", uri);
-
     }
 
     public DocumentList getPublishedPosts() {
         return getPublishedContent("post");
     }
-
+    
+    public DocumentList getPublishedPosts(boolean applyPaging) {
+        return getPublishedContent("post", applyPaging);
+    }
+    
     public DocumentList getPublishedPostsByTag(String tag) {
         return query("select * from post where status='published' and ? in tags order by date desc", tag);
     }
@@ -159,17 +162,29 @@ public class ContentStore {
     }
 
     public DocumentList getPublishedContent(String docType) {
+        return getPublishedContent(docType, false);
+    }
+    
+    public DocumentList getPublishedContent(String docType, boolean applyPaging) {
         String query = "select * from " + docType + " where status='published' order by date desc";
-        if ((start >= 0) && (limit > -1)) {
-            query += " SKIP " + start + " LIMIT " + limit;
+        if (applyPaging) {
+	        if ((start >= 0) && (limit > -1)) {
+	            query += " SKIP " + start + " LIMIT " + limit;
+	        }
         }
         return query(query);
     }
 
     public DocumentList getAllContent(String docType) {
+        return getAllContent(docType, false);
+    }
+    
+    public DocumentList getAllContent(String docType, boolean applyPaging) {
         String query = "select * from " + docType + " order by date desc";
-        if ((start >= 0) && (limit > -1)) {
-            query += " SKIP " + start + " LIMIT " + limit;
+        if (applyPaging) {
+	        if ((start >= 0) && (limit > -1)) {
+	            query += " SKIP " + start + " LIMIT " + limit;
+	        }
         }
         return query(query);
     }

--- a/src/main/java/org/jbake/template/model/PublishedPostsExtractor.java
+++ b/src/main/java/org/jbake/template/model/PublishedPostsExtractor.java
@@ -10,8 +10,11 @@ public class PublishedPostsExtractor implements ModelExtractor<DocumentList> {
 
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
-
-        return db.getPublishedPosts();
+    		if (model.containsKey("numberOfPages")) {
+    			return db.getPublishedPosts(true);
+    		} else {
+    			return db.getPublishedPosts();
+    		}
     }
 
 }

--- a/src/test/java/org/jbake/app/PaginationTest.java
+++ b/src/test/java/org/jbake/app/PaginationTest.java
@@ -90,7 +90,7 @@ public class PaginationTest {
 
         while (start < TOTAL_POSTS) {
             db.setStart(start);
-            DocumentList posts = db.getAllContent("post");
+            DocumentList posts = db.getPublishedPosts(true);
 
             assertThat( posts.size() ).isLessThanOrEqualTo( 2 );
 


### PR DESCRIPTION
Added additional methods to allow control over when the paging filter is applied. Removed paging on all_content as I believe it was a mistake being added to this as paging is currently based around 'post' type only. Kept the rest of the method signatures the same though.