### PR TITLE
Lazy evaluation of extractor values for ThymeleafTemplateEngine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     junit4Version = '4.12'
     flexmarkVersion = '0.32.20'
     jettyServerVersion = '9.2.24.v20180105'
-    orientDbVersion = '2.2.33'
+    orientDbVersion = '2.2.36'
     groovyVersion = '2.4.15'
     slf4jVersion = '1.7.25'
     logbackVersion = '1.2.3'

--- a/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
@@ -3,7 +3,6 @@ package org.jbake.template;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.lang.LocaleUtils;
 import org.jbake.app.ContentStore;
-import org.jbake.app.Crawler;
 import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.thymeleaf.TemplateEngine;
@@ -92,10 +91,10 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
         String localeString = config.getThymeleafLocale();
         Locale locale = localeString != null ? LocaleUtils.toLocale(localeString) : Locale.getDefault();
 
-        Context context = wrap(locale,model);
 
         lock.lock();
         try {
+            initializeContext(locale,model);
             updateTemplateMode(model);
             templateEngine.process(templateName, context, writer);
         } finally {
@@ -103,7 +102,7 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
         }
     }
 
-    private Context wrap(Locale locale,Map<String, Object> model) {
+    private void initializeContext(Locale locale, Map<String, Object> model) {
         context.clearVariables();
         context.setLocale(locale);
         context.setVariables(model);
@@ -111,8 +110,6 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
         for (String key : extractors.keySet()) {
             context.setVariable(key, new ContextVariable(db,key,model));
         }
-
-        return context;
     }
 
     /**

--- a/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
@@ -14,7 +14,6 @@ import org.thymeleaf.templateresolver.FileTemplateResolver;
 import java.io.File;
 import java.io.Writer;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -36,11 +35,11 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Cédric Champeau
  */
 public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
+    private static final String DEFAULT_TEMPLATE_MODE = "HTML";
     private final ReentrantLock lock = new ReentrantLock();
-
     private TemplateEngine templateEngine;
-
-    private String templateMode;
+    private Context context;
+    private FileTemplateResolver templateResolver;
 
     /**
      * @deprecated Use {@link #ThymeleafTemplateEngine(JBakeConfiguration, ContentStore)} instead
@@ -48,90 +47,122 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
 	@Deprecated
     public ThymeleafTemplateEngine(final CompositeConfiguration config, final ContentStore db, final File destination, final File templatesPath) {
         super(config, db, destination, templatesPath);
+        this.context = new Context();
+        initializeTemplateEngine();
     }
 
     public ThymeleafTemplateEngine(final JBakeConfiguration config, final ContentStore db) {
         super(config, db);
+        this.context = new Context();
+        initializeTemplateEngine();
     }
 
-    private void initializeTemplateEngine(String mode) {
-        if (mode.equals(templateMode)) {
-            return;
-        }
-        templateMode = mode;
-        FileTemplateResolver templateResolver = new FileTemplateResolver();
+    private void initializeTemplateEngine() {
+        templateResolver = new FileTemplateResolver();
         templateResolver.setPrefix(config.getTemplateFolder().getAbsolutePath() + File.separatorChar);
         templateResolver.setCharacterEncoding(config.getTemplateEncoding());
-        templateResolver.setTemplateMode(mode);
+        templateResolver.setTemplateMode(DEFAULT_TEMPLATE_MODE);
         templateEngine = new TemplateEngine();
         templateEngine.setTemplateResolver(templateResolver);
+        templateEngine.clearTemplateCache();
+    }
+
+    private void updateTemplateMode(Map<String, Object> model) {
+        templateResolver.setTemplateMode(getTemplateModeByModel(model));
+    }
+
+    private String getTemplateModeByModel(Map<String, Object> model) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> config = (Map<String, Object>) model.get("config");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> content = (Map<String, Object>) model.get("content");
+        if (config != null && content != null) {
+            String key = "template_" + content.get(Attributes.TYPE) + "_thymeleaf_mode";
+            String configMode = (String) config.get(key);
+            if (configMode != null) {
+                return configMode;
+            }
+        }
+        return DEFAULT_TEMPLATE_MODE;
     }
 
     @Override
-    public void renderDocument(final Map<String, Object> model, final String templateName, final Writer writer) throws RenderingException {
+    public void renderDocument(Map<String, Object> model, String templateName, Writer writer) throws RenderingException {
+
         String localeString = config.getThymeleafLocale();
         Locale locale = localeString != null ? LocaleUtils.toLocale(localeString) : Locale.getDefault();
-        Context context = new Context(locale, wrap(model));
+
+        Context context = wrap(locale,model);
+
         lock.lock();
         try {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> config = (Map<String, Object>) model.get("config");
-            @SuppressWarnings("unchecked")
-            Map<String, Object> content = (Map<String, Object>) model.get("content");
-            String mode = "HTML";
-            if (config != null && content != null) {
-                String key = "template_" + content.get(Attributes.TYPE) + "_thymeleaf_mode";
-                String configMode = (String) config.get(key);
-                if (configMode != null) {
-                    mode = configMode;
-                }
-            }
-            initializeTemplateEngine(mode);
+            updateTemplateMode(model);
             templateEngine.process(templateName, context, writer);
         } finally {
             lock.unlock();
         }
     }
 
-    private Map<String, Object> wrap(final Map<String, Object> model) {
-        return new JBakeMap(model);
+    private Context wrap(Locale locale,Map<String, Object> model) {
+        context.clearVariables();
+        context.setLocale(locale);
+        context.setVariables(model);
+
+        for (String key : extractors.keySet()) {
+            context.setVariable(key, new ContextVariable(db,key,model));
+        }
+
+        return context;
     }
 
-    private class JBakeMap extends HashMap<String, Object> {
-        JBakeMap(final Map<String, Object> model) {
-            super(model);
-            for (String key : extractors.keySet()) {
-                try {
-                    put(key, extractors.extractAndTransform(db, key, model, new TemplateEngineAdapter<LazyContextVariable>() {
-                        @Override
-                        public LazyContextVariable adapt(String key, final Object extractedValue) {
-                            if (key.equals(Crawler.Attributes.ALLTAGS)) {
-                                return new LazyContextVariable<Set<?>>() {
-                                    @Override
-                                    protected Set<?> loadValue() {
-                                        return (Set<?>) extractedValue;
-                                    }
-                                };
-                            } else if (key.equals(Crawler.Attributes.PUBLISHED_DATE)) {
-                                return new LazyContextVariable<Date>() {
-                                    @Override
-                                    protected Date loadValue() {
-                                        return (Date) extractedValue;
-                                    }
-                                };
-                            } else {
-                                return new LazyContextVariable<Object>() {
-                                    @Override
-                                    protected Object loadValue() {
-                                        return extractedValue;
-                                    }
-                                };
-                            }
+    /**
+     * Helper class to lazy load data form extractors by key
+     */
+    private class ContextVariable extends LazyContextVariable {
+
+        private ContentStore db;
+        private String key;
+        private Map<String,Object> model;
+
+        public ContextVariable(ContentStore db, String key, Map<String, Object> model) {
+            this.db = db;
+            this.key = key;
+            this.model = model;
+        }
+
+        @Override
+        protected Object loadValue() {
+
+            try {
+                return extractors.extractAndTransform(db, key, model, new TemplateEngineAdapter<LazyContextVariable>() {
+                    @Override
+                    public LazyContextVariable adapt(String key, final Object extractedValue) {
+                        if (key.equals(Attributes.ALLTAGS)) {
+                            return new LazyContextVariable<Set<?>>() {
+                                @Override
+                                protected Set<?> loadValue() {
+                                    return (Set<?>) extractedValue;
+                                }
+                            };
+                        } else if (key.equals(Attributes.PUBLISHED_DATE)) {
+                            return new LazyContextVariable<Date>() {
+                                @Override
+                                protected Date loadValue() {
+                                    return (Date) extractedValue;
+                                }
+                            };
+                        } else {
+                            return new LazyContextVariable<Object>() {
+                                @Override
+                                protected Object loadValue() {
+                                    return extractedValue;
+                                }
+                            };
                         }
-                    }));
-                } catch (NoModelExtractorException e) {
-                    // should never happen, as we iterate over existing extractors
-                }
+                    }
+                }).getValue();
+            } catch (NoModelExtractorException e) {
+                return "";
             }
         }
     }


### PR DESCRIPTION
I noticed a strange behaviour baking a site using thymeleaf template engine.
https://gitlab.com/devlug/devlug-web

It was awful slow.

```
08:28:18.835 INFO  org.jbake.app.Oven - Baking finished!
08:28:18.835 INFO  org.jbake.app.Oven - Baked 86 items in 15048ms
```
I took a look at the memory consumption with visualvm.
![heap-space-jbake-thyme-before](https://user-images.githubusercontent.com/264432/42800525-9e0e0cc8-899c-11e8-987a-a2b8ede19459.png)

When it hits the 500 MB mark the rendering process starts.

With the applied fix the overall bake time goes down do nearly 8 sec.

```
08:38:40.496 INFO  org.jbake.app.Oven - Baking finished!
08:38:40.496 INFO  org.jbake.app.Oven - Baked 86 items in 7894ms
```

And the memory consumption looks much better, too.

![heap-space-jbake-thyme-after](https://user-images.githubusercontent.com/264432/42800725-43ae1ab0-899d-11e8-985d-0f78b2f2b141.png)

I had to update the gradle wrapper as bintray dropped TLS 1.0/1.1 support, which caused the java 7 build to fail on travis and appveyor. See https://jfrog.com/knowledge-base/why-am-i-failing-to-work-with-jfrog-saas-service-with-tls-1-0-1-1/

An update to orientdb slipped into this pr. Shall I revert it?