### PR TITLE
add jdk 10 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ after_success:
 - "./gradlew -PskipSigning jacocoRootReport coveralls || ./gradlew clean"
 
 jdk:
+  - openjdk10
   - oraclejdk9
   - oraclejdk8
   - openjdk8


### PR DESCRIPTION
https://docs.travis-ci.com/user/languages/java/#using-java-10-and-later

unfortunately openjdk11 fails at present in contrast to the
documentation