### PR TITLE
Fix travis jdk9 build -  java.lang.OutOfMemoryError: Direct buffer memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
         dist: precise
       - os: osx
 
+before_install:
+  - unset _JAVA_OPTIONS
+
 install: true
 
 script:

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ subprojects {
     }
 
     test {
-        jvmArgs '-XX:MaxPermSize=2048m', '-XX:MaxDirectMemorySize=512m', '-Dorientdb.installCustomFormatter=false=false'
+        jvmArgs '-Xmx3g', '-Xms512m', '-XX:MaxPermSize=2g', '-XX:MaxDirectMemorySize=2g', '-Dorientdb.installCustomFormatter=false=false'
     }
 
     jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     junit4Version = '4.12'
     flexmarkVersion = '0.28.38'
     jettyServerVersion = '9.2.24.v20180105'
-    orientDbVersion = '2.2.30'
+    orientDbVersion = '2.2.33'
     groovyVersion = '2.4.13'
     slf4jVersion = '1.7.25'
     logbackVersion = '1.2.3'

--- a/jbake-core/src/main/java/org/jbake/app/ContentStore.java
+++ b/jbake-core/src/main/java/org/jbake/app/ContentStore.java
@@ -105,7 +105,7 @@ public class ContentStore {
     }
 
     public void close() {
-        db.activateOnCurrentThread();
+        activateOnCurrentThread();
         db.close();
         DBUtil.closeDataStore();
     }
@@ -129,7 +129,7 @@ public class ContentStore {
     }
 
     public void drop() {
-        db.activateOnCurrentThread();
+        activateOnCurrentThread();
         db.drop();
     }
 
@@ -181,10 +181,8 @@ public class ContentStore {
 
     public DocumentList getPublishedContent(String docType, boolean applyPaging) {
         String query = "select * from " + docType + " where status='published' order by date desc";
-        if (applyPaging) {
-            if ((start >= 0) && (limit > -1)) {
-                query += " SKIP " + start + " LIMIT " + limit;
-            }
+        if (applyPaging && hasStartAndLimitBoundary()) {
+            query += " SKIP " + start + " LIMIT " + limit;
         }
         return query(query);
     }
@@ -195,12 +193,14 @@ public class ContentStore {
 
     public DocumentList getAllContent(String docType, boolean applyPaging) {
         String query = "select * from " + docType + " order by date desc";
-        if (applyPaging) {
-            if ((start >= 0) && (limit > -1)) {
-                query += " SKIP " + start + " LIMIT " + limit;
-            }
+        if (applyPaging && hasStartAndLimitBoundary()) {
+            query += " SKIP " + start + " LIMIT " + limit;
         }
         return query(query);
+    }
+
+    private boolean hasStartAndLimitBoundary() {
+        return (start >= 0) && (limit > -1);
     }
 
     public DocumentList getAllTagsFromPublishedPosts() {

--- a/jbake-core/src/test/java/org/jbake/app/ContentStoreIntegrationTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/ContentStoreIntegrationTest.java
@@ -1,0 +1,32 @@
+package org.jbake.app;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+public abstract class ContentStoreIntegrationTest {
+
+    protected static ContentStore db;
+
+    @BeforeClass
+    public static void setUpClass() {
+        db = DBUtil.createDataStore("memory", "documents" + System.currentTimeMillis());
+    }
+
+    @AfterClass
+    public static void cleanUpClass() {
+        db.close();
+        db.shutdown();
+    }
+
+    @Before
+    public void setUp() {
+        db.updateSchema();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        db.drop();
+    }
+}

--- a/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
@@ -2,25 +2,36 @@ package org.jbake.app;
 
 import org.jbake.FakeDocumentBuilder;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class ContentStoreTest {
 
-    private ContentStore db;
+    private static ContentStore db;
+
+    @BeforeClass
+    public static void setUpClass() {
+        db = DBUtil.createDataStore("memory", "documents" + System.currentTimeMillis());
+    }
+
+    @AfterClass
+    public static void cleanUpClass() {
+        db.close();
+        db.shutdown();
+    }
 
     @Before
-    public void setUp() throws Exception {
-        db = DBUtil.createDataStore("memory", "documents" + System.currentTimeMillis());
+    public void setUp() {
+        db.updateSchema();
     }
 
     @After
     public void tearDown() throws Exception {
         db.drop();
-        db.close();
-        db.shutdown();
     }
 
     @Test
@@ -40,8 +51,8 @@ public class ContentStoreTest {
                 .withRandomSha1()
                 .build();
 
-        assertEquals( 6, db.getDocumentCount("post"));
-        assertEquals( 5, db.getPublishedCount("post"));
+        assertEquals(6, db.getDocumentCount("post"));
+        assertEquals(5, db.getPublishedCount("post"));
     }
 
 }

--- a/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
@@ -1,38 +1,11 @@
 package org.jbake.app;
 
 import org.jbake.FakeDocumentBuilder;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class ContentStoreTest {
-
-    private static ContentStore db;
-
-    @BeforeClass
-    public static void setUpClass() {
-        db = DBUtil.createDataStore("memory", "documents" + System.currentTimeMillis());
-    }
-
-    @AfterClass
-    public static void cleanUpClass() {
-        db.close();
-        db.shutdown();
-    }
-
-    @Before
-    public void setUp() {
-        db.updateSchema();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        db.drop();
-    }
+public class ContentStoreTest extends ContentStoreIntegrationTest {
 
     @Test
     public void shouldGetCountForPublishedDocuments() throws Exception {

--- a/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
@@ -1,17 +1,13 @@
 package org.jbake.app;
 
 import org.apache.commons.configuration.CompositeConfiguration;
-import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.io.FilenameUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.jbake.app.ConfigUtil.Keys;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -21,21 +17,10 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CrawlerTest {
-    private static ContentStore db;
+public class CrawlerTest extends ContentStoreIntegrationTest {
     private CompositeConfiguration config;
     private File sourceFolder;
 
-    @BeforeClass
-    public static void setUpClass() {
-        db = DBUtil.createDataStore("memory", "documents" + System.currentTimeMillis());
-    }
-
-    @AfterClass
-    public static void cleanUpClass() {
-        db.close();
-        db.shutdown();
-    }
 
     @Before
     public void setup() throws Exception {
@@ -46,19 +31,12 @@ public class CrawlerTest {
             throw new Exception("Cannot find sample data structure!");
         }
 
-        db.updateSchema();
-
         config = ConfigUtil.load(sourceFolder);
         Assert.assertEquals(".html", config.getString(Keys.OUTPUT_EXTENSION));
     }
 
-    @After
-    public void cleanup() {
-        db.drop();
-    }
-
     @Test
-    public void crawl() throws ConfigurationException {
+    public void crawl() {
         Crawler crawler = new Crawler(db, sourceFolder, config);
         crawler.crawl(new File(sourceFolder.getPath() + File.separator + config.getString(Keys.CONTENT_FOLDER)));
 
@@ -92,7 +70,7 @@ public class CrawlerTest {
 
     @Test
     public void renderWithPrettyUrls() throws Exception {
-        Map<String, Object> testProperties = new HashMap<String, Object>();
+        Map<String, Object> testProperties = new HashMap<>();
         testProperties.put(Keys.URI_NO_EXTENSION, true);
         testProperties.put(Keys.URI_NO_EXTENSION_PREFIX, "/blog");
 

--- a/jbake-core/src/test/java/org/jbake/app/OvenTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/OvenTest.java
@@ -2,7 +2,6 @@ package org.jbake.app;
 
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
 import org.jbake.app.ConfigUtil.Keys;
 import org.jbake.model.DocumentTypes;
 import org.junit.Before;
@@ -11,7 +10,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,25 +20,25 @@ public class OvenTest {
     public TemporaryFolder folder = new TemporaryFolder();
     private CompositeConfiguration config;
     private File rootPath;
-	private File outputPath;
+    private File outputPath;
 
     @Before
     public void setup() throws Exception {
-    	// reset values to known state otherwise previous test case runs can affect the success of this test case
-    	DocumentTypes.resetDocumentTypes();
-		
-    	URL sourceUrl = this.getClass().getResource("/fixture");
-		rootPath = new File(sourceUrl.getFile());
+        // reset values to known state otherwise previous test case runs can affect the success of this test case
+        DocumentTypes.resetDocumentTypes();
+
+        URL sourceUrl = this.getClass().getResource("/fixture");
+        rootPath = new File(sourceUrl.getFile());
         if (!rootPath.exists()) {
             throw new Exception("Cannot find base path for test!");
         }
         outputPath = folder.newFolder("destination");
-		config = ConfigUtil.load(rootPath);
-		config.setProperty(Keys.TEMPLATE_FOLDER, "freemarkerTemplates");
-	}
+        config = ConfigUtil.load(rootPath);
+        config.setProperty(Keys.TEMPLATE_FOLDER, "freemarkerTemplates");
+    }
 
     @Test
-    public void bakeWithRelativePaths() throws IOException, ConfigurationException {
+    public void bakeWithRelativePaths() {
         Oven oven = new Oven(rootPath, outputPath, config, true);
         oven.setupPaths();
         oven.bake();
@@ -49,7 +47,7 @@ public class OvenTest {
     }
 
     @Test
-    public void bakeWithAbsolutePaths() throws IOException, ConfigurationException {
+    public void bakeWithAbsolutePaths() {
         makeAbsolute(config, rootPath, Keys.TEMPLATE_FOLDER);
         makeAbsolute(config, rootPath, Keys.CONTENT_FOLDER);
         makeAbsolute(config, rootPath, Keys.ASSET_FOLDER);

--- a/jbake-core/src/test/java/org/jbake/app/OvenTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/OvenTest.java
@@ -1,11 +1,5 @@
 package org.jbake.app;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
@@ -15,6 +9,12 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class OvenTest {
 
@@ -41,7 +41,7 @@ public class OvenTest {
 
     @Test
     public void bakeWithRelativePaths() throws IOException, ConfigurationException {
-        final Oven oven = new Oven(rootPath, outputPath, config, true);
+        Oven oven = new Oven(rootPath, outputPath, config, true);
         oven.setupPaths();
         oven.bake();
 
@@ -54,7 +54,7 @@ public class OvenTest {
         makeAbsolute(config, rootPath, Keys.CONTENT_FOLDER);
         makeAbsolute(config, rootPath, Keys.ASSET_FOLDER);
 
-        final Oven oven = new Oven(rootPath, outputPath, config, true);
+        Oven oven = new Oven(rootPath, outputPath, config, true);
         oven.setupPaths();
         oven.bake();
 

--- a/jbake-core/src/test/java/org/jbake/app/PaginationTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/PaginationTest.java
@@ -25,11 +25,8 @@ package org.jbake.app;
 
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.FakeDocumentBuilder;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -43,20 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author jdlee
  */
-public class PaginationTest {
+public class PaginationTest extends ContentStoreIntegrationTest {
 
-    private static ContentStore db;
-
-    @BeforeClass
-    public static void setUpClass() {
-        db = DBUtil.createDataStore("memory", "documents" + System.currentTimeMillis());
-    }
-
-    @AfterClass
-    public static void cleanUpClass() {
-        db.close();
-        db.shutdown();
-    }
 
     @Before
     public void setup() throws Exception {
@@ -71,13 +56,6 @@ public class PaginationTest {
         }
         config.setProperty(ConfigUtil.Keys.PAGINATE_INDEX, true);
         config.setProperty(ConfigUtil.Keys.POSTS_PER_PAGE, 1);
-
-        db.updateSchema();
-    }
-
-    @After
-    public void cleanup() {
-        db.drop();
     }
 
     @Test

--- a/jbake-core/src/test/java/org/jbake/app/template/AbstractTemplateEngineRenderingTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/template/AbstractTemplateEngineRenderingTest.java
@@ -26,7 +26,7 @@ package org.jbake.app.template;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.jbake.app.ConfigUtil;
-import org.jbake.app.ContentStore;
+import org.jbake.app.ContentStoreIntegrationTest;
 import org.jbake.app.Crawler;
 import org.jbake.app.DBUtil;
 import org.jbake.app.Parser;
@@ -35,10 +35,8 @@ import org.jbake.model.DocumentTypes;
 import org.jbake.template.ModelExtractors;
 import org.jbake.template.ModelExtractorsDocumentTypeListener;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -58,9 +56,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author jdlee
  */
-public abstract class AbstractTemplateEngineRenderingTest {
+public abstract class AbstractTemplateEngineRenderingTest extends ContentStoreIntegrationTest {
 
-    protected static ContentStore db;
     protected final String templateDir;
     protected final String templateExtension;
     protected final Map<String, List<String>> outputStrings = new HashMap<>();
@@ -77,17 +74,6 @@ public abstract class AbstractTemplateEngineRenderingTest {
     public AbstractTemplateEngineRenderingTest(String templateDir, String templateExtension) {
         this.templateDir = templateDir;
         this.templateExtension = templateExtension;
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-        db = DBUtil.createDataStore("memory", "documents" + System.currentTimeMillis());
-    }
-
-    @AfterClass
-    public static void cleanUpClass() {
-        db.close();
-        db.shutdown();
     }
 
     @Before
@@ -122,8 +108,6 @@ public abstract class AbstractTemplateEngineRenderingTest {
             }
         }
         Assert.assertEquals(".html", config.getString(ConfigUtil.Keys.OUTPUT_EXTENSION));
-
-        db.updateSchema();
 
         Crawler crawler = new Crawler(db, sourceFolder, config);
         crawler.crawl(new File(sourceFolder.getPath() + File.separator + "content"));
@@ -173,8 +157,7 @@ public abstract class AbstractTemplateEngineRenderingTest {
     }
 
     @After
-    public void cleanup() throws InterruptedException {
-        db.drop();
+    public void cleanup() {
         DocumentTypes.resetDocumentTypes();
         ModelExtractors.getInstance().reset();
         Locale.setDefault(currentLocale);


### PR DESCRIPTION
A jdk9 travis build failed with an OutOfMemoryError.
https://travis-ci.org/jbake-org/jbake/jobs/352334663#L1403

Rearanged test setup to start only one orientdb per test class.
Adjusted Heapspace and MaxDirectMemorySize to fit travis environment.
Updated orientdb to 2.2.33 which include some fixes related to memory estimation in container environments. https://github.com/orientechnologies/orientdb/issues/7812