### PR TITLE
[WIP] Limit number of header lines

### DIFF
--- a/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
@@ -1,11 +1,5 @@
 package org.jbake.app.configuration;
 
-import org.apache.commons.configuration.CompositeConfiguration;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,6 +7,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The default implementation of a {@link JBakeConfiguration}
@@ -31,6 +30,9 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
     private static final String DOCTYPE_TEMPLATE_PREFIX = "template.";
     private Logger logger = LoggerFactory.getLogger(DefaultJBakeConfiguration.class);
     private CompositeConfiguration compositeConfiguration;
+
+    public static final int MAX_HEADER_LINES_DEFAULT = 50;
+
 
     /**
      * Some deprecated implementations just need access to the configuration without access to the source folder
@@ -466,6 +468,12 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
     @Override
     public String getVersion() {
         return getAsString(JBakeProperty.VERSION);
+    }
+
+    @Override
+    public int getMaxHeaderLinesScan()
+    {
+        return getAsInt(JBakeProperty.MAX_HEADER_LINES_SCAN, MAX_HEADER_LINES_DEFAULT);
     }
 
     public void setDestinationFolderName(String folderName) {

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
@@ -300,6 +300,12 @@ public interface JBakeConfiguration {
     String getVersion();
 
     /**
+     * @return Maximum lines to scan when looking for a JBake in-file header.
+     */
+    int getMaxHeaderLinesScan();
+
+
+    /**
      * Set a property value for the given key
      *
      * @param key   the key for the property

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeProperty.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeProperty.java
@@ -46,6 +46,7 @@ public class JBakeProperty {
     public static final String IMG_PATH_UPDATE = "img.path.update";
     public static final String IMG_PATH_PREPEND_HOST = "img.path.prepend.host";
     public static final String VERSION = "version";
+    public static final String MAX_HEADER_LINES_SCAN = "header.maxLines";
 
     private JBakeProperty() {}
 

--- a/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
@@ -36,9 +36,6 @@ public abstract class MarkupEngine implements ParserEngine {
 
     private JBakeConfiguration configuration;
 
-    public static final int MAX_HEADER_LINES = 50;
-
-
     /**
      * Tests if this markup engine can process the document.
      *
@@ -174,9 +171,10 @@ public abstract class MarkupEngine implements ParserEngine {
 
         List<String> headerLines = new ArrayList<>();
 
+        int scanMaxLines = configuration.getMaxHeaderLinesScan();
 
         //for (String line : contents) {
-        for (int i = 0; i < contents.size() && i < MAX_HEADER_LINES; i++) {
+        for (int i = 0; i < contents.size() && i < scanMaxLines; i++) {
             String line = contents.get(i);
             if (StringUtils.isBlank(line))
                 continue;

--- a/jbake-core/src/main/resources/default.properties
+++ b/jbake-core/src/main/resources/default.properties
@@ -117,3 +117,5 @@ header.separator=~~~~~~
 img.path.update=false
 # Prepend site.host to image paths
 img.path.prepend.host=true
+# JBake will only scan this number of lines for a headers block separator.
+header.maxLines=50


### PR DESCRIPTION
Without any limit, JBake may encounter files that are very long, and try parsing them as text, looking for a header for the whole size of the file.

Looking for a header should be stopped after certain amount of lines and bytes.