### PR TITLE
Fix #365 issue: add default 404 file generation

### DIFF
--- a/jbake-core/src/main/java/org/jbake/app/ConfigUtil.java
+++ b/jbake-core/src/main/java/org/jbake/app/ConfigUtil.java
@@ -102,6 +102,10 @@ public class ConfigUtil {
 		 */
 		String INDEX_FILE = "index.file";
 		/**
+		 * Output filename for error 404 file, is only used when {@link #RENDER_ERROR404} is true
+		 */
+		String ERROR404_FILE = "error404.file";
+		/**
 		 * File extension to be used for all output files
 		 */
 		String OUTPUT_EXTENSION = "output.extension";
@@ -133,6 +137,10 @@ public class ConfigUtil {
 		 * Flag indicating if tag index file should be generated
 		 */
 		String RENDER_TAGS_INDEX = "render.tagsindex";
+		/**
+		 * Flag indicating if error 404 file should be generated
+		 */
+		String RENDER_ERROR404= "render.error404";
         /**
          * String used to separate the header from the body.
          */

--- a/jbake-core/src/main/java/org/jbake/app/Renderer.java
+++ b/jbake-core/src/main/java/org/jbake/app/Renderer.java
@@ -325,6 +325,16 @@ public class Renderer {
     }
 
     /**
+     * Render an 404 file using the predefined template.
+     *
+     * @param errorFile      The name of the output file
+     * @throws Exception    if default rendering configuration is not loaded correctly
+     */
+    public void renderError404(String errorFile) throws Exception {
+        render(new DefaultRenderingConfig(errorFile, "error404"));
+    }
+
+    /**
      * Render tag files using the supplied content.
      *
      * @param tagPath The output path

--- a/jbake-core/src/main/java/org/jbake/render/Error404Renderer.java
+++ b/jbake-core/src/main/java/org/jbake/render/Error404Renderer.java
@@ -1,0 +1,27 @@
+package org.jbake.render;
+
+import java.io.File;
+
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.jbake.app.ConfigUtil.Keys;
+import org.jbake.app.ContentStore;
+import org.jbake.app.Renderer;
+import org.jbake.template.RenderingException;
+
+
+public class Error404Renderer implements RenderingTool {
+
+    @Override
+    public int render(Renderer renderer, ContentStore db, File destination, File templatesPath, CompositeConfiguration config) throws RenderingException {
+        if (config.getBoolean(Keys.RENDER_ERROR404)) {
+            try {
+                renderer.renderError404(config.getString(Keys.ERROR404_FILE));
+                return 1;
+            } catch (Exception e) {
+                throw new RenderingException(e);
+            }
+        } else {
+            return 0;
+        }
+    }
+}

--- a/jbake-core/src/main/resources/META-INF/services/org.jbake.render.RenderingTool
+++ b/jbake-core/src/main/resources/META-INF/services/org.jbake.render.RenderingTool
@@ -4,3 +4,4 @@ org.jbake.render.FeedRenderer
 org.jbake.render.IndexRenderer
 org.jbake.render.SitemapRenderer
 org.jbake.render.TagsRenderer
+org.jbake.render.Error404Renderer

--- a/jbake-core/src/main/resources/default.properties
+++ b/jbake-core/src/main/resources/default.properties
@@ -35,7 +35,7 @@ index.file=index.html
 # render feed file?
 render.feed=true
 #render 404 page?
-render.error404=true
+render.error404=false
 # character encoding MIME name used for rendering.
 # use one of http://www.iana.org/assignments/character-sets/character-sets.xhtml
 render.encoding=UTF-8

--- a/jbake-core/src/main/resources/default.properties
+++ b/jbake-core/src/main/resources/default.properties
@@ -10,6 +10,8 @@ template.folder=templates
 template.masterindex.file=index.ftl
 # filename of feed template file
 template.feed.file=feed.ftl
+# filename of 404 error template file
+template.error404.file=error404.ftl
 # filename of archive template file
 template.archive.file=archive.ftl
 # filename of tag template file
@@ -32,6 +34,8 @@ render.index=true
 index.file=index.html
 # render feed file?
 render.feed=true
+#render 404 page?
+render.error404=true
 # character encoding MIME name used for rendering.
 # use one of http://www.iana.org/assignments/character-sets/character-sets.xhtml
 render.encoding=UTF-8
@@ -40,6 +44,8 @@ render.encoding=UTF-8
 template.encoding=UTF-8
 # filename to use for feed
 feed.file=feed.xml
+# filename to use for 404 error
+error404.file=404.html
 # render archive file?
 render.archive=true
 # filename to use for archive file

--- a/jbake-core/src/test/java/org/jbake/render/Error404RendererTest.java
+++ b/jbake-core/src/test/java/org/jbake/render/Error404RendererTest.java
@@ -1,0 +1,90 @@
+package org.jbake.render;
+
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.jbake.app.ContentStore;
+import org.jbake.app.Renderer;
+import org.jbake.render.support.MockCompositeConfiguration;
+import org.jbake.template.RenderingException;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+
+public class Error404RendererTest {
+    @Test
+    public void returnsZeroWhenConfigDoesNotRenderError404() throws RenderingException {
+        Error404Renderer renderer = new Error404Renderer();
+
+        CompositeConfiguration compositeConfiguration = new MockCompositeConfiguration().withDefaultBoolean(false);
+        ContentStore contentStore = mock(ContentStore.class);
+
+        Renderer mockRenderer = mock(Renderer.class);
+        int renderResponse = renderer.render(mockRenderer, contentStore,
+                new File("fake"), new File("fake"), compositeConfiguration);
+
+        assertThat(renderResponse).isEqualTo(0);
+    }
+
+    @Test
+    public void doesNotRenderWhenConfigDoesNotRenderError404() throws Exception {
+        Error404Renderer renderer = new Error404Renderer();
+
+        CompositeConfiguration compositeConfiguration = new MockCompositeConfiguration().withDefaultBoolean(false);
+        ContentStore contentStore = mock(ContentStore.class);
+        Renderer mockRenderer = mock(Renderer.class);
+
+        int renderResponse = renderer.render(mockRenderer, contentStore,
+                new File("fake"), new File("fake"), compositeConfiguration);
+
+        verify(mockRenderer, never()).renderError404(anyString());
+    }
+
+    @Test
+    public void returnsOneWhenConfigRendersError404() throws RenderingException {
+        Error404Renderer renderer = new Error404Renderer();
+
+        CompositeConfiguration compositeConfiguration = new MockCompositeConfiguration().withDefaultBoolean(true);
+        ContentStore contentStore = mock(ContentStore.class);
+
+        Renderer mockRenderer = mock(Renderer.class);
+
+        int renderResponse = renderer.render(mockRenderer, contentStore,
+                new File("fake"), new File("fake"), compositeConfiguration);
+
+        assertThat(renderResponse).isEqualTo(1);
+    }
+
+    @Test
+    public void doesRenderWhenConfigDoesNotRenderError404() throws Exception {
+        Error404Renderer renderer = new Error404Renderer();
+
+        CompositeConfiguration compositeConfiguration = new MockCompositeConfiguration().withDefaultBoolean(true);
+        ContentStore contentStore = mock(ContentStore.class);
+        Renderer mockRenderer = mock(Renderer.class);
+
+        int renderResponse = renderer.render(mockRenderer, contentStore,
+                new File("fake"), new File("fake"), compositeConfiguration);
+
+        verify(mockRenderer, times(1)).renderError404("random string");
+    }
+
+    @Test(expected = RenderingException.class)
+    public void propogatesRenderingException() throws Exception {
+        Error404Renderer renderer = new Error404Renderer();
+
+        CompositeConfiguration compositeConfiguration = new MockCompositeConfiguration().withDefaultBoolean(true);
+        ContentStore contentStore = mock(ContentStore.class);
+        Renderer mockRenderer = mock(Renderer.class);
+
+        doThrow(new Exception()).when(mockRenderer).renderError404(anyString());
+
+        int renderResponse = renderer.render(mockRenderer, contentStore,
+                new File("fake"), new File("fake"), compositeConfiguration);
+
+        verify(mockRenderer, never()).renderError404("random string");
+    }
+}

--- a/jbake-core/src/test/resources/fixture/freemarkerTemplates/error404.ftl
+++ b/jbake-core/src/test/resources/fixture/freemarkerTemplates/error404.ftl
@@ -1,0 +1,8 @@
+<#include "header.ftl">
+
+	<#include "menu.ftl">
+
+	<h1>404 Not found</h1>
+    <h2>The requested page is not found.</h2>
+
+<#include "footer.ftl">

--- a/jbake-core/src/test/resources/fixture/groovyMarkupTemplates/error404.tpl
+++ b/jbake-core/src/test/resources/fixture/groovyMarkupTemplates/error404.tpl
@@ -1,0 +1,7 @@
+package fixture.groovyMarkupTemplates
+
+layout 'layout/main.tpl',
+        bodyContents: contents {
+            h1('404 Not found')
+            h2('The requested page is not found.')
+        }

--- a/jbake-core/src/test/resources/fixture/groovyTemplates/error404.gsp
+++ b/jbake-core/src/test/resources/fixture/groovyTemplates/error404.gsp
@@ -1,0 +1,4 @@
+%include "header.gsp"%>
+	<h1>404 Not found</h1>
+    <h2>The requested page is not found.</h2>
+<%include "footer.gsp"%>

--- a/jbake-core/src/test/resources/fixture/jadeTemplates/error404.jade
+++ b/jbake-core/src/test/resources/fixture/jadeTemplates/error404.jade
@@ -1,0 +1,5 @@
+extends layout.jade
+
+block content
+    h1 404 Not found
+    h2 The requested page is not found.

--- a/jbake-core/src/test/resources/fixture/jbake.properties
+++ b/jbake-core/src/test/resources/fixture/jbake.properties
@@ -4,6 +4,7 @@ asset.folder=assets
 render.index=true
 index.file=index.html
 render.feed=true
+render.error404=true
 feed.file=feed.xml
 render.archive=true
 render.encoding=UTF-8

--- a/jbake-core/src/test/resources/fixture/thymeleafTemplates/error404.thyme
+++ b/jbake-core/src/test/resources/fixture/thymeleafTemplates/error404.thyme
@@ -1,0 +1,13 @@
+<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+      <head th:replace="header.thyme::head"/>
+      <body>
+      <div th:replace="header.thyme::top"/>
+
+      <h1>404 Not found</h1>
+      <h2>The requested page is not found.</h2>
+    <div th:replace="footer.thyme::footer"></div>
+    </body>
+</html>


### PR DESCRIPTION
This PR tries to close #365. This PR stands good on tests against core functionality, but fails on dist test. I assume that happens because there is no standard 404 template in example repositories. I have quickly written 404 templates for all template engines that are present in /fixture folder in test package.  