### PR TITLE
reduce distribution size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 // common variables
 ext {
     asciidoctorjVersion = '1.5.6'
-    asciidoctorjDiagramVersion = '1.5.4.1'
+    asciidoctorjDiagramVersion = '1.5.8'
     commonsIoVersion = '2.6'
     commonsConfigurationVersion = '1.10'
     commonsLangVersion = '3.7'
@@ -18,18 +18,18 @@ ext {
     args4jVersion = '2.33'
     freemarkerVersion = '2.3.27-incubating'
     junit4Version = '4.12'
-    flexmarkVersion = '0.28.38'
+    flexmarkVersion = '0.32.18'
     jettyServerVersion = '9.2.24.v20180105'
     orientDbVersion = '2.2.33'
-    groovyVersion = '2.4.13'
+    groovyVersion = '2.4.14'
     slf4jVersion = '1.7.25'
     logbackVersion = '1.2.3'
     assertjCoreVersion = '2.9.0'
     thymeleafVersion = '3.0.9.RELEASE'
     jsonSimpleVersion = '1.1.1'
     jade4jVersion = '1.2.7'
-    mockitoVersion = '2.13.0'
-    jsoupVersion = '1.10.3'
+    mockitoVersion = '2.16.0'
+    jsoupVersion = '1.11.2'
 }
 
 /**

--- a/jbake-core/build.gradle
+++ b/jbake-core/build.gradle
@@ -7,14 +7,18 @@ dependencies {
     compile "commons-configuration:commons-configuration:$commonsConfigurationVersion"
     compile "org.apache.commons:commons-vfs2:$commonsVfs2Version"
     compile "org.apache.commons:commons-lang3:$commonsLangVersion"
-    compile "com.googlecode.json-simple:json-simple:$jsonSimpleVersion"
-    compile "com.orientechnologies:orientdb-graphdb:$orientDbVersion"
+    compile("com.googlecode.json-simple:json-simple:$jsonSimpleVersion") {
+        exclude group: "junit", module: "junit"
+    }
+    compile "com.orientechnologies:orientdb-core:$orientDbVersion"
     compile "org.asciidoctor:asciidoctorj:$asciidoctorjVersion"
     compile "org.codehaus.groovy:groovy-templates:$groovyVersion"
     compile "org.freemarker:freemarker:$freemarkerVersion"
     compile "org.thymeleaf:thymeleaf:$thymeleafVersion"
     compile "de.neuland-bfi:jade4j:$jade4jVersion"
-    compile "com.vladsch.flexmark:flexmark-all:$flexmarkVersion"
+    compile "com.vladsch.flexmark:flexmark:$flexmarkVersion"
+    compile "com.vladsch.flexmark:flexmark-profile-pegdown:$flexmarkVersion"
+    compile "org.jsoup:jsoup:$jsoupVersion"
 
     // cli specific dependencies
     compile "org.eclipse.jetty:jetty-server:$jettyServerVersion"

--- a/jbake-core/src/test/java/org/jbake/FakeDocumentBuilder.java
+++ b/jbake-core/src/test/java/org/jbake/FakeDocumentBuilder.java
@@ -4,7 +4,7 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import org.jbake.app.Crawler;
 import org.jbake.model.DocumentAttributes;
 
-import javax.xml.bind.DatatypeConverter;
+import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
@@ -88,7 +88,7 @@ public class FakeDocumentBuilder {
         byte[] content = new byte[size];
 
         random.nextBytes(content);
-        return DatatypeConverter.printHexBinary(sha1Digest.digest(content));
+        return new BigInteger(sha1Digest.digest(content)).toString(16);
     }
 
     private boolean hasDate() {


### PR DESCRIPTION
As noted in #437 the size of the distribution package increased.
Modified dependencies of jbake-core to get it smaller.

* replaced orientdb-graphdb with orientdb-core
  we don't use the graphs and do not need the server jar
* replaced flexmark-all with core and pegdown profile
  we don't need converters and stuff like that
* excluded transitive junit dependency
  make no sense at runtime
* updated
  * asciidoctorj-diagram 1.5.4.1 -> 1.5.6
  * flexmark 0.28.38 -> 0.32.18
  * groovy 2.4.13 -> 2.4.14
  * jsoup 1.10.3 -> 1.11.2
  * mockito 2.13.0 -> 2.16.0