### PR TITLE
introduce DocumentModel and TemplateModel

### DIFF
--- a/jbake-core/src/main/java/org/jbake/app/ContentStore.java
+++ b/jbake-core/src/main/java/org/jbake/app/ContentStore.java
@@ -381,23 +381,23 @@ public class ContentStore {
         OClass page = schema.createClass(docType);
 
         // Primary key
-        String attribName = ModelAttributes.SOURCE_URI.toString();
+        String attribName = ModelAttributes.SOURCE_URI;
         page.createProperty(attribName, OType.STRING).setNotNull(true);
         page.createIndex(docType + "sourceUriIndex", OClass.INDEX_TYPE.UNIQUE, attribName);
 
-        attribName = ModelAttributes.SHA1.toString();
+        attribName = ModelAttributes.SHA1;
         page.createProperty(attribName, OType.STRING).setNotNull(true);
         page.createIndex(docType + "sha1Index", OClass.INDEX_TYPE.NOTUNIQUE, attribName);
 
-        attribName = ModelAttributes.CACHED.toString();
+        attribName = ModelAttributes.CACHED;
         page.createProperty(attribName, OType.BOOLEAN).setNotNull(true);
         page.createIndex(docType + "cachedIndex", OClass.INDEX_TYPE.NOTUNIQUE, attribName);
 
-        attribName = ModelAttributes.RENDERED.toString();
+        attribName = ModelAttributes.RENDERED;
         page.createProperty(attribName, OType.BOOLEAN).setNotNull(true);
         page.createIndex(docType + "renderedIndex", OClass.INDEX_TYPE.NOTUNIQUE, attribName);
 
-        attribName = ModelAttributes.STATUS.toString();
+        attribName = ModelAttributes.STATUS;
         page.createProperty(attribName, OType.STRING).setNotNull(true);
         page.createIndex(docType + "statusIndex", OClass.INDEX_TYPE.NOTUNIQUE, attribName);
     }

--- a/jbake-core/src/main/java/org/jbake/app/ContentStore.java
+++ b/jbake-core/src/main/java/org/jbake/app/ContentStore.java
@@ -404,8 +404,8 @@ public class ContentStore {
 
     private void createSignatureType(OSchema schema) {
         OClass signatures = schema.createClass("Signatures");
-        signatures.createProperty(ModelAttributes.SHA1.toString(), OType.STRING).setNotNull(true);
-        signatures.createIndex("sha1Idx", OClass.INDEX_TYPE.UNIQUE, ModelAttributes.SHA1.toString());
+        signatures.createProperty(ModelAttributes.SHA1, OType.STRING).setNotNull(true);
+        signatures.createIndex("sha1Idx", OClass.INDEX_TYPE.UNIQUE, ModelAttributes.SHA1);
     }
 
     public void updateAndClearCacheIfNeeded(boolean needed, File templateFolder) {

--- a/jbake-core/src/main/java/org/jbake/app/ContentStore.java
+++ b/jbake-core/src/main/java/org/jbake/app/ContentStore.java
@@ -36,7 +36,6 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-import org.jbake.model.BaseModel;
 import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import org.jbake.model.ModelAttributes;
@@ -234,29 +233,29 @@ public class ContentStore {
     /*
      * In fact, the URI should be the only input as there can only be one document at given URI; but the DB is split per document type for some reason.
      */
-    public DocumentList getDocumentByUri(String docType, String uri) {
+    public DocumentList<DocumentModel> getDocumentByUri(String docType, String uri) {
         return query(String.format(STATEMENT_GET_POST_BY_TYPE_AND_URI, quoteIdentifier(docType)), uri);
     }
 
-    public DocumentList getDocumentStatus(String docType, String uri) {
+    public DocumentList<DocumentModel> getDocumentStatus(String docType, String uri) {
         String statement = String.format(STATEMENT_GET_DOCUMENT_STATUS_BY_DOCTYPE_AND_URI, quoteIdentifier(docType));
         return query(statement, uri);
     }
 
-    public DocumentList getPublishedPosts() {
+    public DocumentList<DocumentModel> getPublishedPosts() {
         return getPublishedContent("post");
     }
 
-    public DocumentList getPublishedPosts(boolean applyPaging) {
+    public DocumentList<DocumentModel> getPublishedPosts(boolean applyPaging) {
         return getPublishedContent("post", applyPaging);
     }
 
-    public DocumentList getPublishedPostsByTag(String tag) {
+    public DocumentList<DocumentModel> getPublishedPostsByTag(String tag) {
         return query(STATEMENT_GET_PUBLISHED_POSTS_BY_TAG, tag);
     }
 
-    public DocumentList getPublishedDocumentsByTag(String tag) {
-        final DocumentList documents = new DocumentList();
+    public DocumentList<DocumentModel> getPublishedDocumentsByTag(String tag) {
+        final DocumentList<DocumentModel> documents = new DocumentList<>();
 
         for (final String docType : DocumentTypes.getDocumentTypes()) {
             String statement = String.format(STATEMENT_GET_PUBLISHED_POST_BY_TYPE_AND_TAG, quoteIdentifier(docType));
@@ -266,15 +265,15 @@ public class ContentStore {
         return documents;
     }
 
-    public DocumentList getPublishedPages() {
+    public DocumentList<DocumentModel> getPublishedPages() {
         return getPublishedContent("page");
     }
 
-    public DocumentList getPublishedContent(String docType) {
+    public DocumentList<DocumentModel> getPublishedContent(String docType) {
         return getPublishedContent(docType, false);
     }
 
-    private DocumentList getPublishedContent(String docType, boolean applyPaging) {
+    private DocumentList<DocumentModel> getPublishedContent(String docType, boolean applyPaging) {
         String query = String.format(STATEMENT_GET_PUBLISHED_CONTENT_BY_DOCTYPE, quoteIdentifier(docType));
         if (applyPaging && hasStartAndLimitBoundary()) {
             query += " SKIP " + start + " LIMIT " + limit;
@@ -282,11 +281,11 @@ public class ContentStore {
         return query(query);
     }
 
-    public DocumentList getAllContent(String docType) {
+    public DocumentList<DocumentModel> getAllContent(String docType) {
         return getAllContent(docType, false);
     }
 
-    public DocumentList getAllContent(String docType, boolean applyPaging) {
+    public DocumentList<DocumentModel> getAllContent(String docType, boolean applyPaging) {
         String query = String.format(STATEMENT_GET_ALL_CONTENT_BY_DOCTYPE, quoteIdentifier(docType));
         if (applyPaging && hasStartAndLimitBoundary()) {
             query += " SKIP " + start + " LIMIT " + limit;
@@ -298,15 +297,15 @@ public class ContentStore {
         return (start >= 0) && (limit > -1);
     }
 
-    private DocumentList getAllTagsFromPublishedPosts() {
+    private DocumentList<DocumentModel> getAllTagsFromPublishedPosts() {
         return query(STATEMENT_GET_TAGS_FROM_PUBLISHED_POSTS);
     }
 
-    private DocumentList getSignaturesForTemplates() {
+    private DocumentList<DocumentModel> getSignaturesForTemplates() {
         return query(STATEMENT_GET_SIGNATURE_FOR_TEMPLATES);
     }
 
-    public DocumentList getUnrenderedContent(String docType) {
+    public DocumentList<DocumentModel> getUnrenderedContent(String docType) {
         String statement = String.format(STATEMENT_GET_UNDRENDERED_CONTENT, quoteIdentifier(docType));
         return query(statement);
     }
@@ -334,13 +333,13 @@ public class ContentStore {
         executeCommand(STATEMENT_INSERT_TEMPLATES_SIGNATURE, currentTemplatesSignature);
     }
 
-    private DocumentList query(String sql) {
+    private DocumentList<DocumentModel> query(String sql) {
         activateOnCurrentThread();
         OResultSet results = db.query(sql);
         return DocumentList.wrap(results);
     }
 
-    private DocumentList query(String sql, Object... args) {
+    private DocumentList<DocumentModel> query(String sql, Object... args) {
         activateOnCurrentThread();
         OResultSet results = db.command(sql, args);
         return DocumentList.wrap(results);
@@ -352,10 +351,10 @@ public class ContentStore {
     }
 
     public Set<String> getTags() {
-        DocumentList docs = this.getAllTagsFromPublishedPosts();
+        DocumentList<DocumentModel> docs = this.getAllTagsFromPublishedPosts();
         Set<String> result = new HashSet<>();
-        for (BaseModel document : docs) {
-            String[] tags = ((DocumentModel) document).getTags();
+        for (DocumentModel document : docs) {
+            String[] tags = document.getTags();
             Collections.addAll(result, tags);
         }
         return result;
@@ -365,9 +364,9 @@ public class ContentStore {
         Set<String> result = new HashSet<>();
         for (String docType : DocumentTypes.getDocumentTypes()) {
             String statement = String.format(STATEMENT_GET_TAGS_BY_DOCTYPE, quoteIdentifier(docType));
-            DocumentList docs = query(statement);
-            for (BaseModel document : docs) {
-                String[] tags = ((DocumentModel) document).getTags();
+            DocumentList<DocumentModel> docs = query(statement);
+            for (DocumentModel document : docs) {
+                String[] tags = document.getTags();
                 Collections.addAll(result, tags);
             }
         }

--- a/jbake-core/src/main/java/org/jbake/app/ContentStore.java
+++ b/jbake-core/src/main/java/org/jbake/app/ContentStore.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-
 /**
  * @author jdlee
  */
@@ -189,6 +188,7 @@ public class ContentStore {
 
     /**
      * Get a document by sourceUri and update it from the given map.
+     *
      * @param incomingDocMap The document's db columns.
      * @return The saved document.
      * @throws IllegalArgumentException if sourceUri or docType are null, or if the document doesn't exist.
@@ -200,7 +200,7 @@ public class ContentStore {
             throw new IllegalArgumentException("Document sourceUri is null.");
         }
 
-        String docType = (String) incomingDocMap.get(Crawler.Attributes.TYPE);
+        String docType = (String) incomingDocMap.get(DocumentAttributes.TYPE.toString());
 
         if (null == docType) {
             throw new IllegalArgumentException("Document docType is null.");
@@ -356,7 +356,7 @@ public class ContentStore {
         DocumentList docs = this.getAllTagsFromPublishedPosts();
         Set<String> result = new HashSet<>();
         for (Map<String, Object> document : docs) {
-            String[] tags = DBUtil.toStringArray(document.get(Crawler.Attributes.TAGS));
+            String[] tags = DBUtil.toStringArray(document.get(DocumentAttributes.TAGS.toString()));
             Collections.addAll(result, tags);
         }
         return result;
@@ -368,7 +368,7 @@ public class ContentStore {
             String statement = String.format(STATEMENT_GET_TAGS_BY_DOCTYPE, quoteIdentifier(docType));
             DocumentList docs = query(statement);
             for (Map<String, Object> document : docs) {
-                String[] tags = DBUtil.toStringArray(document.get(Crawler.Attributes.TAGS));
+                String[] tags = DBUtil.toStringArray(document.get(DocumentAttributes.TAGS.toString()));
                 Collections.addAll(result, tags);
             }
         }

--- a/jbake-core/src/main/java/org/jbake/app/ContentStore.java
+++ b/jbake-core/src/main/java/org/jbake/app/ContentStore.java
@@ -37,6 +37,7 @@ import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
 import org.jbake.model.DocumentAttributes;
+import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -355,8 +356,8 @@ public class ContentStore {
     public Set<String> getTags() {
         DocumentList docs = this.getAllTagsFromPublishedPosts();
         Set<String> result = new HashSet<>();
-        for (Map<String, Object> document : docs) {
-            String[] tags = DBUtil.toStringArray(document.get(DocumentAttributes.TAGS.toString()));
+        for (DocumentModel document : docs) {
+            String[] tags = document.getTags();
             Collections.addAll(result, tags);
         }
         return result;
@@ -367,8 +368,8 @@ public class ContentStore {
         for (String docType : DocumentTypes.getDocumentTypes()) {
             String statement = String.format(STATEMENT_GET_TAGS_BY_DOCTYPE, quoteIdentifier(docType));
             DocumentList docs = query(statement);
-            for (Map<String, Object> document : docs) {
-                String[] tags = DBUtil.toStringArray(document.get(DocumentAttributes.TAGS.toString()));
+            for (DocumentModel document : docs) {
+                String[] tags = document.getTags();
                 Collections.addAll(result, tags);
             }
         }
@@ -405,7 +406,7 @@ public class ContentStore {
 
     private void createSignatureType(OSchema schema) {
         OClass signatures = schema.createClass("Signatures");
-        signatures.createProperty(String.valueOf(DocumentAttributes.SHA1), OType.STRING).setNotNull(true);
+        signatures.createProperty(DocumentAttributes.SHA1.toString(), OType.STRING).setNotNull(true);
         signatures.createIndex("sha1Idx", OClass.INDEX_TYPE.UNIQUE, DocumentAttributes.SHA1.toString());
     }
 
@@ -434,7 +435,7 @@ public class ContentStore {
             currentTemplatesSignature = "";
         }
         if (!docs.isEmpty()) {
-            String sha1 = (String) docs.get(0).get(String.valueOf(DocumentAttributes.SHA1));
+            String sha1 = docs.get(0).getSha1();
             if (!sha1.equals(currentTemplatesSignature)) {
                 this.updateSignatures(currentTemplatesSignature);
                 templateSignatureChanged = true;

--- a/jbake-core/src/main/java/org/jbake/app/ContentStore.java
+++ b/jbake-core/src/main/java/org/jbake/app/ContentStore.java
@@ -36,9 +36,10 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-import org.jbake.model.DocumentAttributes;
+import org.jbake.model.BaseModel;
 import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
+import org.jbake.model.ModelAttributes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -195,14 +196,11 @@ public class ContentStore {
      * @throws IllegalArgumentException if sourceUri or docType are null, or if the document doesn't exist.
      */
     public ODocument mergeDocument(Map<String, ? extends Object> incomingDocMap) {
-        String sourceUri = (String) incomingDocMap.get(DocumentAttributes.SOURCE_URI.toString());
-
+        String sourceUri = (String) incomingDocMap.get(ModelAttributes.SOURCE_URI.toString());
         if (null == sourceUri) {
             throw new IllegalArgumentException("Document sourceUri is null.");
         }
-
-        String docType = (String) incomingDocMap.get(DocumentAttributes.TYPE.toString());
-
+        String docType = (String) incomingDocMap.get(ModelAttributes.TYPE.toString());
         if (null == docType) {
             throw new IllegalArgumentException("Document docType is null.");
         }
@@ -356,8 +354,8 @@ public class ContentStore {
     public Set<String> getTags() {
         DocumentList docs = this.getAllTagsFromPublishedPosts();
         Set<String> result = new HashSet<>();
-        for (DocumentModel document : docs) {
-            String[] tags = document.getTags();
+        for (BaseModel document : docs) {
+            String[] tags = ((DocumentModel) document).getTags();
             Collections.addAll(result, tags);
         }
         return result;
@@ -368,8 +366,8 @@ public class ContentStore {
         for (String docType : DocumentTypes.getDocumentTypes()) {
             String statement = String.format(STATEMENT_GET_TAGS_BY_DOCTYPE, quoteIdentifier(docType));
             DocumentList docs = query(statement);
-            for (DocumentModel document : docs) {
-                String[] tags = document.getTags();
+            for (BaseModel document : docs) {
+                String[] tags = ((DocumentModel) document).getTags();
                 Collections.addAll(result, tags);
             }
         }
@@ -383,31 +381,31 @@ public class ContentStore {
         OClass page = schema.createClass(docType);
 
         // Primary key
-        String attribName = DocumentAttributes.SOURCE_URI.toString();
+        String attribName = ModelAttributes.SOURCE_URI.toString();
         page.createProperty(attribName, OType.STRING).setNotNull(true);
         page.createIndex(docType + "sourceUriIndex", OClass.INDEX_TYPE.UNIQUE, attribName);
 
-        attribName = DocumentAttributes.SHA1.toString();
+        attribName = ModelAttributes.SHA1.toString();
         page.createProperty(attribName, OType.STRING).setNotNull(true);
         page.createIndex(docType + "sha1Index", OClass.INDEX_TYPE.NOTUNIQUE, attribName);
 
-        attribName = DocumentAttributes.CACHED.toString();
+        attribName = ModelAttributes.CACHED.toString();
         page.createProperty(attribName, OType.BOOLEAN).setNotNull(true);
         page.createIndex(docType + "cachedIndex", OClass.INDEX_TYPE.NOTUNIQUE, attribName);
 
-        attribName = DocumentAttributes.RENDERED.toString();
+        attribName = ModelAttributes.RENDERED.toString();
         page.createProperty(attribName, OType.BOOLEAN).setNotNull(true);
         page.createIndex(docType + "renderedIndex", OClass.INDEX_TYPE.NOTUNIQUE, attribName);
 
-        attribName = DocumentAttributes.STATUS.toString();
+        attribName = ModelAttributes.STATUS.toString();
         page.createProperty(attribName, OType.STRING).setNotNull(true);
         page.createIndex(docType + "statusIndex", OClass.INDEX_TYPE.NOTUNIQUE, attribName);
     }
 
     private void createSignatureType(OSchema schema) {
         OClass signatures = schema.createClass("Signatures");
-        signatures.createProperty(DocumentAttributes.SHA1.toString(), OType.STRING).setNotNull(true);
-        signatures.createIndex("sha1Idx", OClass.INDEX_TYPE.UNIQUE, DocumentAttributes.SHA1.toString());
+        signatures.createProperty(ModelAttributes.SHA1.toString(), OType.STRING).setNotNull(true);
+        signatures.createIndex("sha1Idx", OClass.INDEX_TYPE.UNIQUE, ModelAttributes.SHA1.toString());
     }
 
     public void updateAndClearCacheIfNeeded(boolean needed, File templateFolder) {
@@ -435,7 +433,7 @@ public class ContentStore {
             currentTemplatesSignature = "";
         }
         if (!docs.isEmpty()) {
-            String sha1 = docs.get(0).getSha1();
+            String sha1 = ((DocumentModel) docs.get(0)).getSha1();
             if (!sha1.equals(currentTemplatesSignature)) {
                 this.updateSignatures(currentTemplatesSignature);
                 templateSignatureChanged = true;

--- a/jbake-core/src/main/java/org/jbake/app/Crawler.java
+++ b/jbake-core/src/main/java/org/jbake/app/Crawler.java
@@ -213,6 +213,7 @@ public class Crawler {
         documentModel.setFile(sourceFile.getPath());
         documentModel.setSourceUri(uri);
         documentModel.setUri(uri);
+        documentModel.setCached(true);
 
         if (documentModel.getStatus().equals(ModelAttributes.Status.PUBLISHED_DATE)
                 && (documentModel.getDate() != null)

--- a/jbake-core/src/main/java/org/jbake/app/Crawler.java
+++ b/jbake-core/src/main/java/org/jbake/app/Crawler.java
@@ -20,7 +20,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.Map;
 
 /**
  * Crawls a file system looking for content.
@@ -216,12 +215,10 @@ public class Crawler {
         documentModel.setSourceUri(uri);
         documentModel.setUri(uri);
 
-        if (documentModel.getStatus().equals(Status.PUBLISHED_DATE)) {
-            if (documentModel.getDate() != null) {
-                if (new Date().after(documentModel.getDate())) {
-                    documentModel.setStatus(Status.PUBLISHED);
-                }
-            }
+        if (documentModel.getStatus().equals(Status.PUBLISHED_DATE)
+                && (documentModel.getDate() != null)
+                && new Date().after(documentModel.getDate())) {
+            documentModel.setStatus(Status.PUBLISHED);
         }
 
         if (config.getUriWithoutExtension()) {
@@ -236,9 +233,9 @@ public class Crawler {
     private DocumentStatus findDocumentStatus(String docType, String uri, String sha1) {
         DocumentList match = db.getDocumentStatus(docType, uri);
         if (!match.isEmpty()) {
-            Map entries = match.get(0);
-            String oldHash = (String) entries.get(String.valueOf(DocumentAttributes.SHA1));
-            if (!(oldHash.equals(sha1)) || Boolean.FALSE.equals(entries.get(String.valueOf(DocumentAttributes.RENDERED)))) {
+            DocumentModel documentModel = match.get(0);
+            String oldHash = documentModel.getSha1();
+            if (!(oldHash.equals(sha1)) || Boolean.FALSE.equals(documentModel.getRendered())) {
                 return DocumentStatus.UPDATED;
             } else {
                 return DocumentStatus.IDENTICAL;
@@ -250,7 +247,6 @@ public class Crawler {
 
     public abstract static class Attributes {
 
-        public static final String TAG = "tag";
         public static final String ALLTAGS = "alltags";
         public static final String PUBLISHED_DATE = "published_date";
         public static final String DB = "db";

--- a/jbake-core/src/main/java/org/jbake/app/Crawler.java
+++ b/jbake-core/src/main/java/org/jbake/app/Crawler.java
@@ -230,12 +230,12 @@ public class Crawler {
         return FileUtil.getUriPathToContentRoot(config, sourceFile);
     }
 
-    private DocumentStatus findDocumentStatus(String docType, String uri, String sha1) {
-        DocumentList match = db.getDocumentStatus(docType, uri);
+    private DocumentStatus findDocumentStatus(String documentType, String uri, String sha1) {
+        DocumentList<DocumentModel> match = db.getDocumentStatus(documentType, uri);
         if (!match.isEmpty()) {
-            DocumentModel documentModel = match.getDocumentModel(0);
-            String oldHash = documentModel.getSha1();
-            if (!oldHash.equals(sha1) || !documentModel.getRendered()) {
+            DocumentModel document = match.get(0);
+            String oldHash = document.getSha1();
+            if (!oldHash.equals(sha1) || !document.getRendered()) {
                 return DocumentStatus.UPDATED;
             } else {
                 return DocumentStatus.IDENTICAL;

--- a/jbake-core/src/main/java/org/jbake/app/Crawler.java
+++ b/jbake-core/src/main/java/org/jbake/app/Crawler.java
@@ -6,10 +6,10 @@ import org.apache.commons.io.FilenameUtils;
 import org.jbake.app.Crawler.Attributes.Status;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfigurationFactory;
-import org.jbake.model.DocumentAttributes;
 import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentStatus;
 import org.jbake.model.DocumentTypes;
+import org.jbake.model.ModelAttributes;
 import org.jbake.util.HtmlUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -142,7 +142,7 @@ public class Crawler {
 
         // strip off leading / to enable generating non-root based sites
         if (uri.startsWith(FileUtil.URI_SEPARATOR_CHAR)) {
-            uri = uri.substring(1, uri.length());
+            uri = uri.substring(1);
         }
 
         return uri;
@@ -233,7 +233,7 @@ public class Crawler {
     private DocumentStatus findDocumentStatus(String docType, String uri, String sha1) {
         DocumentList match = db.getDocumentStatus(docType, uri);
         if (!match.isEmpty()) {
-            DocumentModel documentModel = match.get(0);
+            DocumentModel documentModel = match.getDocumentModel(0);
             String oldHash = documentModel.getSha1();
             if (!(oldHash.equals(sha1)) || Boolean.FALSE.equals(documentModel.getRendered())) {
                 return DocumentStatus.UPDATED;
@@ -255,7 +255,7 @@ public class Crawler {
         }
 
         /**
-         * Possible values of the {@link DocumentAttributes#STATUS} property
+         * Possible values of the {@link ModelAttributes#STATUS} property
          *
          * @author ndx
          */

--- a/jbake-core/src/main/java/org/jbake/app/Crawler.java
+++ b/jbake-core/src/main/java/org/jbake/app/Crawler.java
@@ -97,22 +97,27 @@ public class Crawler {
         String sha1 = buildHash(sourceFile);
         String uri = buildURI(sourceFile);
         boolean process = true;
+        DocumentStatus status = DocumentStatus.NEW;
+
         for (String docType : DocumentTypes.getDocumentTypes()) {
-            DocumentStatus status = findDocumentStatus(docType, uri, sha1);
+            status = findDocumentStatus(docType, uri, sha1);
+            if ( status == null ) continue;
             if (status == DocumentStatus.UPDATED) {
                 sb.append(" : modified ");
                 db.deleteContent(docType, uri);
+                break;
             } else if (status == DocumentStatus.IDENTICAL) {
                 sb.append(" : same ");
                 process = false;
-            } else if (DocumentStatus.NEW == status) {
-                sb.append(" : new ");
             }
             if (!process || status != DocumentStatus.NEW) {
                 break;
             }
         }
         if (process) { // new or updated
+            if (status == DocumentStatus.NEW) {
+                sb.append(" : new ");
+            }
             processSourceFile(sourceFile, sha1, uri);
         }
         logger.info("{}", sb);

--- a/jbake-core/src/main/java/org/jbake/app/DBUtil.java
+++ b/jbake-core/src/main/java/org/jbake/app/DBUtil.java
@@ -4,10 +4,7 @@ import com.orientechnologies.orient.core.db.record.OTrackedList;
 import com.orientechnologies.orient.core.record.OElement;
 import com.orientechnologies.orient.core.sql.executor.OResult;
 import org.jbake.app.configuration.JBakeConfiguration;
-
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import org.jbake.model.DocumentModel;
 
 public class DBUtil {
     private static ContentStore contentStore;
@@ -37,12 +34,11 @@ public class DBUtil {
         contentStore = null;
     }
 
-    public static Map<String, Object> documentToModel(OResult doc) {
-        Map<String, Object> result = new HashMap<>();
-        Iterator<String> fieldIterator = doc.getPropertyNames().iterator();
-        while (fieldIterator.hasNext()) {
-            String entry = fieldIterator.next();
-            result.put(entry, doc.getProperty(entry));
+    public static DocumentModel documentToModel(OResult doc) {
+        DocumentModel result = new DocumentModel();
+
+        for (String key : doc.getPropertyNames()) {
+            result.put(key, doc.getProperty(key));
         }
         return result;
     }

--- a/jbake-core/src/main/java/org/jbake/app/DocumentList.java
+++ b/jbake-core/src/main/java/org/jbake/app/DocumentList.java
@@ -2,9 +2,10 @@ package org.jbake.app;
 
 import com.orientechnologies.orient.core.sql.executor.OResult;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import org.jbake.model.DocumentModel;
 
 import java.util.LinkedList;
-import java.util.Map;
 
 /**
  * Wraps an OrientDB document iterator into a model usable by
@@ -12,7 +13,7 @@ import java.util.Map;
  *
  * @author Cédric Champeau
  */
-public class DocumentList extends LinkedList<Map<String, Object>> {
+public class DocumentList extends LinkedList<DocumentModel> {
 
     public static DocumentList wrap(OResultSet docs) {
         DocumentList list = new DocumentList();

--- a/jbake-core/src/main/java/org/jbake/app/DocumentList.java
+++ b/jbake-core/src/main/java/org/jbake/app/DocumentList.java
@@ -3,6 +3,7 @@ package org.jbake.app;
 import com.orientechnologies.orient.core.sql.executor.OResult;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import org.jbake.model.BaseModel;
 import org.jbake.model.DocumentModel;
 
 import java.util.LinkedList;
@@ -13,7 +14,7 @@ import java.util.LinkedList;
  *
  * @author Cédric Champeau
  */
-public class DocumentList extends LinkedList<DocumentModel> {
+public class DocumentList extends LinkedList<BaseModel> {
 
     public static DocumentList wrap(OResultSet docs) {
         DocumentList list = new DocumentList();
@@ -25,4 +26,7 @@ public class DocumentList extends LinkedList<DocumentModel> {
         return list;
     }
 
+    public DocumentModel getDocumentModel(int index) {
+        return (DocumentModel) get(index);
+    }
 }

--- a/jbake-core/src/main/java/org/jbake/app/DocumentList.java
+++ b/jbake-core/src/main/java/org/jbake/app/DocumentList.java
@@ -2,8 +2,6 @@ package org.jbake.app;
 
 import com.orientechnologies.orient.core.sql.executor.OResult;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
-import com.orientechnologies.orient.core.record.impl.ODocument;
-import org.jbake.model.BaseModel;
 import org.jbake.model.DocumentModel;
 
 import java.util.LinkedList;
@@ -14,10 +12,10 @@ import java.util.LinkedList;
  *
  * @author Cédric Champeau
  */
-public class DocumentList extends LinkedList<BaseModel> {
+public class DocumentList<T> extends LinkedList<T> {
 
-    public static DocumentList wrap(OResultSet docs) {
-        DocumentList list = new DocumentList();
+    public static DocumentList<DocumentModel> wrap(OResultSet docs) {
+        DocumentList<DocumentModel> list = new DocumentList<>();
         while (docs.hasNext()) {
             OResult next = docs.next();
             list.add(DBUtil.documentToModel(next));
@@ -26,7 +24,4 @@ public class DocumentList extends LinkedList<BaseModel> {
         return list;
     }
 
-    public DocumentModel getDocumentModel(int index) {
-        return (DocumentModel) get(index);
-    }
 }

--- a/jbake-core/src/main/java/org/jbake/app/Parser.java
+++ b/jbake-core/src/main/java/org/jbake/app/Parser.java
@@ -1,13 +1,13 @@
 package org.jbake.app;
 
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentModel;
 import org.jbake.parser.Engines;
 import org.jbake.parser.ParserEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Map;
 
 /**
  * Parses a File for content.
@@ -31,13 +31,13 @@ public class Parser {
     /**
      * Process the file by parsing the contents.
      *
-     * @param    file File input for parsing
-     * @return                The contents of the file
+     * @param file File input for parsing
+     * @return The contents of the file
      */
-    public Map<String, Object> processFile(File file) {
+    public DocumentModel processFile(File file) {
         ParserEngine engine = Engines.get(FileUtil.fileExt(file));
-        if (engine==null) {
-            LOGGER.error("Unable to find suitable markup engine for {}",file);
+        if (engine == null) {
+            LOGGER.error("Unable to find suitable markup engine for {}", file);
             return null;
         }
 

--- a/jbake-core/src/main/java/org/jbake/app/Renderer.java
+++ b/jbake-core/src/main/java/org/jbake/app/Renderer.java
@@ -5,6 +5,8 @@ import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfigurationFactory;
+import org.jbake.model.DocumentAttributes;
+import org.jbake.model.DocumentModel;
 import org.jbake.template.DelegatingTemplateEngine;
 import org.jbake.util.PagingHelper;
 import org.slf4j.Logger;
@@ -107,8 +109,8 @@ public class Renderer {
      * @throws Exception if IOException or SecurityException are raised
      */
     public void render(Map<String, Object> content) throws Exception {
-        String docType = (String) content.get(Crawler.Attributes.TYPE);
-        String outputFilename = config.getDestinationFolder().getPath() + File.separatorChar + content.get(Attributes.URI);
+        String docType = (String) content.get(DocumentAttributes.TYPE.toString());
+        String outputFilename = config.getDestinationFolder().getPath() + File.separatorChar + content.get(DocumentAttributes.URI.toString());
         if (outputFilename.lastIndexOf('.') > outputFilename.lastIndexOf(File.separatorChar)) {
             outputFilename = outputFilename.substring(0, outputFilename.lastIndexOf('.'));
         }
@@ -125,7 +127,7 @@ public class Renderer {
             publishedFile.delete();
         }
 
-        if (content.get(Crawler.Attributes.STATUS).equals(Crawler.Attributes.Status.DRAFT)) {
+        if (content.get(DocumentAttributes.STATUS.toString()).equals(Crawler.Attributes.Status.DRAFT)) {
             outputFilename = outputFilename + config.getDraftSuffix();
         }
 
@@ -204,10 +206,10 @@ public class Renderer {
                     String nextFileName = pagingHelper.getNextFileName(page);
                     model.put("nextFileName", nextFileName);
 
-                    Map<String, Object> contentModel =  buildSimpleModel(MASTERINDEX_TEMPLATE_NAME);
+                    DocumentModel contentModel = buildSimpleModel(MASTERINDEX_TEMPLATE_NAME);
 
-                    if(page > 1){
-                        contentModel.put(Attributes.ROOTPATH, "../");
+                    if (page > 1) {
+                        contentModel.setRootPath("../");
                     }
                     model.put("content", contentModel);
 
@@ -268,14 +270,16 @@ public class Renderer {
 
         for (String tag : db.getAllTags()) {
             try {
+
                 Map<String, Object> model = new HashMap<>();
+                File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + tag + config.getOutputExtension());
+
                 model.put("renderer", renderingEngine);
                 model.put(Attributes.TAG, tag);
-                Map<String, Object> map = buildSimpleModel(Attributes.TAG);
+                DocumentModel map = buildSimpleModel(Attributes.TAG);
+                map.setRootPath(FileUtil.getUriPathToDestinationRoot(config, path));
                 model.put("content", map);
 
-                File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + tag + config.getOutputExtension());
-                map.put(Attributes.ROOTPATH, FileUtil.getUriPathToDestinationRoot(config, path));
 
                 render(new ModelRenderingConfig(path, Attributes.TAG, model, findTemplateName(Attributes.TAG)));
 
@@ -291,12 +295,14 @@ public class Renderer {
                 // This will prevent directory listing and also provide an option to
                 // display all tags page.
                 Map<String, Object> model = new HashMap<String, Object>();
+                File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + "index" + config.getOutputExtension());
+
                 model.put("renderer", renderingEngine);
-                Map<String, Object> map = buildSimpleModel(Attributes.TAGS);
+                DocumentModel map = buildSimpleModel(DocumentAttributes.TAGS.toString());
+                map.setRootPath(FileUtil.getUriPathToDestinationRoot(config, path));
                 model.put("content", map);
 
-                File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + "index" + config.getOutputExtension());
-                map.put(Attributes.ROOTPATH, FileUtil.getUriPathToDestinationRoot(config, path));
+
                 render(new ModelRenderingConfig(path, "tagindex", model, findTemplateName("tagsindex")));
                 renderedCount++;
             } catch (Exception e) {
@@ -320,12 +326,12 @@ public class Renderer {
      * Builds simple map of values, which are exposed when rendering index/archive/sitemap/feed/tags.
      *
      * @param type
-     * @return
+     * @return a basic {@link DocumentModel}
      */
-    private Map<String, Object> buildSimpleModel(String type) {
-        Map<String, Object> content = new HashMap<String, Object>();
-        content.put(Attributes.TYPE, type);
-        content.put(Attributes.ROOTPATH, "");
+    private DocumentModel buildSimpleModel(String type) {
+        DocumentModel content = new DocumentModel();
+        content.setType(type);
+        content.setRootPath("");
         // add any more keys here that need to have a default value to prevent need to perform null check in templates
         return content;
     }

--- a/jbake-core/src/main/java/org/jbake/app/Renderer.java
+++ b/jbake-core/src/main/java/org/jbake/app/Renderer.java
@@ -126,7 +126,7 @@ public class Renderer {
             Files.delete(publishedFile.toPath());
         }
 
-        if (content.getStatus().equals(Crawler.Attributes.Status.DRAFT)) {
+        if (content.getStatus().equals(ModelAttributes.Status.DRAFT)) {
             outputFilename = outputFilename + config.getDraftSuffix();
         }
 

--- a/jbake-core/src/main/java/org/jbake/app/Renderer.java
+++ b/jbake-core/src/main/java/org/jbake/app/Renderer.java
@@ -1,7 +1,6 @@
 package org.jbake.app;
 
 import org.apache.commons.configuration.CompositeConfiguration;
-import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfigurationFactory;
@@ -17,10 +16,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.util.HashMap;
+import java.nio.file.Files;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Render output to a file.
@@ -33,7 +31,7 @@ public class Renderer {
     private static final String FEED_TEMPLATE_NAME = "feed";
     private static final String ARCHIVE_TEMPLATE_NAME = "archive";
 
-    private final Logger LOGGER = LoggerFactory.getLogger(Renderer.class);
+    private final Logger logger = LoggerFactory.getLogger(Renderer.class);
     private final JBakeConfiguration config;
     private final DelegatingTemplateEngine renderingEngine;
     private final ContentStore db;
@@ -108,9 +106,9 @@ public class Renderer {
      * @param content The content to renderDocument
      * @throws Exception if IOException or SecurityException are raised
      */
-    public void render(Map<String, Object> content) throws Exception {
-        String docType = (String) content.get(DocumentAttributes.TYPE.toString());
-        String outputFilename = config.getDestinationFolder().getPath() + File.separatorChar + content.get(DocumentAttributes.URI.toString());
+    public void render(DocumentModel content) throws Exception {
+        String docType = content.getType();
+        String outputFilename = config.getDestinationFolder().getPath() + File.separatorChar + content.getUri();
         if (outputFilename.lastIndexOf('.') > outputFilename.lastIndexOf(File.separatorChar)) {
             outputFilename = outputFilename.substring(0, outputFilename.lastIndexOf('.'));
         }
@@ -119,30 +117,30 @@ public class Renderer {
         String outputExtension = config.getOutputExtensionByDocType(docType);
         File draftFile = new File(outputFilename, config.getDraftSuffix() + outputExtension);
         if (draftFile.exists()) {
-            draftFile.delete();
+            Files.delete(draftFile.toPath());
         }
 
         File publishedFile = new File(outputFilename + outputExtension);
         if (publishedFile.exists()) {
-            publishedFile.delete();
+            Files.delete(publishedFile.toPath());
         }
 
-        if (content.get(DocumentAttributes.STATUS.toString()).equals(Crawler.Attributes.Status.DRAFT)) {
+        if (content.getStatus().equals(Crawler.Attributes.Status.DRAFT)) {
             outputFilename = outputFilename + config.getDraftSuffix();
         }
 
         File outputFile = new File(outputFilename + outputExtension);
-        Map<String, Object> model = new HashMap<String, Object>();
-        model.put("content", content);
-        model.put("renderer", renderingEngine);
+        DocumentModel model = new DocumentModel();
+        model.setContent(content);
+        model.setRenderer(renderingEngine);
 
         try {
             try (Writer out = createWriter(outputFile)) {
                 renderingEngine.renderDocument(model, findTemplateName(docType), out);
             }
-            LOGGER.info("Rendering [{}]... done!", outputFile);
+            logger.info("Rendering [{}]... done!", outputFile);
         } catch (Exception e) {
-            LOGGER.error("Rendering [{}]... failed!", outputFile, e);
+            logger.error("Rendering [{}]... failed!", outputFile, e);
             throw new Exception("Failed to render file " + outputFile.getAbsolutePath() + ". Cause: " + e.getMessage(), e);
         }
     }
@@ -162,9 +160,9 @@ public class Renderer {
             try (Writer out = createWriter(outputFile)) {
                 renderingEngine.renderDocument(renderConfig.getModel(), renderConfig.getTemplate(), out);
             }
-            LOGGER.info("Rendering {} [{}]... done!", renderConfig.getName(), outputFile);
+            logger.info("Rendering {} [{}]... done!", renderConfig.getName(), outputFile);
         } catch (Exception e) {
-            LOGGER.error("Rendering {} [{}]... failed!", renderConfig.getName(), outputFile, e);
+            logger.error("Rendering {} [{}]... failed!", renderConfig.getName(), outputFile, e);
             throw new Exception("Failed to render " + renderConfig.getName(), e);
         }
     }
@@ -190,9 +188,9 @@ public class Renderer {
         } else {
             PagingHelper pagingHelper = new PagingHelper(totalPosts, postsPerPage);
 
-            Map<String, Object> model = new HashMap<String, Object>();
-            model.put("renderer", renderingEngine);
-            model.put("numberOfPages", pagingHelper.getNumberOfPages());
+            DocumentModel model = new DocumentModel();
+            model.setRenderer(renderingEngine);
+            model.setNumberOfPages(pagingHelper.getNumberOfPages());
 
             try {
                 db.setLimit(postsPerPage);
@@ -200,18 +198,18 @@ public class Renderer {
                     String fileName = indexFile;
 
                     db.setStart(pageStart);
-                    model.put("currentPageNumber", page);
+                    model.setCurrentPageNuber(page);
                     String previous = pagingHelper.getPreviousFileName(page);
-                    model.put("previousFileName", previous);
+                    model.setPreviousFilename(previous);
                     String nextFileName = pagingHelper.getNextFileName(page);
-                    model.put("nextFileName", nextFileName);
+                    model.setNextFileName(nextFileName);
 
                     DocumentModel contentModel = buildSimpleModel(MASTERINDEX_TEMPLATE_NAME);
 
                     if (page > 1) {
                         contentModel.setRootPath("../");
                     }
-                    model.put("content", contentModel);
+                    model.setContent(contentModel);
 
                     // Add page number to file name
                     fileName = pagingHelper.getCurrentFileName(page, fileName);
@@ -270,18 +268,15 @@ public class Renderer {
 
         for (String tag : db.getAllTags()) {
             try {
-
-                Map<String, Object> model = new HashMap<>();
+                DocumentModel model = new DocumentModel();
                 File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + tag + config.getOutputExtension());
-
-                model.put("renderer", renderingEngine);
-                model.put(Attributes.TAG, tag);
-                DocumentModel map = buildSimpleModel(Attributes.TAG);
+                model.setRenderer(renderingEngine);
+                model.setTag(tag);
+                DocumentModel map = buildSimpleModel(DocumentAttributes.TAG.toString());
                 map.setRootPath(FileUtil.getUriPathToDestinationRoot(config, path));
-                model.put("content", map);
+                model.setContent(map);
 
-
-                render(new ModelRenderingConfig(path, Attributes.TAG, model, findTemplateName(Attributes.TAG)));
+                render(new ModelRenderingConfig(path, DocumentAttributes.TAG.toString(), model, findTemplateName(DocumentAttributes.TAG.toString())));
 
                 renderedCount++;
             } catch (Exception e) {
@@ -294,7 +289,7 @@ public class Renderer {
                 // Add an index file at root folder of tags.
                 // This will prevent directory listing and also provide an option to
                 // display all tags page.
-                Map<String, Object> model = new HashMap<String, Object>();
+                DocumentModel model = new DocumentModel();
                 File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + "index" + config.getOutputExtension());
 
                 model.put("renderer", renderingEngine);
@@ -344,10 +339,10 @@ public class Renderer {
 
         String getTemplate();
 
-        Map<String, Object> getModel();
+        DocumentModel getModel();
     }
 
-    private static abstract class AbstractRenderingConfig implements RenderingConfig {
+    private abstract static class AbstractRenderingConfig implements RenderingConfig {
 
         protected final File path;
         protected final String name;
@@ -378,20 +373,20 @@ public class Renderer {
     }
 
     public class ModelRenderingConfig extends AbstractRenderingConfig {
-        private final Map<String, Object> model;
+        private final DocumentModel model;
 
-        public ModelRenderingConfig(String fileName, Map<String, Object> model, String templateType) {
+        public ModelRenderingConfig(String fileName, DocumentModel model, String templateType) {
             super(new File(config.getDestinationFolder(), fileName), fileName, findTemplateName(templateType));
             this.model = model;
         }
 
-        public ModelRenderingConfig(File path, String name, Map<String, Object> model, String template) {
+        public ModelRenderingConfig(File path, String name, DocumentModel model, String template) {
             super(path, name, template);
             this.model = model;
         }
 
         @Override
-        public Map<String, Object> getModel() {
+        public DocumentModel getModel() {
             return model;
         }
     }
@@ -421,8 +416,8 @@ public class Renderer {
         }
 
         @Override
-        public Map<String, Object> getModel() {
-            Map<String, Object> model = new HashMap<String, Object>();
+        public DocumentModel getModel() {
+            DocumentModel model = new DocumentModel();
             model.put("renderer", renderingEngine);
             model.put("content", content);
 

--- a/jbake-core/src/main/java/org/jbake/app/Renderer.java
+++ b/jbake-core/src/main/java/org/jbake/app/Renderer.java
@@ -4,9 +4,10 @@ import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfigurationFactory;
-import org.jbake.model.DocumentAttributes;
 import org.jbake.model.DocumentModel;
+import org.jbake.model.ModelAttributes;
 import org.jbake.template.DelegatingTemplateEngine;
+import org.jbake.template.model.TemplateModel;
 import org.jbake.util.PagingHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -130,7 +131,7 @@ public class Renderer {
         }
 
         File outputFile = new File(outputFilename + outputExtension);
-        DocumentModel model = new DocumentModel();
+        TemplateModel model = new TemplateModel();
         model.setContent(content);
         model.setRenderer(renderingEngine);
 
@@ -188,7 +189,7 @@ public class Renderer {
         } else {
             PagingHelper pagingHelper = new PagingHelper(totalPosts, postsPerPage);
 
-            DocumentModel model = new DocumentModel();
+            TemplateModel model = new TemplateModel();
             model.setRenderer(renderingEngine);
             model.setNumberOfPages(pagingHelper.getNumberOfPages());
 
@@ -268,15 +269,16 @@ public class Renderer {
 
         for (String tag : db.getAllTags()) {
             try {
-                DocumentModel model = new DocumentModel();
-                File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + tag + config.getOutputExtension());
+                TemplateModel model = new TemplateModel();
                 model.setRenderer(renderingEngine);
                 model.setTag(tag);
-                DocumentModel map = buildSimpleModel(DocumentAttributes.TAG.toString());
+                DocumentModel map = buildSimpleModel(ModelAttributes.TAG.toString());
+                File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + tag + config.getOutputExtension());
+
                 map.setRootPath(FileUtil.getUriPathToDestinationRoot(config, path));
                 model.setContent(map);
 
-                render(new ModelRenderingConfig(path, DocumentAttributes.TAG.toString(), model, findTemplateName(DocumentAttributes.TAG.toString())));
+                render(new ModelRenderingConfig(path, ModelAttributes.TAG.toString(), model, findTemplateName(ModelAttributes.TAG.toString())));
 
                 renderedCount++;
             } catch (Exception e) {
@@ -289,11 +291,11 @@ public class Renderer {
                 // Add an index file at root folder of tags.
                 // This will prevent directory listing and also provide an option to
                 // display all tags page.
-                DocumentModel model = new DocumentModel();
+                TemplateModel model = new TemplateModel();
+                model.put("renderer", renderingEngine);
+                DocumentModel map = buildSimpleModel(ModelAttributes.TAGS.toString());
                 File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + "index" + config.getOutputExtension());
 
-                model.put("renderer", renderingEngine);
-                DocumentModel map = buildSimpleModel(DocumentAttributes.TAGS.toString());
                 map.setRootPath(FileUtil.getUriPathToDestinationRoot(config, path));
                 model.put("content", map);
 
@@ -339,7 +341,7 @@ public class Renderer {
 
         String getTemplate();
 
-        DocumentModel getModel();
+        TemplateModel getModel();
     }
 
     private abstract static class AbstractRenderingConfig implements RenderingConfig {
@@ -373,27 +375,27 @@ public class Renderer {
     }
 
     public class ModelRenderingConfig extends AbstractRenderingConfig {
-        private final DocumentModel model;
+        private final TemplateModel model;
 
-        public ModelRenderingConfig(String fileName, DocumentModel model, String templateType) {
+        public ModelRenderingConfig(String fileName, TemplateModel model, String templateType) {
             super(new File(config.getDestinationFolder(), fileName), fileName, findTemplateName(templateType));
             this.model = model;
         }
 
-        public ModelRenderingConfig(File path, String name, DocumentModel model, String template) {
+        public ModelRenderingConfig(File path, String name, TemplateModel model, String template) {
             super(path, name, template);
             this.model = model;
         }
 
         @Override
-        public DocumentModel getModel() {
+        public TemplateModel getModel() {
             return model;
         }
     }
 
     class DefaultRenderingConfig extends AbstractRenderingConfig {
 
-        private final Object content;
+        private final DocumentModel content;
 
         private DefaultRenderingConfig(File path, String allInOneName) {
             super(path, allInOneName, findTemplateName(allInOneName));
@@ -416,10 +418,10 @@ public class Renderer {
         }
 
         @Override
-        public DocumentModel getModel() {
-            DocumentModel model = new DocumentModel();
-            model.put("renderer", renderingEngine);
-            model.put("content", content);
+        public TemplateModel getModel() {
+            TemplateModel model = new TemplateModel();
+            model.setRenderer(renderingEngine);
+            model.setContent(content);
 
             if (config.getPaginateIndex()) {
                 model.put("numberOfPages", 0);

--- a/jbake-core/src/main/java/org/jbake/app/Renderer.java
+++ b/jbake-core/src/main/java/org/jbake/app/Renderer.java
@@ -292,12 +292,12 @@ public class Renderer {
                 // This will prevent directory listing and also provide an option to
                 // display all tags page.
                 TemplateModel model = new TemplateModel();
-                model.put("renderer", renderingEngine);
+                model.setRenderer(renderingEngine);
                 DocumentModel map = buildSimpleModel(ModelAttributes.TAGS.toString());
                 File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + "index" + config.getOutputExtension());
 
                 map.setRootPath(FileUtil.getUriPathToDestinationRoot(config, path));
-                model.put("content", map);
+                model.setContent(map);
 
 
                 render(new ModelRenderingConfig(path, "tagindex", model, findTemplateName("tagsindex")));
@@ -424,10 +424,10 @@ public class Renderer {
             model.setContent(content);
 
             if (config.getPaginateIndex()) {
-                model.put("numberOfPages", 0);
-                model.put("currentPageNumber", 0);
-                model.put("previousFileName", "");
-                model.put("nextFileName", "");
+                model.setNumberOfPages(0);
+                model.setCurrentPageNuber(0);
+                model.setPreviousFilename("");
+                model.setNextFileName("");
             }
 
             return model;

--- a/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
 public class DefaultJBakeConfiguration implements JBakeConfiguration {
 
 
+    public static final String DEFAULT_TYHMELEAF_TEMPLATE_MODE = "HTML";
     private static final String SOURCE_FOLDER_KEY = "sourceFolder";
     private static final String DESTINATION_FOLDER_KEY = "destinationFolder";
     private static final String ASSET_FOLDER_KEY = "assetFolder";
@@ -488,6 +489,12 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
     @Override
     public String getServerHostname() {
         return getAsString(JBakeProperty.SERVER_HOSTNAME);
+    }
+
+    @Override
+    public String getThymeleafModeByType(String type) {
+        String key = "template_" + type + "_thymeleaf_mode";
+        return getAsString(key, DEFAULT_TYHMELEAF_TEMPLATE_MODE);
     }
 
     public void setTemplateExtensionForDocType(String docType, String extension) {

--- a/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
@@ -11,8 +11,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -495,6 +497,25 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
     public String getThymeleafModeByType(String type) {
         String key = "template_" + type + "_thymeleaf_mode";
         return getAsString(key, DEFAULT_TYHMELEAF_TEMPLATE_MODE);
+    }
+
+    @Override
+    public Map<String, Object> asHashMap() {
+        HashMap<String, Object> configModel = new HashMap<>();
+        Iterator<String> configKeys = this.getKeys();
+        while (configKeys.hasNext()) {
+            String key = configKeys.next();
+            Object valueObject;
+
+            if (key.equals(JBakeProperty.PAGINATE_INDEX)) {
+                valueObject = this.getPaginateIndex();
+            } else {
+                valueObject = this.get(key);
+            }
+            //replace "." in key so you can use dot notation in templates
+            configModel.put(key.replace(".", "_"), valueObject);
+        }
+        return configModel;
     }
 
     public void setTemplateExtensionForDocType(String docType, String extension) {

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
@@ -3,6 +3,7 @@ package org.jbake.app.configuration;
 import java.io.File;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * JBakeConfiguration gives you access to the project configuration. Typically located in a file called jbake.properties.
@@ -313,6 +314,8 @@ public interface JBakeConfiguration {
      * @return the the thymeleaf render mode ( defaults to {@link DefaultJBakeConfiguration#DEFAULT_TYHMELEAF_TEMPLATE_MODE} )
      */
     String getThymeleafModeByType(String type);
+
+    Map<String, Object> asHashMap();
 
     String getServerContextPath();
 

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 /**
  * JBakeConfiguration gives you access to the project configuration. Typically located in a file called jbake.properties.
- *
+ * <p>
  * Use one of {@link JBakeConfigurationFactory} methods to create an instance.
  */
 public interface JBakeConfiguration {
@@ -306,6 +306,13 @@ public interface JBakeConfiguration {
      * @param value the value of the property
      */
     void setProperty(String key, Object value);
+
+    /**
+     *
+     * @param type the documents type
+     * @return the the thymeleaf render mode ( defaults to {@link DefaultJBakeConfiguration#DEFAULT_TYHMELEAF_TEMPLATE_MODE} )
+     */
+    String getThymeleafModeByType(String type);
 
     String getServerContextPath();
 

--- a/jbake-core/src/main/java/org/jbake/model/BaseModel.java
+++ b/jbake-core/src/main/java/org/jbake/model/BaseModel.java
@@ -5,14 +5,14 @@ import java.util.HashMap;
 public abstract class BaseModel extends HashMap<String, Object> {
 
     public String getUri() {
-        return (String) get(ModelAttributes.URI.toString());
+        return (String) get(ModelAttributes.URI);
     }
 
     public void setUri(String uri) {
-        put(ModelAttributes.URI.toString(), uri);
+        put(ModelAttributes.URI, uri);
     }
 
     public void setName(String name) {
-        put(ModelAttributes.NAME.toString(), name);
+        put(ModelAttributes.NAME, name);
     }
 }

--- a/jbake-core/src/main/java/org/jbake/model/BaseModel.java
+++ b/jbake-core/src/main/java/org/jbake/model/BaseModel.java
@@ -1,0 +1,18 @@
+package org.jbake.model;
+
+import java.util.HashMap;
+
+public abstract class BaseModel extends HashMap<String, Object> {
+
+    public String getUri() {
+        return (String) get(ModelAttributes.URI.toString());
+    }
+
+    public void setUri(String uri) {
+        put(ModelAttributes.URI.toString(), uri);
+    }
+
+    public void setName(String name) {
+        put(ModelAttributes.NAME.toString(), name);
+    }
+}

--- a/jbake-core/src/main/java/org/jbake/model/DocumentAttributes.java
+++ b/jbake-core/src/main/java/org/jbake/model/DocumentAttributes.java
@@ -15,7 +15,19 @@ public enum DocumentAttributes {
     ROOTPATH("rootpath"),
     FILE("file"),
     NO_EXTENSION_URI("noExtensionUri"),
-    TITLE("title");
+    TITLE("title"),
+    TAGGED_POSTS("tagged_posts"),
+    TAGGED_DOCUMENTS("tagged_documents"),
+    NEXT_CONTENT("nextContent"),
+    PREVIOUS_CONTENT("previousContent"),
+    CONFIG("config"),
+    CONTENT("content"),
+    RENDERER("renderer"),
+    NUMBER_OF_PAGES("numberOfPages"),
+    CURRENT_PAGE_NUMBERS("currentPageNumber"),
+    PREVIOUS_FILENAME("previousFileName"),
+    NEXT_FILENAME("nextFileName"),
+    TAG("tag");
 
     private String label;
 

--- a/jbake-core/src/main/java/org/jbake/model/DocumentAttributes.java
+++ b/jbake-core/src/main/java/org/jbake/model/DocumentAttributes.java
@@ -4,9 +4,18 @@ public enum DocumentAttributes {
     SHA1("sha1"),
     SOURCE_URI("sourceuri"),
     RENDERED("rendered"),
-    CACHED("cached"),
+    CACHED("cached"), //TODO: Do we need this?
     STATUS("status"),
-    NAME("name");
+    NAME("name"),
+    BODY("body"),
+    DATE("date"),
+    TYPE("type"),
+    TAGS("tags"),
+    URI("uri"),
+    ROOTPATH("rootpath"),
+    FILE("file"),
+    NO_EXTENSION_URI("noExtensionUri"),
+    TITLE("title");
 
     private String label;
 

--- a/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
+++ b/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
@@ -1,7 +1,14 @@
 package org.jbake.model;
 
+import org.jbake.app.Crawler;
+import org.jbake.app.DBUtil;
+import org.jbake.app.DocumentList;
+import org.jbake.template.DelegatingTemplateEngine;
+
+import javax.swing.text.Document;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 
 public class DocumentModel extends HashMap<String, Object> {
 
@@ -50,7 +57,7 @@ public class DocumentModel extends HashMap<String, Object> {
     }
 
     public String[] getTags() {
-        return (String[]) get(DocumentAttributes.TAGS.toString());
+        return DBUtil.toStringArray(get(DocumentAttributes.TAGS.toString()));
     }
 
     public void setTags(String[] tags) {
@@ -81,6 +88,10 @@ public class DocumentModel extends HashMap<String, Object> {
         put(DocumentAttributes.ROOTPATH.toString(), pathToRoot);
     }
 
+    public Boolean getRendered() {
+        return (Boolean) get(DocumentAttributes.RENDERED.toString());
+    }
+
     public void setRendered(boolean rendered) {
         put(DocumentAttributes.RENDERED.toString(), rendered);
     }
@@ -97,6 +108,10 @@ public class DocumentModel extends HashMap<String, Object> {
         put(DocumentAttributes.NO_EXTENSION_URI.toString(), noExtensionUri);
     }
 
+    public String getTitle() {
+        return (String) get(DocumentAttributes.TITLE.toString());
+    }
+
     public void setTitle(String title) {
         put(DocumentAttributes.TITLE.toString(), title);
     }
@@ -111,5 +126,61 @@ public class DocumentModel extends HashMap<String, Object> {
 
     public boolean getCached() {
         return (boolean) get(DocumentAttributes.CACHED.toString());
+    }
+
+    public void setTaggedPosts(DocumentList taggedPosts) {
+        put(DocumentAttributes.TAGGED_POSTS.toString(), taggedPosts);
+    }
+
+    public void setTaggedDocuments(DocumentList taggedDocuments) {
+        put(DocumentAttributes.TAGGED_DOCUMENTS.toString(), taggedDocuments);
+    }
+
+    public void setNextContent(DocumentModel nextDocumentModel) {
+        put(DocumentAttributes.NEXT_CONTENT.toString(), nextDocumentModel);
+    }
+
+    public void setPreviousContent(DocumentModel previousDocumentModel) {
+        put(DocumentAttributes.PREVIOUS_CONTENT.toString(), previousDocumentModel);
+    }
+
+    public Map<String, Object> getConfig() {
+        return (Map<String, Object>) get(DocumentAttributes.CONFIG.toString());
+    }
+
+    public void setConfig(Map<String, Object> configModel) {
+        put(DocumentAttributes.CONFIG.toString(), configModel);
+    }
+
+    public void setContent(DocumentModel content) {
+        put(DocumentAttributes.CONTENT.toString(), content);
+    }
+
+    public DocumentModel getContent() {
+        return (DocumentModel) get(DocumentAttributes.CONTENT.toString());
+    }
+
+    public void setRenderer(DelegatingTemplateEngine renderingEngine) {
+        put(DocumentAttributes.RENDERER.toString(), renderingEngine);
+    }
+
+    public void setNumberOfPages(int numberOfPages) {
+        put(DocumentAttributes.NUMBER_OF_PAGES.toString(), numberOfPages);
+    }
+
+    public void setCurrentPageNuber(int currentPageNumber) {
+        put(DocumentAttributes.CURRENT_PAGE_NUMBERS.toString(), currentPageNumber);
+    }
+
+    public void setPreviousFilename(String previousFilename) {
+        put(DocumentAttributes.PREVIOUS_FILENAME.toString(), previousFilename);
+    }
+
+    public void setNextFileName(String nextFilename) {
+        put(DocumentAttributes.NEXT_FILENAME.toString(), nextFilename);
+    }
+
+    public void setTag(String tag) {
+        put(DocumentAttributes.TAG.toString(), tag);
     }
 }

--- a/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
+++ b/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
@@ -1,186 +1,112 @@
 package org.jbake.model;
 
-import org.jbake.app.Crawler;
 import org.jbake.app.DBUtil;
 import org.jbake.app.DocumentList;
-import org.jbake.template.DelegatingTemplateEngine;
 
-import javax.swing.text.Document;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
-public class DocumentModel extends HashMap<String, Object> {
-
-
-    public DocumentModel() {
-        super();
-    }
+public class DocumentModel extends BaseModel {
 
     public String getBody() {
-        return get(DocumentAttributes.BODY.toString()).toString();
+        return get(ModelAttributes.BODY.toString()).toString();
     }
 
     public void setBody(String body) {
-        put(DocumentAttributes.BODY.toString(), body);
+        put(ModelAttributes.BODY.toString(), body);
     }
 
     public Date getDate() {
-        return (Date) get(DocumentAttributes.DATE.toString());
+        return (Date) get(ModelAttributes.DATE.toString());
     }
 
     public void setDate(Date date) {
-        put(DocumentAttributes.DATE.toString(), date);
+        put(ModelAttributes.DATE.toString(), date);
     }
 
     public String getStatus() {
-        if (containsKey(DocumentAttributes.STATUS.toString())) {
-            return get(DocumentAttributes.STATUS.toString()).toString();
+        if (containsKey(ModelAttributes.STATUS.toString())) {
+            return get(ModelAttributes.STATUS.toString()).toString();
         }
         return "";
 
     }
 
     public void setStatus(String status) {
-        put(DocumentAttributes.STATUS.toString(), status);
+        put(ModelAttributes.STATUS.toString(), status);
     }
 
     public String getType() {
-        if (containsKey(DocumentAttributes.TYPE.toString())) {
-            return get(DocumentAttributes.TYPE.toString()).toString();
+        if (containsKey(ModelAttributes.TYPE.toString())) {
+            return get(ModelAttributes.TYPE.toString()).toString();
         }
         return "";
     }
 
     public void setType(String type) {
-        put(DocumentAttributes.TYPE.toString(), type);
+        put(ModelAttributes.TYPE.toString(), type);
     }
 
     public String[] getTags() {
-        return DBUtil.toStringArray(get(DocumentAttributes.TAGS.toString()));
+        return DBUtil.toStringArray(get(ModelAttributes.TAGS.toString()));
     }
 
     public void setTags(String[] tags) {
-        put(DocumentAttributes.TAGS.toString(), tags);
+        put(ModelAttributes.TAGS.toString(), tags);
     }
 
     public String getSha1() {
-        return (String) get(DocumentAttributes.SHA1.toString());
+        return (String) get(ModelAttributes.SHA1.toString());
     }
 
     public void setSha1(String sha1) {
-        put(DocumentAttributes.SHA1.toString(), sha1);
-    }
-
-    public String getUri() {
-        return (String) get(DocumentAttributes.URI.toString());
-    }
-
-    public void setUri(String uri) {
-        put(DocumentAttributes.URI.toString(), uri);
+        put(ModelAttributes.SHA1.toString(), sha1);
     }
 
     public void setSourceUri(String uri) {
-        put(DocumentAttributes.SOURCE_URI.toString(), uri);
+        put(ModelAttributes.SOURCE_URI.toString(), uri);
     }
 
     public void setRootPath(String pathToRoot) {
-        put(DocumentAttributes.ROOTPATH.toString(), pathToRoot);
+        put(ModelAttributes.ROOTPATH.toString(), pathToRoot);
     }
 
     public Boolean getRendered() {
-        return (Boolean) get(DocumentAttributes.RENDERED.toString());
+        return (Boolean) get(ModelAttributes.RENDERED.toString());
     }
 
     public void setRendered(boolean rendered) {
-        put(DocumentAttributes.RENDERED.toString(), rendered);
+        put(ModelAttributes.RENDERED.toString(), rendered);
     }
 
     public void setFile(String path) {
-        put(DocumentAttributes.FILE.toString(), path);
+        put(ModelAttributes.FILE.toString(), path);
     }
 
     public String getNoExtensionUri() {
-        return (String) get(DocumentAttributes.NO_EXTENSION_URI.toString());
+        return (String) get(ModelAttributes.NO_EXTENSION_URI.toString());
     }
 
     public void setNoExtensionUri(String noExtensionUri) {
-        put(DocumentAttributes.NO_EXTENSION_URI.toString(), noExtensionUri);
+        put(ModelAttributes.NO_EXTENSION_URI.toString(), noExtensionUri);
     }
 
     public String getTitle() {
-        return (String) get(DocumentAttributes.TITLE.toString());
+        return (String) get(ModelAttributes.TITLE.toString());
     }
 
     public void setTitle(String title) {
-        put(DocumentAttributes.TITLE.toString(), title);
-    }
-
-    public void setName(String name) {
-        put(DocumentAttributes.NAME.toString(), name);
+        put(ModelAttributes.TITLE.toString(), title);
     }
 
     public void setCached(boolean cached) {
-        put(DocumentAttributes.CACHED.toString(), cached);
-    }
-
-    public boolean getCached() {
-        return (boolean) get(DocumentAttributes.CACHED.toString());
-    }
-
-    public void setTaggedPosts(DocumentList taggedPosts) {
-        put(DocumentAttributes.TAGGED_POSTS.toString(), taggedPosts);
-    }
-
-    public void setTaggedDocuments(DocumentList taggedDocuments) {
-        put(DocumentAttributes.TAGGED_DOCUMENTS.toString(), taggedDocuments);
+        put(ModelAttributes.CACHED.toString(), cached);
     }
 
     public void setNextContent(DocumentModel nextDocumentModel) {
-        put(DocumentAttributes.NEXT_CONTENT.toString(), nextDocumentModel);
+        put(ModelAttributes.NEXT_CONTENT.toString(), nextDocumentModel);
     }
 
     public void setPreviousContent(DocumentModel previousDocumentModel) {
-        put(DocumentAttributes.PREVIOUS_CONTENT.toString(), previousDocumentModel);
-    }
-
-    public Map<String, Object> getConfig() {
-        return (Map<String, Object>) get(DocumentAttributes.CONFIG.toString());
-    }
-
-    public void setConfig(Map<String, Object> configModel) {
-        put(DocumentAttributes.CONFIG.toString(), configModel);
-    }
-
-    public void setContent(DocumentModel content) {
-        put(DocumentAttributes.CONTENT.toString(), content);
-    }
-
-    public DocumentModel getContent() {
-        return (DocumentModel) get(DocumentAttributes.CONTENT.toString());
-    }
-
-    public void setRenderer(DelegatingTemplateEngine renderingEngine) {
-        put(DocumentAttributes.RENDERER.toString(), renderingEngine);
-    }
-
-    public void setNumberOfPages(int numberOfPages) {
-        put(DocumentAttributes.NUMBER_OF_PAGES.toString(), numberOfPages);
-    }
-
-    public void setCurrentPageNuber(int currentPageNumber) {
-        put(DocumentAttributes.CURRENT_PAGE_NUMBERS.toString(), currentPageNumber);
-    }
-
-    public void setPreviousFilename(String previousFilename) {
-        put(DocumentAttributes.PREVIOUS_FILENAME.toString(), previousFilename);
-    }
-
-    public void setNextFileName(String nextFilename) {
-        put(DocumentAttributes.NEXT_FILENAME.toString(), nextFilename);
-    }
-
-    public void setTag(String tag) {
-        put(DocumentAttributes.TAG.toString(), tag);
+        put(ModelAttributes.PREVIOUS_CONTENT.toString(), previousDocumentModel);
     }
 }

--- a/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
+++ b/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
@@ -7,6 +7,12 @@ import java.util.Date;
 
 public class DocumentModel extends BaseModel {
 
+    public static DocumentModel createDefaultDocumentModel() {
+        DocumentModel documentModel = new DocumentModel();
+        documentModel.setCached(true);
+        return documentModel;
+    }
+
     public String getBody() {
         return (String) get(ModelAttributes.BODY);
     }
@@ -104,6 +110,16 @@ public class DocumentModel extends BaseModel {
 
     public void setTitle(String title) {
         put(ModelAttributes.TITLE, title);
+    }
+
+    public Boolean getCached() {
+
+        Object value = get(ModelAttributes.CACHED);
+        if ( value instanceof String ) {
+            return Boolean.valueOf((String) value);
+        } else {
+            return (Boolean) value;
+        }
     }
 
     public void setCached(boolean cached) {

--- a/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
+++ b/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
@@ -1,7 +1,6 @@
 package org.jbake.model;
 
 import org.jbake.app.DBUtil;
-import org.jbake.app.DocumentList;
 
 import java.util.Date;
 

--- a/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
+++ b/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
@@ -8,105 +8,113 @@ import java.util.Date;
 public class DocumentModel extends BaseModel {
 
     public String getBody() {
-        return get(ModelAttributes.BODY.toString()).toString();
+        return (String) get(ModelAttributes.BODY);
     }
 
     public void setBody(String body) {
-        put(ModelAttributes.BODY.toString(), body);
+        put(ModelAttributes.BODY, body);
     }
 
     public Date getDate() {
-        return (Date) get(ModelAttributes.DATE.toString());
+        return (Date) get(ModelAttributes.DATE);
     }
 
     public void setDate(Date date) {
-        put(ModelAttributes.DATE.toString(), date);
+        put(ModelAttributes.DATE, date);
     }
 
     public String getStatus() {
-        if (containsKey(ModelAttributes.STATUS.toString())) {
-            return get(ModelAttributes.STATUS.toString()).toString();
+        if (containsKey(ModelAttributes.STATUS)) {
+            return (String) get(ModelAttributes.STATUS);
         }
         return "";
 
     }
 
     public void setStatus(String status) {
-        put(ModelAttributes.STATUS.toString(), status);
+        put(ModelAttributes.STATUS, status);
     }
 
     public String getType() {
-        if (containsKey(ModelAttributes.TYPE.toString())) {
-            return get(ModelAttributes.TYPE.toString()).toString();
+        if (containsKey(ModelAttributes.TYPE)) {
+            return (String) get(ModelAttributes.TYPE);
         }
         return "";
     }
 
     public void setType(String type) {
-        put(ModelAttributes.TYPE.toString(), type);
+        put(ModelAttributes.TYPE, type);
     }
 
     public String[] getTags() {
-        return DBUtil.toStringArray(get(ModelAttributes.TAGS.toString()));
+        return DBUtil.toStringArray(get(ModelAttributes.TAGS));
     }
 
     public void setTags(String[] tags) {
-        put(ModelAttributes.TAGS.toString(), tags);
+        put(ModelAttributes.TAGS, tags);
     }
 
     public String getSha1() {
-        return (String) get(ModelAttributes.SHA1.toString());
+        return (String) get(ModelAttributes.SHA1);
     }
 
     public void setSha1(String sha1) {
-        put(ModelAttributes.SHA1.toString(), sha1);
+        put(ModelAttributes.SHA1, sha1);
     }
 
     public void setSourceUri(String uri) {
-        put(ModelAttributes.SOURCE_URI.toString(), uri);
+        put(ModelAttributes.SOURCE_URI, uri);
+    }
+
+    public String getRootPath() {
+        return (String) get(ModelAttributes.ROOTPATH);
     }
 
     public void setRootPath(String pathToRoot) {
-        put(ModelAttributes.ROOTPATH.toString(), pathToRoot);
+        put(ModelAttributes.ROOTPATH, pathToRoot);
     }
 
     public Boolean getRendered() {
-        return (Boolean) get(ModelAttributes.RENDERED.toString());
+        return (Boolean) get(ModelAttributes.RENDERED);
     }
 
     public void setRendered(boolean rendered) {
-        put(ModelAttributes.RENDERED.toString(), rendered);
+        put(ModelAttributes.RENDERED, rendered);
+    }
+
+    public String getFile() {
+        return (String) get(ModelAttributes.FILE);
     }
 
     public void setFile(String path) {
-        put(ModelAttributes.FILE.toString(), path);
+        put(ModelAttributes.FILE, path);
     }
 
     public String getNoExtensionUri() {
-        return (String) get(ModelAttributes.NO_EXTENSION_URI.toString());
+        return (String) get(ModelAttributes.NO_EXTENSION_URI);
     }
 
     public void setNoExtensionUri(String noExtensionUri) {
-        put(ModelAttributes.NO_EXTENSION_URI.toString(), noExtensionUri);
+        put(ModelAttributes.NO_EXTENSION_URI, noExtensionUri);
     }
 
     public String getTitle() {
-        return (String) get(ModelAttributes.TITLE.toString());
+        return (String) get(ModelAttributes.TITLE);
     }
 
     public void setTitle(String title) {
-        put(ModelAttributes.TITLE.toString(), title);
+        put(ModelAttributes.TITLE, title);
     }
 
     public void setCached(boolean cached) {
-        put(ModelAttributes.CACHED.toString(), cached);
+        put(ModelAttributes.CACHED, cached);
     }
 
     public void setNextContent(DocumentModel nextDocumentModel) {
-        put(ModelAttributes.NEXT_CONTENT.toString(), nextDocumentModel);
+        put(ModelAttributes.NEXT_CONTENT, nextDocumentModel);
     }
 
     public void setPreviousContent(DocumentModel previousDocumentModel) {
-        put(ModelAttributes.PREVIOUS_CONTENT.toString(), previousDocumentModel);
+        put(ModelAttributes.PREVIOUS_CONTENT, previousDocumentModel);
     }
 }

--- a/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
+++ b/jbake-core/src/main/java/org/jbake/model/DocumentModel.java
@@ -1,0 +1,115 @@
+package org.jbake.model;
+
+import java.util.Date;
+import java.util.HashMap;
+
+public class DocumentModel extends HashMap<String, Object> {
+
+
+    public DocumentModel() {
+        super();
+    }
+
+    public String getBody() {
+        return get(DocumentAttributes.BODY.toString()).toString();
+    }
+
+    public void setBody(String body) {
+        put(DocumentAttributes.BODY.toString(), body);
+    }
+
+    public Date getDate() {
+        return (Date) get(DocumentAttributes.DATE.toString());
+    }
+
+    public void setDate(Date date) {
+        put(DocumentAttributes.DATE.toString(), date);
+    }
+
+    public String getStatus() {
+        if (containsKey(DocumentAttributes.STATUS.toString())) {
+            return get(DocumentAttributes.STATUS.toString()).toString();
+        }
+        return "";
+
+    }
+
+    public void setStatus(String status) {
+        put(DocumentAttributes.STATUS.toString(), status);
+    }
+
+    public String getType() {
+        if (containsKey(DocumentAttributes.TYPE.toString())) {
+            return get(DocumentAttributes.TYPE.toString()).toString();
+        }
+        return "";
+    }
+
+    public void setType(String type) {
+        put(DocumentAttributes.TYPE.toString(), type);
+    }
+
+    public String[] getTags() {
+        return (String[]) get(DocumentAttributes.TAGS.toString());
+    }
+
+    public void setTags(String[] tags) {
+        put(DocumentAttributes.TAGS.toString(), tags);
+    }
+
+    public String getSha1() {
+        return (String) get(DocumentAttributes.SHA1.toString());
+    }
+
+    public void setSha1(String sha1) {
+        put(DocumentAttributes.SHA1.toString(), sha1);
+    }
+
+    public String getUri() {
+        return (String) get(DocumentAttributes.URI.toString());
+    }
+
+    public void setUri(String uri) {
+        put(DocumentAttributes.URI.toString(), uri);
+    }
+
+    public void setSourceUri(String uri) {
+        put(DocumentAttributes.SOURCE_URI.toString(), uri);
+    }
+
+    public void setRootPath(String pathToRoot) {
+        put(DocumentAttributes.ROOTPATH.toString(), pathToRoot);
+    }
+
+    public void setRendered(boolean rendered) {
+        put(DocumentAttributes.RENDERED.toString(), rendered);
+    }
+
+    public void setFile(String path) {
+        put(DocumentAttributes.FILE.toString(), path);
+    }
+
+    public String getNoExtensionUri() {
+        return (String) get(DocumentAttributes.NO_EXTENSION_URI.toString());
+    }
+
+    public void setNoExtensionUri(String noExtensionUri) {
+        put(DocumentAttributes.NO_EXTENSION_URI.toString(), noExtensionUri);
+    }
+
+    public void setTitle(String title) {
+        put(DocumentAttributes.TITLE.toString(), title);
+    }
+
+    public void setName(String name) {
+        put(DocumentAttributes.NAME.toString(), name);
+    }
+
+    public void setCached(boolean cached) {
+        put(DocumentAttributes.CACHED.toString(), cached);
+    }
+
+    public boolean getCached() {
+        return (boolean) get(DocumentAttributes.CACHED.toString());
+    }
+}

--- a/jbake-core/src/main/java/org/jbake/model/ModelAttributes.java
+++ b/jbake-core/src/main/java/org/jbake/model/ModelAttributes.java
@@ -1,43 +1,33 @@
 package org.jbake.model;
 
-public enum ModelAttributes {
-    SHA1("sha1"),
-    SOURCE_URI("sourceuri"),
-    RENDERED("rendered"),
-    CACHED("cached"), //TODO: Do we need this?
-    STATUS("status"),
-    NAME("name"),
-    BODY("body"),
-    DATE("date"),
-    TYPE("type"),
-    TAGS("tags"),
-    URI("uri"),
-    ROOTPATH("rootpath"),
-    FILE("file"),
-    NO_EXTENSION_URI("noExtensionUri"),
-    TITLE("title"),
-    TAGGED_POSTS("tagged_posts"),
-    TAGGED_DOCUMENTS("tagged_documents"),
-    NEXT_CONTENT("nextContent"),
-    PREVIOUS_CONTENT("previousContent"),
-    CONFIG("config"),
-    CONTENT("content"),
-    RENDERER("renderer"),
-    NUMBER_OF_PAGES("numberOfPages"),
-    CURRENT_PAGE_NUMBERS("currentPageNumber"),
-    PREVIOUS_FILENAME("previousFileName"),
-    NEXT_FILENAME("nextFileName"),
-    TAG("tag"),
-    VERSION("version");
-
-    private String label;
-
-    ModelAttributes(String label) {
-        this.label = label;
-    }
-
-    @Override
-    public String toString() {
-        return label;
-    }
+public abstract class ModelAttributes {
+    public static final String SHA1 = "sha1";
+    public static final String SOURCE_URI = "sourceuri";
+    public static final String RENDERED = "rendered";
+    public static final String CACHED = "cached"; //TODO: Do we need this?
+    public static final String STATUS = "status";
+    public static final String NAME = "name";
+    public static final String BODY = "body";
+    public static final String DATE = "date";
+    public static final String TYPE = "type";
+    public static final String TAGS = "tags";
+    public static final String URI = "uri";
+    public static final String ROOTPATH = "rootpath";
+    public static final String FILE = "file";
+    public static final String NO_EXTENSION_URI = "noExtensionUri";
+    public static final String TITLE = "title";
+    public static final String TAGGED_POSTS = "tagged_posts";
+    public static final String TAGGED_DOCUMENTS = "tagged_documents";
+    public static final String NEXT_CONTENT = "nextContent";
+    public static final String PREVIOUS_CONTENT = "previousContent";
+    public static final String CONFIG = "config";
+    public static final String CONTENT = "content";
+    public static final String RENDERER = "renderer";
+    public static final String NUMBER_OF_PAGES = "numberOfPages";
+    public static final String CURRENT_PAGE_NUMBERS = "currentPageNumber";
+    public static final String PREVIOUS_FILENAME = "previousFileName";
+    public static final String NEXT_FILENAME = "nextFileName";
+    public static final String TAG = "tag";
+    public static final String VERSION = "version";
+    public static final String OUT = "out";
 }

--- a/jbake-core/src/main/java/org/jbake/model/ModelAttributes.java
+++ b/jbake-core/src/main/java/org/jbake/model/ModelAttributes.java
@@ -30,4 +30,24 @@ public abstract class ModelAttributes {
     public static final String TAG = "tag";
     public static final String VERSION = "version";
     public static final String OUT = "out";
+    public static final String ALLTAGS = "alltags";
+    public static final String PUBLISHED_DATE = "published_date";
+    public static final String DB = "db";
+
+    private ModelAttributes() {
+    }
+
+    /**
+     * Possible values of the {@link ModelAttributes#STATUS} property
+     *
+     * @author ndx
+     */
+    public abstract static class Status {
+        public static final String PUBLISHED_DATE = "published-date";
+        public static final String PUBLISHED = "published";
+        public static final String DRAFT = "draft";
+
+        private Status() {
+        }
+    }
 }

--- a/jbake-core/src/main/java/org/jbake/model/ModelAttributes.java
+++ b/jbake-core/src/main/java/org/jbake/model/ModelAttributes.java
@@ -4,7 +4,7 @@ public abstract class ModelAttributes {
     public static final String SHA1 = "sha1";
     public static final String SOURCE_URI = "sourceuri";
     public static final String RENDERED = "rendered";
-    public static final String CACHED = "cached"; //TODO: Do we need this?
+    public static final String CACHED = "cached";
     public static final String STATUS = "status";
     public static final String NAME = "name";
     public static final String BODY = "body";

--- a/jbake-core/src/main/java/org/jbake/model/ModelAttributes.java
+++ b/jbake-core/src/main/java/org/jbake/model/ModelAttributes.java
@@ -1,6 +1,6 @@
 package org.jbake.model;
 
-public enum DocumentAttributes {
+public enum ModelAttributes {
     SHA1("sha1"),
     SOURCE_URI("sourceuri"),
     RENDERED("rendered"),
@@ -27,11 +27,12 @@ public enum DocumentAttributes {
     CURRENT_PAGE_NUMBERS("currentPageNumber"),
     PREVIOUS_FILENAME("previousFileName"),
     NEXT_FILENAME("nextFileName"),
-    TAG("tag");
+    TAG("tag"),
+    VERSION("version");
 
     private String label;
 
-    DocumentAttributes(String label) {
+    ModelAttributes(String label) {
         this.label = label;
     }
 

--- a/jbake-core/src/main/java/org/jbake/parser/AsciidoctorEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/AsciidoctorEngine.java
@@ -13,11 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.asciidoctor.AttributesBuilder.attributes;
@@ -91,7 +87,7 @@ public class AsciidoctorEngine extends MarkupEngine {
         DocumentHeader header = asciidoctor.readDocumentHeader(context.getFile());
         DocumentModel documentModel = context.getDocumentModel();
         if (header.getDocumentTitle() != null) {
-            documentModel.put("title", header.getDocumentTitle().getCombined());
+            documentModel.setTitle(header.getDocumentTitle().getCombined());
         }
         Map<String, Object> attributes = header.getAttributes();
         for (Map.Entry<String, Object> attribute : attributes.entrySet()) {

--- a/jbake-core/src/main/java/org/jbake/parser/AsciidoctorEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/AsciidoctorEngine.java
@@ -6,6 +6,7 @@ import org.asciidoctor.Options;
 import org.asciidoctor.ast.DocumentHeader;
 import org.asciidoctor.jruby.AsciidoctorJRuby;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +89,7 @@ public class AsciidoctorEngine extends MarkupEngine {
         Options options = getAsciiDocOptionsAndAttributes(context);
         final Asciidoctor asciidoctor = getEngine(options);
         DocumentHeader header = asciidoctor.readDocumentHeader(context.getFile());
-        Map<String, Object> documentModel = context.getDocumentModel();
+        DocumentModel documentModel = context.getDocumentModel();
         if (header.getDocumentTitle() != null) {
             documentModel.put("title", header.getDocumentTitle().getCombined());
         }

--- a/jbake-core/src/main/java/org/jbake/parser/ErrorEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/ErrorEngine.java
@@ -1,9 +1,8 @@
 package org.jbake.parser;
 
-import org.jbake.app.Crawler.Attributes;
+import org.jbake.model.DocumentModel;
 
 import java.util.Date;
-import java.util.Map;
 
 /**
  * An internal rendering engine used to notify the user that the markup format he used requires an engine that couldn't
@@ -24,13 +23,12 @@ public class ErrorEngine extends MarkupEngine {
 
     @Override
     public void processHeader(final ParserContext context) {
-        Map<String, Object> contents = context.getDocumentModel();
-        contents.put(Attributes.TYPE, "post");
-        contents.put(Attributes.STATUS, "published");
-        contents.put(Attributes.TITLE, "Rendering engine missing");
-        contents.put(Attributes.DATE, new Date());
-        contents.put(Attributes.TAGS, new String[0]);
-        contents.put(Attributes.ID, context.getFile().getName());
+        DocumentModel documentModel = context.getDocumentModel();
+        documentModel.setType("post");
+        documentModel.setStatus("published");
+        documentModel.setTitle("Rendering engine missing");
+        documentModel.setDate(new Date());
+        documentModel.setTags(new String[0]);
     }
 
     @Override

--- a/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
@@ -266,14 +266,14 @@ public abstract class MarkupEngine implements ParserEngine {
         }
     }
 
-    private void processHeaderLine(String line, Map<String, Object> content) {
+    private void processHeaderLine(String line, DocumentModel content) {
         String[] parts = line.split("=", 2);
         if (!line.isEmpty() && parts.length == 2) {
             storeHeaderValue(parts[0], parts[1], content);
         }
     }
 
-    void storeHeaderValue(String inputKey, String inputValue, Map<String, Object> content) {
+    void storeHeaderValue(String inputKey, String inputValue, DocumentModel content) {
         String key = sanitize(inputKey);
         String value = sanitize(inputValue);
 
@@ -281,17 +281,18 @@ public abstract class MarkupEngine implements ParserEngine {
             DateFormat df = new SimpleDateFormat(configuration.getDateFormat());
             try {
                 Date date = df.parse(value);
-                content.put(key, date);
+                content.setDate(date);
             } catch (ParseException e) {
                 LOGGER.error("unable to parse date {}", value);
             }
         } else if (key.equalsIgnoreCase(DocumentAttributes.TAGS.toString())) {
-            content.put(key, getTags(value));
+            content.setTags(getTags(value));
         } else if (isJson(value)) {
             content.put(key, JSONValue.parse(value));
         } else {
             content.put(key, value);
         }
+
     }
 
     private String sanitize(String part) {

--- a/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
@@ -5,8 +5,8 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.io.IOUtils;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfiguration;
-import org.jbake.model.DocumentAttributes;
 import org.jbake.model.DocumentModel;
+import org.jbake.model.ModelAttributes;
 import org.json.simple.JSONValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -277,7 +277,7 @@ public abstract class MarkupEngine implements ParserEngine {
         String key = sanitize(inputKey);
         String value = sanitize(inputValue);
 
-        if (key.equalsIgnoreCase(DocumentAttributes.DATE.toString())) {
+        if (key.equalsIgnoreCase(ModelAttributes.DATE.toString())) {
             DateFormat df = new SimpleDateFormat(configuration.getDateFormat());
             try {
                 Date date = df.parse(value);
@@ -285,7 +285,7 @@ public abstract class MarkupEngine implements ParserEngine {
             } catch (ParseException e) {
                 LOGGER.error("unable to parse date {}", value);
             }
-        } else if (key.equalsIgnoreCase(DocumentAttributes.TAGS.toString())) {
+        } else if (key.equalsIgnoreCase(ModelAttributes.TAGS.toString())) {
             content.setTags(getTags(value));
         } else if (isJson(value)) {
             content.put(key, JSONValue.parse(value));

--- a/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
@@ -277,7 +277,7 @@ public abstract class MarkupEngine implements ParserEngine {
         String key = sanitize(inputKey);
         String value = sanitize(inputValue);
 
-        if (key.equalsIgnoreCase(ModelAttributes.DATE.toString())) {
+        if (key.equalsIgnoreCase(ModelAttributes.DATE)) {
             DateFormat df = new SimpleDateFormat(configuration.getDateFormat());
             try {
                 Date date = df.parse(value);
@@ -285,7 +285,7 @@ public abstract class MarkupEngine implements ParserEngine {
             } catch (ParseException e) {
                 LOGGER.error("unable to parse date {}", value);
             }
-        } else if (key.equalsIgnoreCase(ModelAttributes.TAGS.toString())) {
+        } else if (key.equalsIgnoreCase(ModelAttributes.TAGS)) {
             content.setTags(getTags(value));
         } else if (isJson(value)) {
             content.put(key, JSONValue.parse(value));

--- a/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
@@ -3,9 +3,10 @@ package org.jbake.parser;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.io.IOUtils;
-import org.jbake.app.Crawler;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentAttributes;
+import org.jbake.model.DocumentModel;
 import org.json.simple.JSONValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +76,7 @@ public abstract class MarkupEngine implements ParserEngine {
      * @param file file to process
      * @return a map containing all infos. Returning null indicates an error, even if an exception would be better.
      */
-    public Map<String, Object> parse(JBakeConfiguration config, File file) {
+    public DocumentModel parse(JBakeConfiguration config, File file) {
         this.configuration = config;
         List<String> fileContent = getFileContent(file, config.getRenderEncoding());
 
@@ -276,7 +277,7 @@ public abstract class MarkupEngine implements ParserEngine {
         String key = sanitize(inputKey);
         String value = sanitize(inputValue);
 
-        if (key.equalsIgnoreCase(Crawler.Attributes.DATE)) {
+        if (key.equalsIgnoreCase(DocumentAttributes.DATE.toString())) {
             DateFormat df = new SimpleDateFormat(configuration.getDateFormat());
             try {
                 Date date = df.parse(value);
@@ -284,7 +285,7 @@ public abstract class MarkupEngine implements ParserEngine {
             } catch (ParseException e) {
                 LOGGER.error("unable to parse date {}", value);
             }
-        } else if (key.equalsIgnoreCase(Crawler.Attributes.TAGS)) {
+        } else if (key.equalsIgnoreCase(DocumentAttributes.TAGS.toString())) {
             content.put(key, getTags(value));
         } else if (isJson(value)) {
             content.put(key, JSONValue.parse(value));

--- a/jbake-core/src/main/java/org/jbake/parser/ParserContext.java
+++ b/jbake-core/src/main/java/org/jbake/parser/ParserContext.java
@@ -23,7 +23,7 @@ public class ParserContext {
         this.fileLines = fileLines;
         this.config = config;
         this.hasHeader = hasHeader;
-        this.documentModel = new DocumentModel();
+        this.documentModel = DocumentModel.createDefaultDocumentModel();
     }
 
     public File getFile() {

--- a/jbake-core/src/main/java/org/jbake/parser/ParserContext.java
+++ b/jbake-core/src/main/java/org/jbake/parser/ParserContext.java
@@ -1,6 +1,5 @@
 package org.jbake.parser;
 
-import com.orientechnologies.orient.core.hook.ORecordHook;
 import org.jbake.app.Crawler;
 import org.jbake.app.configuration.JBakeConfiguration;
 

--- a/jbake-core/src/main/java/org/jbake/parser/ParserContext.java
+++ b/jbake-core/src/main/java/org/jbake/parser/ParserContext.java
@@ -1,20 +1,18 @@
 package org.jbake.parser;
 
-import org.jbake.app.Crawler;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentModel;
 
 import java.io.File;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class ParserContext {
     private final File file;
     private final List<String> fileLines;
     private final JBakeConfiguration config;
     private final boolean hasHeader;
-    private final Map<String,Object> documentModel;
+    private final DocumentModel documentModel;
 
     public ParserContext(
             File file,
@@ -25,7 +23,7 @@ public class ParserContext {
         this.fileLines = fileLines;
         this.config = config;
         this.hasHeader = hasHeader;
-        this.documentModel = new HashMap<>();
+        this.documentModel = new DocumentModel();
     }
 
     public File getFile() {
@@ -40,7 +38,7 @@ public class ParserContext {
         return config;
     }
 
-    public Map<String, Object> getDocumentModel() {
+    public DocumentModel getDocumentModel() {
         return documentModel;
     }
 
@@ -50,48 +48,48 @@ public class ParserContext {
 
     // short methods for common use
     public String getBody() {
-        return documentModel.get(Crawler.Attributes.BODY).toString();
+        return documentModel.getBody();
     }
 
     public void setBody(String str) {
-        documentModel.put(Crawler.Attributes.BODY, str);
+        documentModel.setBody(str);
     }
 
-    public Object getDate() {
-        return getDocumentModel().get(Crawler.Attributes.DATE);
+    public Date getDate() {
+        return getDocumentModel().getDate();
     }
 
     public void setDate(Date date) {
-        getDocumentModel().put(Crawler.Attributes.DATE, date);
+        getDocumentModel().setDate(date);
     }
 
     public String getStatus() {
-        if (getDocumentModel().containsKey(Crawler.Attributes.STATUS)) {
-            return getDocumentModel().get(Crawler.Attributes.STATUS).toString();
+        if (getDocumentModel().getStatus() != null) {
+            return getDocumentModel().getStatus();
         }
         return "";
     }
 
     public void setDefaultStatus() {
-        getDocumentModel().put(Crawler.Attributes.STATUS, getConfig().getDefaultStatus());
+        getDocumentModel().setStatus(getConfig().getDefaultStatus());
     }
 
     public String getType() {
-        if (getDocumentModel().containsKey(Crawler.Attributes.TYPE)) {
-            return getDocumentModel().get(Crawler.Attributes.TYPE).toString();
+        if (getDocumentModel().getType() != null) {
+            return getDocumentModel().getType();
         }
         return "";
     }
 
     public void setDefaultType() {
-        getDocumentModel().put(Crawler.Attributes.TYPE, getConfig().getDefaultType());
+        getDocumentModel().setType(getConfig().getDefaultType());
     }
 
     public Object getTags() {
-        return getDocumentModel().get(Crawler.Attributes.TAGS);
+        return getDocumentModel().getTags();
     }
 
     public void setTags(String[] tags) {
-        getDocumentModel().put(Crawler.Attributes.TAGS, tags);
+        getDocumentModel().setTags(tags);
     }
 }

--- a/jbake-core/src/main/java/org/jbake/parser/ParserContext.java
+++ b/jbake-core/src/main/java/org/jbake/parser/ParserContext.java
@@ -1,5 +1,6 @@
 package org.jbake.parser;
 
+import com.orientechnologies.orient.core.hook.ORecordHook;
 import org.jbake.app.Crawler;
 import org.jbake.app.configuration.JBakeConfiguration;
 

--- a/jbake-core/src/main/java/org/jbake/parser/ParserEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/ParserEngine.java
@@ -2,6 +2,7 @@ package org.jbake.parser;
 
 import org.apache.commons.configuration.Configuration;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentModel;
 
 import java.io.File;
 import java.util.Map;
@@ -11,15 +12,16 @@ public interface ParserEngine {
     /**
      * Parse a given file and transform to a model representation used by {@link MarkdownEngine} implementations
      * to render the file content.
+     *
      * @param config The project configuration
-     * @param file The file to be parsed
+     * @param file   The file to be parsed
      * @return A model representation of the given file
      */
-    Map<String, Object> parse(JBakeConfiguration config, File file);
+    DocumentModel parse(JBakeConfiguration config, File file);
 
     /**
-     * @param config The project configuration
-     * @param file The file to be parsed
+     * @param config      The project configuration
+     * @param file        The file to be parsed
      * @param contentPath unknown
      * @return A model representation of the given file
      * @deprecated use {@link #parse(JBakeConfiguration, File)} instead

--- a/jbake-core/src/main/java/org/jbake/render/DocumentsRenderer.java
+++ b/jbake-core/src/main/java/org/jbake/render/DocumentsRenderer.java
@@ -5,7 +5,6 @@ import org.jbake.app.ContentStore;
 import org.jbake.app.DocumentList;
 import org.jbake.app.Renderer;
 import org.jbake.app.configuration.JBakeConfiguration;
-import org.jbake.model.DocumentAttributes;
 import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import org.jbake.template.RenderingException;
@@ -13,7 +12,6 @@ import org.jbake.template.RenderingException;
 import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 public class DocumentsRenderer implements RenderingTool {
 
@@ -30,21 +28,21 @@ public class DocumentsRenderer implements RenderingTool {
 
             int index = 0;
 
-            Map<String, Object> nextDocument = null;
+            DocumentModel nextDocument = null;
 
             while (index < documentList.size()) {
                 try {
-                    Map<String, Object> document = documentList.get(index);
-                    document.put("nextContent", null);
-                    document.put("previousContent", null);
+                    DocumentModel document = documentList.get(index);
+                    document.setNextContent(null);
+                    document.setPreviousContent(null);
 
-                    if (index > 0) {
-                        document.put("nextContent", getContentForNav(nextDocument));
+                    if (nextDocument != null && index > 0) {
+                        document.setNextContent(getContentForNav(nextDocument));
                     }
 
                     if (index < documentList.size() - 1) {
-                        Map<String, Object> tempNext = documentList.get(index + 1);
-                        document.put("previousContent", getContentForNav(tempNext));
+                        DocumentModel tempNext = documentList.get(index + 1);
+                        document.setPreviousContent(getContentForNav(tempNext));
                     }
 
                     nextDocument = document;
@@ -79,11 +77,11 @@ public class DocumentsRenderer implements RenderingTool {
      * @param document
      * @return
      */
-    private DocumentModel getContentForNav(Map<String, Object> document) {
+    private DocumentModel getContentForNav(DocumentModel document) {
         DocumentModel navDocument = new DocumentModel();
-        navDocument.setNoExtensionUri((String) document.get(DocumentAttributes.NO_EXTENSION_URI.toString()));
-        navDocument.setUri((String) document.get(DocumentAttributes.URI.toString()));
-        navDocument.setTitle((String) document.get(DocumentAttributes.TITLE.toString()));
+        navDocument.setNoExtensionUri(document.getNoExtensionUri());
+        navDocument.setUri(document.getUri());
+        navDocument.setTitle(document.getTitle());
         return navDocument;
     }
 

--- a/jbake-core/src/main/java/org/jbake/render/DocumentsRenderer.java
+++ b/jbake-core/src/main/java/org/jbake/render/DocumentsRenderer.java
@@ -32,7 +32,7 @@ public class DocumentsRenderer implements RenderingTool {
 
             while (index < documentList.size()) {
                 try {
-                    DocumentModel document = documentList.get(index);
+                    DocumentModel document = documentList.getDocumentModel(index);
                     document.setNextContent(null);
                     document.setPreviousContent(null);
 
@@ -41,7 +41,7 @@ public class DocumentsRenderer implements RenderingTool {
                     }
 
                     if (index < documentList.size() - 1) {
-                        DocumentModel tempNext = documentList.get(index + 1);
+                        DocumentModel tempNext = (DocumentModel) documentList.get(index + 1);
                         document.setPreviousContent(getContentForNav(tempNext));
                     }
 

--- a/jbake-core/src/main/java/org/jbake/render/DocumentsRenderer.java
+++ b/jbake-core/src/main/java/org/jbake/render/DocumentsRenderer.java
@@ -20,7 +20,7 @@ public class DocumentsRenderer implements RenderingTool {
         int renderedCount = 0;
         final List<String> errors = new LinkedList<>();
         for (String docType : DocumentTypes.getDocumentTypes()) {
-            DocumentList documentList = db.getUnrenderedContent(docType);
+            DocumentList<DocumentModel> documentList = db.getUnrenderedContent(docType);
 
             if (documentList == null) {
                 continue;
@@ -32,7 +32,7 @@ public class DocumentsRenderer implements RenderingTool {
 
             while (index < documentList.size()) {
                 try {
-                    DocumentModel document = documentList.getDocumentModel(index);
+                    DocumentModel document = documentList.get(index);
                     document.setNextContent(null);
                     document.setPreviousContent(null);
 
@@ -41,7 +41,7 @@ public class DocumentsRenderer implements RenderingTool {
                     }
 
                     if (index < documentList.size() - 1) {
-                        DocumentModel tempNext = (DocumentModel) documentList.get(index + 1);
+                        DocumentModel tempNext = documentList.get(index + 1);
                         document.setPreviousContent(getContentForNav(tempNext));
                     }
 

--- a/jbake-core/src/main/java/org/jbake/render/DocumentsRenderer.java
+++ b/jbake-core/src/main/java/org/jbake/render/DocumentsRenderer.java
@@ -2,15 +2,15 @@ package org.jbake.render;
 
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.ContentStore;
-import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.DocumentList;
 import org.jbake.app.Renderer;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentAttributes;
+import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import org.jbake.template.RenderingException;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -79,11 +79,11 @@ public class DocumentsRenderer implements RenderingTool {
      * @param document
      * @return
      */
-    private Map<String, Object> getContentForNav(Map<String, Object> document) {
-        Map<String, Object> navDocument = new HashMap<>();
-        navDocument.put(Attributes.NO_EXTENSION_URI, document.get(Attributes.NO_EXTENSION_URI));
-        navDocument.put(Attributes.URI, document.get(Attributes.URI));
-        navDocument.put(Attributes.TITLE, document.get(Attributes.TITLE));
+    private DocumentModel getContentForNav(Map<String, Object> document) {
+        DocumentModel navDocument = new DocumentModel();
+        navDocument.setNoExtensionUri((String) document.get(DocumentAttributes.NO_EXTENSION_URI.toString()));
+        navDocument.setUri((String) document.get(DocumentAttributes.URI.toString()));
+        navDocument.setTitle((String) document.get(DocumentAttributes.TITLE.toString()));
         return navDocument;
     }
 

--- a/jbake-core/src/main/java/org/jbake/template/AbstractTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/AbstractTemplateEngine.java
@@ -5,7 +5,7 @@ import org.apache.commons.configuration.Configuration;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfigurationFactory;
-import org.jbake.model.DocumentModel;
+import org.jbake.template.model.TemplateModel;
 
 import java.io.File;
 import java.io.Writer;
@@ -22,7 +22,7 @@ import java.io.Writer;
  * data access based on the underlying template engine capabilities.
  * <p>
  * Note that some rendering engines may rely on a different rendering model than the one
- * provided by the first argument of {@link #renderDocument(DocumentModel, String, Writer)}.
+ * provided by the first argument of {@link #renderDocument(TemplateModel, String, Writer)}.
  * In this case, it is the responsibility of the engine to convert it.
  *
  * @author Cédric Champeau
@@ -46,5 +46,5 @@ public abstract class AbstractTemplateEngine {
         this.db = db;
     }
 
-    public abstract void renderDocument(DocumentModel model, String templateName, Writer writer) throws RenderingException;
+    public abstract void renderDocument(TemplateModel model, String templateName, Writer writer) throws RenderingException;
 }

--- a/jbake-core/src/main/java/org/jbake/template/AbstractTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/AbstractTemplateEngine.java
@@ -5,24 +5,24 @@ import org.apache.commons.configuration.Configuration;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfigurationFactory;
+import org.jbake.model.DocumentModel;
 
 import java.io.File;
 import java.io.Writer;
-import java.util.Map;
 
 
 /**
  * A template is responsible for converting a model into a rendered document. The model
  * consists of key/value pairs, some of them potentially converted from a markup language
  * to HTML already.
- *
+ * <p>
  * An appropriate rendering engine will be chosen by JBake based on the template suffix. If
  * contents is not available in the supplied model, a template has access to the document
  * database in order to complete the model. It is in particular interesting to optimize
  * data access based on the underlying template engine capabilities.
- *
+ * <p>
  * Note that some rendering engines may rely on a different rendering model than the one
- * provided by the first argument of {@link #renderDocument(java.util.Map, String, java.io.Writer)}.
+ * provided by the first argument of {@link #renderDocument(DocumentModel, String, Writer)}.
  * In this case, it is the responsibility of the engine to convert it.
  *
  * @author Cédric Champeau
@@ -33,9 +33,12 @@ public abstract class AbstractTemplateEngine {
     protected final JBakeConfiguration config;
     protected final ContentStore db;
 
+    /**
+     * @deprecated use {@link AbstractTemplateEngine(JBakeConfiguration,ContentStore)} instead
+     */
     @Deprecated
     protected AbstractTemplateEngine(final Configuration config, final ContentStore db, final File destination, final File templatesPath) {
-        this(new JBakeConfigurationFactory().createDefaultJbakeConfiguration(templatesPath.getParentFile(),destination, (CompositeConfiguration) config),db);
+        this(new JBakeConfigurationFactory().createDefaultJbakeConfiguration(templatesPath.getParentFile(), destination, (CompositeConfiguration) config), db);
     }
 
     protected AbstractTemplateEngine(final JBakeConfiguration config, final ContentStore db) {
@@ -43,5 +46,5 @@ public abstract class AbstractTemplateEngine {
         this.db = db;
     }
 
-    public abstract void renderDocument(Map<String,Object> model, String templateName, Writer writer) throws RenderingException;
+    public abstract void renderDocument(DocumentModel model, String templateName, Writer writer) throws RenderingException;
 }

--- a/jbake-core/src/main/java/org/jbake/template/DelegatingTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/DelegatingTemplateEngine.java
@@ -5,7 +5,7 @@ import org.jbake.app.ContentStore;
 import org.jbake.app.FileUtil;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.app.configuration.JBakeProperty;
-import org.jbake.model.DocumentModel;
+import org.jbake.template.model.TemplateModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,8 +46,8 @@ public class DelegatingTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(final DocumentModel model, String templateName, final Writer writer) throws RenderingException {
-        model.put("version", config.getVersion());
+    public void renderDocument(final TemplateModel model, String templateName, final Writer writer) throws RenderingException {
+        model.setVersion(config.getVersion());
 
         // TODO: create config model from configuration
         Map<String, Object> configModel = new HashMap<>();

--- a/jbake-core/src/main/java/org/jbake/template/DelegatingTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/DelegatingTemplateEngine.java
@@ -42,13 +42,14 @@ public class DelegatingTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(final TemplateModel model, String templateName, final Writer writer) throws RenderingException {
+    public void renderDocument(final TemplateModel model, final String templateName, final Writer writer) throws RenderingException {
         model.setVersion(config.getVersion());
         model.setConfig(config.asHashMap());
 
         // if default template exists we will use it
         File templateFolder = config.getTemplateFolder();
         File templateFile = new File(templateFolder, templateName);
+        String theTemplateName = templateName;
         if (!templateFile.exists()) {
             LOGGER.info("Default template: {} was not found, searching for others...", templateName);
             // if default template does not exist then check if any alternative engine templates exist
@@ -57,17 +58,17 @@ public class DelegatingTemplateEngine extends AbstractTemplateEngine {
                 templateFile = new File(templateFolder, templateNameWithoutExt + "." + extension);
                 if (templateFile.exists()) {
                     LOGGER.info("Found alternative template file: {} using this instead", templateFile.getName());
-                    templateName = templateFile.getName();
+                    theTemplateName = templateFile.getName();
                     break;
                 }
             }
         }
-        String ext = FileUtil.fileExt(templateName);
+        String ext = FileUtil.fileExt(theTemplateName);
         AbstractTemplateEngine engine = renderers.getEngine(ext);
         if (engine != null) {
-            engine.renderDocument(model, templateName, writer);
+            engine.renderDocument(model, theTemplateName, writer);
         } else {
-            LOGGER.error("Warning - No template engine found for template: {}", templateName);
+            LOGGER.error("Warning - No template engine found for template: {}", theTemplateName);
         }
     }
 }

--- a/jbake-core/src/main/java/org/jbake/template/DelegatingTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/DelegatingTemplateEngine.java
@@ -4,16 +4,12 @@ import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.ContentStore;
 import org.jbake.app.FileUtil;
 import org.jbake.app.configuration.JBakeConfiguration;
-import org.jbake.app.configuration.JBakeProperty;
 import org.jbake.template.model.TemplateModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.Writer;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
 
 /**
  * A template which is responsible for delegating to a supported template engine,
@@ -48,23 +44,8 @@ public class DelegatingTemplateEngine extends AbstractTemplateEngine {
     @Override
     public void renderDocument(final TemplateModel model, String templateName, final Writer writer) throws RenderingException {
         model.setVersion(config.getVersion());
+        model.setConfig(config.asHashMap());
 
-        // TODO: create config model from configuration
-        Map<String, Object> configModel = new HashMap<>();
-        Iterator<String> configKeys = config.getKeys();
-        while (configKeys.hasNext()) {
-            String key = configKeys.next();
-            Object valueObject;
-
-            if (key.equals(JBakeProperty.PAGINATE_INDEX)) {
-                valueObject = config.getPaginateIndex();
-            } else {
-                valueObject = config.get(key);
-            }
-            //replace "." in key so you can use dot notation in templates
-            configModel.put(key.replace(".", "_"), valueObject);
-        }
-        model.setConfig(configModel);
         // if default template exists we will use it
         File templateFolder = config.getTemplateFolder();
         File templateFile = new File(templateFolder, templateName);

--- a/jbake-core/src/main/java/org/jbake/template/DelegatingTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/DelegatingTemplateEngine.java
@@ -5,6 +5,7 @@ import org.jbake.app.ContentStore;
 import org.jbake.app.FileUtil;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.app.configuration.JBakeProperty;
+import org.jbake.model.DocumentModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +46,7 @@ public class DelegatingTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(final Map<String, Object> model, String templateName, final Writer writer) throws RenderingException {
+    public void renderDocument(final DocumentModel model, String templateName, final Writer writer) throws RenderingException {
         model.put("version", config.getVersion());
 
         // TODO: create config model from configuration
@@ -55,7 +56,7 @@ public class DelegatingTemplateEngine extends AbstractTemplateEngine {
             String key = configKeys.next();
             Object valueObject;
 
-            if ( key.equals(JBakeProperty.PAGINATE_INDEX) ){
+            if (key.equals(JBakeProperty.PAGINATE_INDEX)) {
                 valueObject = config.getPaginateIndex();
             } else {
                 valueObject = config.get(key);
@@ -63,7 +64,7 @@ public class DelegatingTemplateEngine extends AbstractTemplateEngine {
             //replace "." in key so you can use dot notation in templates
             configModel.put(key.replace(".", "_"), valueObject);
         }
-        model.put("config", configModel);
+        model.setConfig(configModel);
         // if default template exists we will use it
         File templateFolder = config.getTemplateFolder();
         File templateFile = new File(templateFolder, templateName);

--- a/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Collection;
 import java.util.Date;
-import java.util.Map;
 
 /**
  * Renders pages using the <a href="http://freemarker.org/">Freemarker</a> template engine.
@@ -75,7 +74,7 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
         private final SimpleHash eagerModel;
         private final ContentStore db;
 
-        public LazyLoadingModel(ObjectWrapper wrapper, Map<String, Object> eagerModel, final ContentStore db) {
+        public LazyLoadingModel(ObjectWrapper wrapper, TemplateModel eagerModel, final ContentStore db) {
             this.eagerModel = new SimpleHash(eagerModel, wrapper);
             this.db = db;
             this.wrapper = wrapper;

--- a/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
@@ -6,8 +6,8 @@ import freemarker.ext.beans.BeansWrapperBuilder;
 import freemarker.template.*;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.ContentStore;
-import org.jbake.app.Crawler;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.ModelAttributes;
 import org.jbake.template.model.TemplateModel;
 
 import java.io.File;
@@ -78,7 +78,7 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
                 // GIT Issue#357: Accessing db in freemarker template throws exception
                 // When content store is accessed with key "db" then wrap the ContentStore with BeansWrapper and return to template.
                 // All methods on db are then accessible in template. Eg: ${db.getPublishedPostsByTag(tagName).size()}
-                if (key.equals(Crawler.Attributes.DB)) {
+                if (key.equals(ModelAttributes.DB)) {
                     BeansWrapperBuilder bwb = new BeansWrapperBuilder(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
                     BeansWrapper bw = bwb.build();
                     return bw.wrap(db);
@@ -89,9 +89,9 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
 
                     @Override
                     public freemarker.template.TemplateModel adapt(String key, Object extractedValue) {
-                        if (key.equals(Crawler.Attributes.ALLTAGS)) {
+                        if (key.equals(ModelAttributes.ALLTAGS)) {
                             return new SimpleCollection((Collection) extractedValue, wrapper);
-                        } else if (key.equals(Crawler.Attributes.PUBLISHED_DATE)) {
+                        } else if (key.equals(ModelAttributes.PUBLISHED_DATE)) {
                             return new SimpleDate((Date) extractedValue, TemplateDateModel.UNKNOWN);
                         } else {
                             // All other cases, as far as I know, are document collections

--- a/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
@@ -8,7 +8,7 @@ import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.ContentStore;
 import org.jbake.app.Crawler;
 import org.jbake.app.configuration.JBakeConfiguration;
-import org.jbake.model.DocumentModel;
+import org.jbake.template.model.TemplateModel;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,7 +48,7 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(final DocumentModel model, final String templateName, final Writer writer) throws RenderingException {
+    public void renderDocument(final TemplateModel model, final String templateName, final Writer writer) throws RenderingException {
         try {
             Template template = templateCfg.getTemplate(templateName);
             template.process(new LazyLoadingModel(templateCfg.getObjectWrapper(), model, db), writer);
@@ -72,7 +72,7 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
         }
 
         @Override
-        public TemplateModel get(final String key) throws TemplateModelException {
+        public freemarker.template.TemplateModel get(final String key) throws TemplateModelException {
             try {
 
                 // GIT Issue#357: Accessing db in freemarker template throws exception
@@ -85,10 +85,10 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
                 }
 
 
-                return extractors.extractAndTransform(db, key, eagerModel.toMap(), new TemplateEngineAdapter<TemplateModel>() {
+                return extractors.extractAndTransform(db, key, eagerModel.toMap(), new TemplateEngineAdapter<freemarker.template.TemplateModel>() {
 
                     @Override
-                    public TemplateModel adapt(String key, Object extractedValue) {
+                    public freemarker.template.TemplateModel adapt(String key, Object extractedValue) {
                         if (key.equals(Crawler.Attributes.ALLTAGS)) {
                             return new SimpleCollection((Collection) extractedValue, wrapper);
                         } else if (key.equals(Crawler.Attributes.PUBLISHED_DATE)) {
@@ -106,7 +106,7 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
         }
 
         @Override
-        public boolean isEmpty() throws TemplateModelException {
+        public boolean isEmpty() {
             return false;
         }
 

--- a/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
@@ -3,22 +3,12 @@ package org.jbake.template;
 
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.ext.beans.BeansWrapperBuilder;
-import freemarker.template.Configuration;
-import freemarker.template.ObjectWrapper;
-import freemarker.template.SimpleCollection;
-import freemarker.template.SimpleDate;
-import freemarker.template.SimpleHash;
-import freemarker.template.SimpleSequence;
-import freemarker.template.Template;
-import freemarker.template.TemplateDateModel;
-import freemarker.template.TemplateException;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
+import freemarker.template.*;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.ContentStore;
 import org.jbake.app.Crawler;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentModel;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,13 +48,11 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(final Map<String, Object> model, final String templateName, final Writer writer) throws RenderingException {
+    public void renderDocument(final DocumentModel model, final String templateName, final Writer writer) throws RenderingException {
         try {
             Template template = templateCfg.getTemplate(templateName);
             template.process(new LazyLoadingModel(templateCfg.getObjectWrapper(), model, db), writer);
-        } catch (IOException e) {
-            throw new RenderingException(e);
-        } catch (TemplateException e) {
+        } catch (IOException | TemplateException e) {
             throw new RenderingException(e);
         }
     }
@@ -90,7 +78,7 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
                 // GIT Issue#357: Accessing db in freemarker template throws exception
                 // When content store is accessed with key "db" then wrap the ContentStore with BeansWrapper and return to template.
                 // All methods on db are then accessible in template. Eg: ${db.getPublishedPostsByTag(tagName).size()}
-                if(key.equals(Crawler.Attributes.DB)) {
+                if (key.equals(Crawler.Attributes.DB)) {
                     BeansWrapperBuilder bwb = new BeansWrapperBuilder(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
                     BeansWrapper bw = bwb.build();
                     return bw.wrap(db);
@@ -101,9 +89,9 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
 
                     @Override
                     public TemplateModel adapt(String key, Object extractedValue) {
-                        if(key.equals(Crawler.Attributes.ALLTAGS)) {
+                        if (key.equals(Crawler.Attributes.ALLTAGS)) {
                             return new SimpleCollection((Collection) extractedValue, wrapper);
-                        } else if(key.equals(Crawler.Attributes.PUBLISHED_DATE)) {
+                        } else if (key.equals(Crawler.Attributes.PUBLISHED_DATE)) {
                             return new SimpleDate((Date) extractedValue, TemplateDateModel.UNKNOWN);
                         } else {
                             // All other cases, as far as I know, are document collections
@@ -112,7 +100,7 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
 
                     }
                 });
-            } catch(NoModelExtractorException e) {
+            } catch (NoModelExtractorException e) {
                 return eagerModel.get(key);
             }
         }

--- a/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
@@ -3,7 +3,17 @@ package org.jbake.template;
 
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.ext.beans.BeansWrapperBuilder;
-import freemarker.template.*;
+import freemarker.template.Configuration;
+import freemarker.template.ObjectWrapper;
+import freemarker.template.SimpleCollection;
+import freemarker.template.SimpleDate;
+import freemarker.template.SimpleHash;
+import freemarker.template.SimpleSequence;
+import freemarker.template.Template;
+import freemarker.template.TemplateDateModel;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateHashModel;
+import freemarker.template.TemplateModelException;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;

--- a/jbake-core/src/main/java/org/jbake/template/GroovyMarkupTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/GroovyMarkupTemplateEngine.java
@@ -8,6 +8,7 @@ import groovy.text.markup.TemplateConfiguration;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentModel;
 
 import java.io.File;
 import java.io.Writer;
@@ -59,7 +60,7 @@ public class GroovyMarkupTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(final Map<String, Object> model, final String templateName, final Writer writer) throws RenderingException {
+    public void renderDocument(final DocumentModel model, final String templateName, final Writer writer) throws RenderingException {
         try {
             Template template = templateEngine.createTemplateByPath(templateName);
             Map<String, Object> wrappedModel = wrap(model);
@@ -70,7 +71,7 @@ public class GroovyMarkupTemplateEngine extends AbstractTemplateEngine {
         }
     }
 
-    private Map<String, Object> wrap(final Map<String, Object> model) {
+    private Map<String, Object> wrap(final DocumentModel model) {
         return new HashMap<String, Object>(model) {
             @Override
             public Object get(final Object property) {

--- a/jbake-core/src/main/java/org/jbake/template/GroovyMarkupTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/GroovyMarkupTemplateEngine.java
@@ -8,7 +8,7 @@ import groovy.text.markup.TemplateConfiguration;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;
-import org.jbake.model.DocumentModel;
+import org.jbake.template.model.TemplateModel;
 
 import java.io.File;
 import java.io.Writer;
@@ -60,7 +60,7 @@ public class GroovyMarkupTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(final DocumentModel model, final String templateName, final Writer writer) throws RenderingException {
+    public void renderDocument(final TemplateModel model, final String templateName, final Writer writer) throws RenderingException {
         try {
             Template template = templateEngine.createTemplateByPath(templateName);
             Map<String, Object> wrappedModel = wrap(model);
@@ -71,7 +71,7 @@ public class GroovyMarkupTemplateEngine extends AbstractTemplateEngine {
         }
     }
 
-    private Map<String, Object> wrap(final DocumentModel model) {
+    private Map<String, Object> wrap(final TemplateModel model) {
         return new HashMap<String, Object>(model) {
             @Override
             public Object get(final Object property) {

--- a/jbake-core/src/main/java/org/jbake/template/GroovyMarkupTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/GroovyMarkupTemplateEngine.java
@@ -1,6 +1,5 @@
 package org.jbake.template;
 
-import groovy.lang.GString;
 import groovy.lang.Writable;
 import groovy.text.Template;
 import groovy.text.markup.MarkupTemplateEngine;
@@ -12,7 +11,6 @@ import org.jbake.template.model.TemplateModel;
 
 import java.io.File;
 import java.io.Writer;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -71,20 +69,15 @@ public class GroovyMarkupTemplateEngine extends AbstractTemplateEngine {
         }
     }
 
-    private Map<String, Object> wrap(final TemplateModel model) {
-        return new HashMap<String, Object>(model) {
+    private TemplateModel wrap(final TemplateModel model) {
+        return new TemplateModel(model) {
             @Override
-            public Object get(final Object property) {
-                if (property instanceof String || property instanceof GString) {
-                    String key = property.toString();
-                    try {
-                        put(key, extractors.extractAndTransform(db, key, model, new TemplateEngineAdapter.NoopAdapter()));
-                    } catch (NoModelExtractorException e) {
-                        // should never happen, as we iterate over existing extractors
-                    }
+            public Object get(Object key) {
+                try {
+                    return extractors.extractAndTransform(db, (String) key, model, new TemplateEngineAdapter.NoopAdapter());
+                } catch (NoModelExtractorException e) {
+                    return super.get(key);
                 }
-
-                return super.get(property);
             }
         };
     }

--- a/jbake-core/src/main/java/org/jbake/template/GroovyTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/GroovyTemplateEngine.java
@@ -91,11 +91,10 @@ public class GroovyTemplateEngine extends AbstractTemplateEngine {
     }
 
     private void doInclude(Map<String, Object> model, String templateName) throws Exception {
-        AbstractTemplateEngine engine = (AbstractTemplateEngine) model.get("renderer");
-        Writer out = (Writer) model.get("out");
         TemplateModel templateModel = new TemplateModel();
         templateModel.putAll(model);
+        AbstractTemplateEngine engine = templateModel.getRenderer();
+        Writer out = templateModel.getWriter();
         engine.renderDocument(templateModel, templateName, out);
-        model.put("out", out);
     }
 }

--- a/jbake-core/src/main/java/org/jbake/template/GroovyTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/GroovyTemplateEngine.java
@@ -11,7 +11,7 @@ import org.apache.commons.configuration.CompositeConfiguration;
 import org.codehaus.groovy.runtime.MethodClosure;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;
-import org.jbake.model.DocumentModel;
+import org.jbake.template.model.TemplateModel;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -48,7 +48,7 @@ public class GroovyTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(final DocumentModel model, final String templateName, final Writer writer) throws RenderingException {
+    public void renderDocument(final TemplateModel model, final String templateName, final Writer writer) throws RenderingException {
         try {
             Template template = findTemplate(templateName);
             Writable writable = template.make(wrap(model));
@@ -93,9 +93,9 @@ public class GroovyTemplateEngine extends AbstractTemplateEngine {
     private void doInclude(Map<String, Object> model, String templateName) throws Exception {
         AbstractTemplateEngine engine = (AbstractTemplateEngine) model.get("renderer");
         Writer out = (Writer) model.get("out");
-        DocumentModel documentModel = new DocumentModel();
-        documentModel.putAll(model);
-        engine.renderDocument(documentModel, templateName, out);
+        TemplateModel templateModel = new TemplateModel();
+        templateModel.putAll(model);
+        engine.renderDocument(templateModel, templateName, out);
         model.put("out", out);
     }
 }

--- a/jbake-core/src/main/java/org/jbake/template/GroovyTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/GroovyTemplateEngine.java
@@ -11,15 +11,11 @@ import org.apache.commons.configuration.CompositeConfiguration;
 import org.codehaus.groovy.runtime.MethodClosure;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentModel;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Writer;
+import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,7 +48,7 @@ public class GroovyTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(final Map<String, Object> model, final String templateName, final Writer writer) throws RenderingException {
+    public void renderDocument(final DocumentModel model, final String templateName, final Writer writer) throws RenderingException {
         try {
             Template template = findTemplate(templateName);
             Writable writable = template.make(wrap(model));
@@ -97,7 +93,9 @@ public class GroovyTemplateEngine extends AbstractTemplateEngine {
     private void doInclude(Map<String, Object> model, String templateName) throws Exception {
         AbstractTemplateEngine engine = (AbstractTemplateEngine) model.get("renderer");
         Writer out = (Writer) model.get("out");
-        engine.renderDocument(model, templateName, out);
+        DocumentModel documentModel = new DocumentModel();
+        documentModel.putAll(model);
+        engine.renderDocument(documentModel, templateName, out);
         model.put("out", out);
     }
 }

--- a/jbake-core/src/main/java/org/jbake/template/JadeTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/JadeTemplateEngine.java
@@ -3,7 +3,6 @@ package org.jbake.template;
 
 import de.neuland.jade4j.Jade4J;
 import de.neuland.jade4j.JadeConfiguration;
-import de.neuland.jade4j.exceptions.JadeCompilerException;
 import de.neuland.jade4j.filter.CDATAFilter;
 import de.neuland.jade4j.filter.CssFilter;
 import de.neuland.jade4j.filter.JsFilter;
@@ -15,6 +14,7 @@ import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentModel;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,7 +56,7 @@ public class JadeTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(Map<String, Object> model, String templateName, Writer writer) throws RenderingException {
+    public void renderDocument(DocumentModel model, String templateName, Writer writer) throws RenderingException {
         try {
             JadeTemplate template = jadeConfiguration.getTemplate(templateName);
 
@@ -66,7 +66,7 @@ public class JadeTemplateEngine extends AbstractTemplateEngine {
         }
     }
 
-    public void renderTemplate(JadeTemplate template, Map<String, Object> model, Writer writer) throws JadeCompilerException {
+    public void renderTemplate(JadeTemplate template, Map<String, Object> model, Writer writer) {
         JadeModel jadeModel = wrap(jadeConfiguration.getSharedVariables());
         jadeModel.putAll(model);
         template.process(jadeModel, writer);
@@ -80,7 +80,7 @@ public class JadeTemplateEngine extends AbstractTemplateEngine {
                 String key = property.toString();
                 try {
                     return extractors.extractAndTransform(db, key, this, new TemplateEngineAdapter.NoopAdapter());
-                } catch(NoModelExtractorException e) {
+                } catch (NoModelExtractorException e) {
                     // fallback to parent model
                 }
 
@@ -90,13 +90,13 @@ public class JadeTemplateEngine extends AbstractTemplateEngine {
     }
 
     public static class FormatHelper {
-        private Map<String, SimpleDateFormat> formatters = new HashMap<String, SimpleDateFormat>();
+        private Map<String, SimpleDateFormat> formatters = new HashMap<>();
 
         public String format(Date date, String pattern) {
-            if(date!=null && pattern!=null) {
+            if (date != null && pattern != null) {
                 SimpleDateFormat df = formatters.get(pattern);
 
-                if(df==null) {
+                if (df == null) {
                     df = new SimpleDateFormat(pattern);
                     formatters.put(pattern, df);
                 }

--- a/jbake-core/src/main/java/org/jbake/template/JadeTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/JadeTemplateEngine.java
@@ -77,14 +77,11 @@ public class JadeTemplateEngine extends AbstractTemplateEngine {
 
             @Override
             public Object get(final Object property) {
-                String key = property.toString();
                 try {
-                    return extractors.extractAndTransform(db, key, this, new TemplateEngineAdapter.NoopAdapter());
+                    return extractors.extractAndTransform(db, (String) property, this, new TemplateEngineAdapter.NoopAdapter());
                 } catch (NoModelExtractorException e) {
-                    // fallback to parent model
+                    return super.get(property);
                 }
-
-                return super.get(property);
             }
         };
     }

--- a/jbake-core/src/main/java/org/jbake/template/JadeTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/JadeTemplateEngine.java
@@ -14,7 +14,7 @@ import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;
-import org.jbake.model.DocumentModel;
+import org.jbake.template.model.TemplateModel;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,7 +56,7 @@ public class JadeTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(DocumentModel model, String templateName, Writer writer) throws RenderingException {
+    public void renderDocument(TemplateModel model, String templateName, Writer writer) throws RenderingException {
         try {
             JadeTemplate template = jadeConfiguration.getTemplate(templateName);
 
@@ -66,13 +66,13 @@ public class JadeTemplateEngine extends AbstractTemplateEngine {
         }
     }
 
-    public void renderTemplate(JadeTemplate template, Map<String, Object> model, Writer writer) {
-        JadeModel jadeModel = wrap(jadeConfiguration.getSharedVariables());
-        jadeModel.putAll(model);
+    public void renderTemplate(JadeTemplate template, TemplateModel model, Writer writer) {
+        JadeModel jadeModel = wrap(model);
+        jadeModel.putAll(jadeConfiguration.getSharedVariables());
         template.process(jadeModel, writer);
     }
 
-    private JadeModel wrap(final Map<String, Object> model) {
+    private JadeModel wrap(final TemplateModel model) {
         return new JadeModel(model) {
 
             @Override

--- a/jbake-core/src/main/java/org/jbake/template/ModelExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/ModelExtractor.java
@@ -6,10 +6,8 @@ import java.util.Map;
 
 
 /**
- *
- * @author ndx
- *
  * @param <T> the type of data returned by this model extractor
+ * @author ndx
  */
 public interface ModelExtractor<T> {
 

--- a/jbake-core/src/main/java/org/jbake/template/PebbleTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/PebbleTemplateEngine.java
@@ -8,6 +8,7 @@ import com.mitchellbosecke.pebble.loader.Loader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentModel;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -42,7 +43,7 @@ public class PebbleTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(final Map<String, Object> model, final String templateName, final Writer writer)
+    public void renderDocument(final DocumentModel model, final String templateName, final Writer writer)
         throws RenderingException {
 
         PebbleTemplate template;

--- a/jbake-core/src/main/java/org/jbake/template/PebbleTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/PebbleTemplateEngine.java
@@ -12,7 +12,6 @@ import org.jbake.template.model.TemplateModel;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -50,32 +49,26 @@ public class PebbleTemplateEngine extends AbstractTemplateEngine {
         try {
             template = engine.getTemplate(templateName);
             template.evaluate(writer, wrap(model));
-        } catch (PebbleException e) {
-            throw new RenderingException(e);
-        } catch (IOException e) {
+        } catch (PebbleException | IOException e) {
             throw new RenderingException(e);
         }
 
     }
 
-    private Map<String, Object> wrap(final Map<String, Object> model) {
-        Map<String, Object> result = new HashMap<String, Object>(model) {
+    private TemplateModel wrap(final TemplateModel model) {
+        return new TemplateModel(model) {
 
             private static final long serialVersionUID = -5489285491728950547L;
 
             @Override
             public Object get(final Object property) {
-                String key = property.toString();
                 try {
-                    return extractors.extractAndTransform(db, key, this, new TemplateEngineAdapter.NoopAdapter());
+                    return extractors.extractAndTransform(db, (String) property, this, new TemplateEngineAdapter.NoopAdapter());
                 } catch(NoModelExtractorException e) {
-                    // fallback to parent model
+                    return super.get(property);
                 }
-
-                return super.get(property);
             }
         };
 
-        return result;
     }
 }

--- a/jbake-core/src/main/java/org/jbake/template/PebbleTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/PebbleTemplateEngine.java
@@ -8,7 +8,6 @@ import com.mitchellbosecke.pebble.loader.Loader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;
-import org.jbake.model.DocumentModel;
 import org.jbake.template.model.TemplateModel;
 
 import java.io.IOException;
@@ -44,7 +43,7 @@ public class PebbleTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(TemplateModel model, String templateName, Writer writer)
+    public void renderDocument(final TemplateModel model, final String templateName, final Writer writer)
         throws RenderingException {
 
         PebbleTemplate template;

--- a/jbake-core/src/main/java/org/jbake/template/PebbleTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/PebbleTemplateEngine.java
@@ -9,6 +9,7 @@ import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import org.jbake.app.ContentStore;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.model.DocumentModel;
+import org.jbake.template.model.TemplateModel;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -43,7 +44,7 @@ public class PebbleTemplateEngine extends AbstractTemplateEngine {
     }
 
     @Override
-    public void renderDocument(final DocumentModel model, final String templateName, final Writer writer)
+    public void renderDocument(TemplateModel model, String templateName, Writer writer)
         throws RenderingException {
 
         PebbleTemplate template;

--- a/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
@@ -7,6 +7,7 @@ import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.model.DocumentModel;
+import org.jbake.template.model.TemplateModel;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.context.LazyContextVariable;
@@ -72,17 +73,17 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
         templateEngine.clearTemplateCache();
     }
 
-    private void updateTemplateMode(DocumentModel model) {
+    private void updateTemplateMode(TemplateModel model) {
         templateResolver.setTemplateMode(getTemplateModeByModel(model));
     }
 
-    private String getTemplateModeByModel(DocumentModel model) {
+    private String getTemplateModeByModel(TemplateModel model) {
         DocumentModel content = model.getContent();
         return config.getThymeleafModeByType(content.getType());
     }
 
     @Override
-    public void renderDocument(DocumentModel model, String templateName, Writer writer) throws RenderingException {
+    public void renderDocument(TemplateModel model, String templateName, Writer writer) {
 
         String localeString = config.getThymeleafLocale();
         Locale locale = localeString != null ? LocaleUtils.toLocale(localeString) : Locale.getDefault();

--- a/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
@@ -3,10 +3,10 @@ package org.jbake.template;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.lang.LocaleUtils;
 import org.jbake.app.ContentStore;
-import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.model.DocumentModel;
+import org.jbake.model.ModelAttributes;
 import org.jbake.template.model.TemplateModel;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
@@ -130,14 +130,14 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
                 return extractors.extractAndTransform(db, key, model, new TemplateEngineAdapter<LazyContextVariable>() {
                     @Override
                     public LazyContextVariable adapt(String key, final Object extractedValue) {
-                        if (key.equals(Attributes.ALLTAGS)) {
+                        if (key.equals(ModelAttributes.ALLTAGS)) {
                             return new LazyContextVariable<Set<?>>() {
                                 @Override
                                 protected Set<?> loadValue() {
                                     return (Set<?>) extractedValue;
                                 }
                             };
-                        } else if (key.equals(Attributes.PUBLISHED_DATE)) {
+                        } else if (key.equals(ModelAttributes.PUBLISHED_DATE)) {
                             return new LazyContextVariable<Date>() {
                                 @Override
                                 protected Date loadValue() {

--- a/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.Writer;
 import java.util.Date;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -98,7 +97,7 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
         }
     }
 
-    private void initializeContext(Locale locale, Map<String, Object> model) {
+    private void initializeContext(Locale locale, TemplateModel model) {
         context.clearVariables();
         context.setLocale(locale);
         context.setVariables(model);
@@ -115,9 +114,9 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
 
         private ContentStore db;
         private String key;
-        private Map<String, Object> model;
+        private TemplateModel model;
 
-        public ContextVariable(ContentStore db, String key, Map<String, Object> model) {
+        public ContextVariable(ContentStore db, String key, TemplateModel model) {
             this.db = db;
             this.key = key;
             this.model = model;

--- a/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/ThymeleafTemplateEngine.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang.LocaleUtils;
 import org.jbake.app.ContentStore;
 import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentAttributes;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.context.LazyContextVariable;
@@ -81,7 +82,7 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
         @SuppressWarnings("unchecked")
         Map<String, Object> content = (Map<String, Object>) model.get("content");
         if (config != null && content != null) {
-            String key = "template_" + content.get(Attributes.TYPE) + "_thymeleaf_mode";
+            String key = "template_" + content.get(DocumentAttributes.TYPE.toString()) + "_thymeleaf_mode";
             String configMode = (String) config.get(key);
             if (configMode != null) {
                 return configMode;
@@ -99,7 +100,7 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
 
         lock.lock();
         try {
-            initializeContext(locale,model);
+            initializeContext(locale, model);
             updateTemplateMode(model);
             templateEngine.process(templateName, context, writer);
         } finally {
@@ -113,7 +114,7 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
         context.setVariables(model);
 
         for (String key : extractors.keySet()) {
-            context.setVariable(key, new ContextVariable(db,key,model));
+            context.setVariable(key, new ContextVariable(db, key, model));
         }
     }
 
@@ -124,7 +125,7 @@ public class ThymeleafTemplateEngine extends AbstractTemplateEngine {
 
         private ContentStore db;
         private String key;
-        private Map<String,Object> model;
+        private Map<String, Object> model;
 
         public ContextVariable(ContentStore db, String key, Map<String, Object> model) {
             this.db = db;

--- a/jbake-core/src/main/java/org/jbake/template/model/AllContentExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/AllContentExtractor.java
@@ -2,6 +2,7 @@ package org.jbake.template.model;
 
 import org.jbake.app.ContentStore;
 import org.jbake.app.DocumentList;
+import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import org.jbake.template.ModelExtractor;
 
@@ -11,10 +12,10 @@ public class AllContentExtractor implements ModelExtractor<DocumentList> {
 
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
-        DocumentList allContent = new DocumentList();
+        DocumentList<DocumentModel> allContent = new DocumentList<>();
         String[] documentTypes = DocumentTypes.getDocumentTypes();
         for (String docType : documentTypes) {
-            DocumentList query = db.getAllContent(docType);
+            DocumentList<DocumentModel> query = db.getAllContent(docType);
             allContent.addAll(query);
         }
         return allContent;

--- a/jbake-core/src/main/java/org/jbake/template/model/PublishedContentExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/PublishedContentExtractor.java
@@ -2,6 +2,7 @@ package org.jbake.template.model;
 
 import org.jbake.app.ContentStore;
 import org.jbake.app.DocumentList;
+import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import org.jbake.template.ModelExtractor;
 
@@ -11,10 +12,10 @@ public class PublishedContentExtractor implements ModelExtractor<DocumentList> {
 
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
-        DocumentList publishedContent = new DocumentList();
+        DocumentList<DocumentModel> publishedContent = new DocumentList<>();
         String[] documentTypes = DocumentTypes.getDocumentTypes();
         for (String docType : documentTypes) {
-            DocumentList query = db.getPublishedContent(docType);
+            DocumentList<DocumentModel> query = db.getPublishedContent(docType);
             publishedContent.addAll(query);
         }
         return publishedContent;

--- a/jbake-core/src/main/java/org/jbake/template/model/TagPostsExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TagPostsExtractor.java
@@ -1,9 +1,8 @@
 package org.jbake.template.model;
 
 import org.jbake.app.ContentStore;
-import org.jbake.app.Crawler;
 import org.jbake.app.DocumentList;
-import org.jbake.model.DocumentAttributes;
+import org.jbake.model.ModelAttributes;
 import org.jbake.template.ModelExtractor;
 
 import java.util.Map;
@@ -13,8 +12,8 @@ public class TagPostsExtractor implements ModelExtractor<DocumentList> {
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
         String tag = null;
-        if (model.get(DocumentAttributes.TAG.toString()) != null) {
-            tag = model.get(DocumentAttributes.TAG.toString()).toString();
+        if (model.get(ModelAttributes.TAG.toString()) != null) {
+            tag = model.get(ModelAttributes.TAG.toString()).toString();
         }
         // fetch the tag posts from db
         return db.getPublishedPostsByTag(tag);

--- a/jbake-core/src/main/java/org/jbake/template/model/TagPostsExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TagPostsExtractor.java
@@ -3,6 +3,7 @@ package org.jbake.template.model;
 import org.jbake.app.ContentStore;
 import org.jbake.app.Crawler;
 import org.jbake.app.DocumentList;
+import org.jbake.model.DocumentAttributes;
 import org.jbake.template.ModelExtractor;
 
 import java.util.Map;
@@ -12,8 +13,8 @@ public class TagPostsExtractor implements ModelExtractor<DocumentList> {
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
         String tag = null;
-        if (model.get(Crawler.Attributes.TAG) != null) {
-            tag = model.get(Crawler.Attributes.TAG).toString();
+        if (model.get(DocumentAttributes.TAG.toString()) != null) {
+            tag = model.get(DocumentAttributes.TAG.toString()).toString();
         }
         // fetch the tag posts from db
         return db.getPublishedPostsByTag(tag);

--- a/jbake-core/src/main/java/org/jbake/template/model/TagPostsExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TagPostsExtractor.java
@@ -2,7 +2,6 @@ package org.jbake.template.model;
 
 import org.jbake.app.ContentStore;
 import org.jbake.app.DocumentList;
-import org.jbake.model.ModelAttributes;
 import org.jbake.template.ModelExtractor;
 
 import java.util.Map;
@@ -12,8 +11,10 @@ public class TagPostsExtractor implements ModelExtractor<DocumentList> {
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
         String tag = null;
-        if (model.get(ModelAttributes.TAG.toString()) != null) {
-            tag = model.get(ModelAttributes.TAG.toString()).toString();
+        TemplateModel templateModel = new TemplateModel();
+        templateModel.putAll(model);
+        if (templateModel.getTag() != null) {
+            tag = templateModel.getTag();
         }
         // fetch the tag posts from db
         return db.getPublishedPostsByTag(tag);

--- a/jbake-core/src/main/java/org/jbake/template/model/TaggedDocumentsExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TaggedDocumentsExtractor.java
@@ -2,7 +2,7 @@ package org.jbake.template.model;
 
 import org.jbake.app.ContentStore;
 import org.jbake.app.DocumentList;
-import org.jbake.model.DocumentAttributes;
+import org.jbake.model.ModelAttributes;
 import org.jbake.template.ModelExtractor;
 
 import java.util.Map;
@@ -12,8 +12,8 @@ public class TaggedDocumentsExtractor implements ModelExtractor<DocumentList> {
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
         String tag = null;
-        if (model.get(DocumentAttributes.TAG.toString()) != null) {
-            tag = model.get(DocumentAttributes.TAG.toString()).toString();
+        if (model.get(ModelAttributes.TAG.toString()) != null) {
+            tag = model.get(ModelAttributes.TAG.toString()).toString();
         }
         // fetch the tagged documents from db
         return db.getPublishedDocumentsByTag(tag);

--- a/jbake-core/src/main/java/org/jbake/template/model/TaggedDocumentsExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TaggedDocumentsExtractor.java
@@ -2,7 +2,6 @@ package org.jbake.template.model;
 
 import org.jbake.app.ContentStore;
 import org.jbake.app.DocumentList;
-import org.jbake.model.ModelAttributes;
 import org.jbake.template.ModelExtractor;
 
 import java.util.Map;
@@ -12,8 +11,10 @@ public class TaggedDocumentsExtractor implements ModelExtractor<DocumentList> {
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
         String tag = null;
-        if (model.get(ModelAttributes.TAG.toString()) != null) {
-            tag = model.get(ModelAttributes.TAG.toString()).toString();
+        TemplateModel templateModel = new TemplateModel();
+        templateModel.putAll(model);
+        if (templateModel.getTag() != null) {
+            tag = templateModel.getTag();
         }
         // fetch the tagged documents from db
         return db.getPublishedDocumentsByTag(tag);

--- a/jbake-core/src/main/java/org/jbake/template/model/TaggedDocumentsExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TaggedDocumentsExtractor.java
@@ -1,8 +1,8 @@
 package org.jbake.template.model;
 
 import org.jbake.app.ContentStore;
-import org.jbake.app.Crawler;
 import org.jbake.app.DocumentList;
+import org.jbake.model.DocumentAttributes;
 import org.jbake.template.ModelExtractor;
 
 import java.util.Map;
@@ -12,8 +12,8 @@ public class TaggedDocumentsExtractor implements ModelExtractor<DocumentList> {
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
         String tag = null;
-        if (model.get(Crawler.Attributes.TAG) != null) {
-            tag = model.get(Crawler.Attributes.TAG).toString();
+        if (model.get(DocumentAttributes.TAG.toString()) != null) {
+            tag = model.get(DocumentAttributes.TAG.toString()).toString();
         }
         // fetch the tagged documents from db
         return db.getPublishedDocumentsByTag(tag);

--- a/jbake-core/src/main/java/org/jbake/template/model/TagsExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TagsExtractor.java
@@ -15,7 +15,7 @@ public class TagsExtractor implements ModelExtractor<DocumentList> {
 
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
-        DocumentList dl = new DocumentList();
+        DocumentList<TemplateModel> dl = new DocumentList<>();
         TemplateModel templateModel = new TemplateModel();
         templateModel.putAll(model);
         Map<?, ?> config = templateModel.getConfig();

--- a/jbake-core/src/main/java/org/jbake/template/model/TagsExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TagsExtractor.java
@@ -3,9 +3,9 @@ package org.jbake.template.model;
 import org.jbake.app.ContentStore;
 import org.jbake.app.DocumentList;
 import org.jbake.app.FileUtil;
+import org.jbake.model.DocumentModel;
 import org.jbake.template.ModelExtractor;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.jbake.app.configuration.JBakeProperty.OUTPUT_EXTENSION;
@@ -22,15 +22,15 @@ public class TagsExtractor implements ModelExtractor<DocumentList> {
         String tagPath = config.get(TAG_PATH.replace(".", "_")).toString();
 
         for (String tag : db.getAllTags()) {
-            Map<String, Object> newTag = new HashMap<>();
+            DocumentModel newTag = new DocumentModel();
             String tagName = tag;
-            newTag.put("name", tagName);
+            newTag.setName(tagName);
 
             String uri = tagPath + FileUtil.URI_SEPARATOR_CHAR + tag + config.get(OUTPUT_EXTENSION.replace(".", "_")).toString();
 
-            newTag.put("uri", uri);
-            newTag.put("tagged_posts", db.getPublishedPostsByTag(tagName));
-            newTag.put("tagged_documents", db.getPublishedDocumentsByTag(tagName));
+            newTag.setUri(uri);
+            newTag.setTaggedPosts(db.getPublishedPostsByTag(tagName));
+            newTag.setTaggedDocuments(db.getPublishedDocumentsByTag(tagName));
             dl.push(newTag);
         }
         return dl;

--- a/jbake-core/src/main/java/org/jbake/template/model/TagsExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TagsExtractor.java
@@ -3,7 +3,6 @@ package org.jbake.template.model;
 import org.jbake.app.ContentStore;
 import org.jbake.app.DocumentList;
 import org.jbake.app.FileUtil;
-import org.jbake.model.DocumentModel;
 import org.jbake.template.ModelExtractor;
 
 import java.util.Map;
@@ -17,12 +16,14 @@ public class TagsExtractor implements ModelExtractor<DocumentList> {
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
         DocumentList dl = new DocumentList();
-        Map<?, ?> config = (Map<?, ?>) model.get("config");
+        TemplateModel templateModel = new TemplateModel();
+        templateModel.putAll(model);
+        Map<?, ?> config = templateModel.getConfig();
 
         String tagPath = config.get(TAG_PATH.replace(".", "_")).toString();
 
         for (String tag : db.getAllTags()) {
-            DocumentModel newTag = new DocumentModel();
+            TemplateModel newTag = new TemplateModel();
             String tagName = tag;
             newTag.setName(tagName);
 

--- a/jbake-core/src/main/java/org/jbake/template/model/TemplateModel.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TemplateModel.java
@@ -6,59 +6,72 @@ import org.jbake.model.DocumentModel;
 import org.jbake.model.ModelAttributes;
 import org.jbake.template.DelegatingTemplateEngine;
 
+import java.io.Writer;
 import java.util.Map;
 
 public class TemplateModel extends BaseModel {
 
     public Map<String, Object> getConfig() {
-        return (Map<String, Object>) get(ModelAttributes.CONFIG.toString());
+        return (Map<String, Object>) get(ModelAttributes.CONFIG);
     }
 
     public void setConfig(Map<String, Object> configModel) {
-        put(ModelAttributes.CONFIG.toString(), configModel);
-    }
-
-    public void setContent(DocumentModel content) {
-        put(ModelAttributes.CONTENT.toString(), content);
+        put(ModelAttributes.CONFIG, configModel);
     }
 
     public DocumentModel getContent() {
-        return (DocumentModel) get(ModelAttributes.CONTENT.toString());
+        return (DocumentModel) get(ModelAttributes.CONTENT);
+    }
+
+    public void setContent(DocumentModel content) {
+        put(ModelAttributes.CONTENT, content);
+    }
+
+    public DelegatingTemplateEngine getRenderer() {
+        return (DelegatingTemplateEngine) get(ModelAttributes.RENDERER);
     }
 
     public void setRenderer(DelegatingTemplateEngine renderingEngine) {
-        put(ModelAttributes.RENDERER.toString(), renderingEngine);
+        put(ModelAttributes.RENDERER, renderingEngine);
     }
 
     public void setNumberOfPages(int numberOfPages) {
-        put(ModelAttributes.NUMBER_OF_PAGES.toString(), numberOfPages);
+        put(ModelAttributes.NUMBER_OF_PAGES, numberOfPages);
     }
 
     public void setCurrentPageNuber(int currentPageNumber) {
-        put(ModelAttributes.CURRENT_PAGE_NUMBERS.toString(), currentPageNumber);
+        put(ModelAttributes.CURRENT_PAGE_NUMBERS, currentPageNumber);
     }
 
     public void setPreviousFilename(String previousFilename) {
-        put(ModelAttributes.PREVIOUS_FILENAME.toString(), previousFilename);
+        put(ModelAttributes.PREVIOUS_FILENAME, previousFilename);
     }
 
     public void setNextFileName(String nextFilename) {
-        put(ModelAttributes.NEXT_FILENAME.toString(), nextFilename);
+        put(ModelAttributes.NEXT_FILENAME, nextFilename);
+    }
+
+    public String getTag() {
+        return (String) get(ModelAttributes.TAG);
     }
 
     public void setTag(String tag) {
-        put(ModelAttributes.TAG.toString(), tag);
+        put(ModelAttributes.TAG, tag);
     }
 
     public void setTaggedPosts(DocumentList taggedPosts) {
-        put(ModelAttributes.TAGGED_POSTS.toString(), taggedPosts);
+        put(ModelAttributes.TAGGED_POSTS, taggedPosts);
     }
 
     public void setTaggedDocuments(DocumentList taggedDocuments) {
-        put(ModelAttributes.TAGGED_DOCUMENTS.toString(), taggedDocuments);
+        put(ModelAttributes.TAGGED_DOCUMENTS, taggedDocuments);
     }
 
     public void setVersion(String version) {
-        put(ModelAttributes.VERSION.toString(), version);
+        put(ModelAttributes.VERSION, version);
+    }
+
+    public Writer getWriter() {
+        return (Writer) get(ModelAttributes.OUT);
     }
 }

--- a/jbake-core/src/main/java/org/jbake/template/model/TemplateModel.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TemplateModel.java
@@ -11,6 +11,13 @@ import java.util.Map;
 
 public class TemplateModel extends BaseModel {
 
+    public TemplateModel() {
+    }
+
+    public TemplateModel(TemplateModel model) {
+        putAll(model);
+    }
+
     public Map<String, Object> getConfig() {
         return (Map<String, Object>) get(ModelAttributes.CONFIG);
     }

--- a/jbake-core/src/main/java/org/jbake/template/model/TemplateModel.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/TemplateModel.java
@@ -1,0 +1,64 @@
+package org.jbake.template.model;
+
+import org.jbake.app.DocumentList;
+import org.jbake.model.BaseModel;
+import org.jbake.model.DocumentModel;
+import org.jbake.model.ModelAttributes;
+import org.jbake.template.DelegatingTemplateEngine;
+
+import java.util.Map;
+
+public class TemplateModel extends BaseModel {
+
+    public Map<String, Object> getConfig() {
+        return (Map<String, Object>) get(ModelAttributes.CONFIG.toString());
+    }
+
+    public void setConfig(Map<String, Object> configModel) {
+        put(ModelAttributes.CONFIG.toString(), configModel);
+    }
+
+    public void setContent(DocumentModel content) {
+        put(ModelAttributes.CONTENT.toString(), content);
+    }
+
+    public DocumentModel getContent() {
+        return (DocumentModel) get(ModelAttributes.CONTENT.toString());
+    }
+
+    public void setRenderer(DelegatingTemplateEngine renderingEngine) {
+        put(ModelAttributes.RENDERER.toString(), renderingEngine);
+    }
+
+    public void setNumberOfPages(int numberOfPages) {
+        put(ModelAttributes.NUMBER_OF_PAGES.toString(), numberOfPages);
+    }
+
+    public void setCurrentPageNuber(int currentPageNumber) {
+        put(ModelAttributes.CURRENT_PAGE_NUMBERS.toString(), currentPageNumber);
+    }
+
+    public void setPreviousFilename(String previousFilename) {
+        put(ModelAttributes.PREVIOUS_FILENAME.toString(), previousFilename);
+    }
+
+    public void setNextFileName(String nextFilename) {
+        put(ModelAttributes.NEXT_FILENAME.toString(), nextFilename);
+    }
+
+    public void setTag(String tag) {
+        put(ModelAttributes.TAG.toString(), tag);
+    }
+
+    public void setTaggedPosts(DocumentList taggedPosts) {
+        put(ModelAttributes.TAGGED_POSTS.toString(), taggedPosts);
+    }
+
+    public void setTaggedDocuments(DocumentList taggedDocuments) {
+        put(ModelAttributes.TAGGED_DOCUMENTS.toString(), taggedDocuments);
+    }
+
+    public void setVersion(String version) {
+        put(ModelAttributes.VERSION.toString(), version);
+    }
+}

--- a/jbake-core/src/main/java/org/jbake/util/HtmlUtil.java
+++ b/jbake-core/src/main/java/org/jbake/util/HtmlUtil.java
@@ -1,13 +1,11 @@
 package org.jbake.util;
 
-import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentModel;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
-
-import java.util.Map;
 
 /**
  * @author Manik Magar
@@ -26,8 +24,8 @@ public class HtmlUtil {
      * @param fileContents  Map representing file contents
      * @param configuration Configuration object
      */
-    public static void fixImageSourceUrls(Map<String, Object> fileContents, JBakeConfiguration configuration) {
-        String htmlContent = fileContents.get(Attributes.BODY).toString();
+    public static void fixImageSourceUrls(DocumentModel fileContents, JBakeConfiguration configuration) {
+        String htmlContent = fileContents.getBody();
         boolean prependSiteHost = configuration.getImgPathPrependHost();
         String siteHost = configuration.getSiteHost();
         String uri = getDocumentUri(fileContents);
@@ -40,14 +38,14 @@ public class HtmlUtil {
         }
 
         //Use body().html() to prevent adding <body></body> from parsed fragment.
-        fileContents.put(Attributes.BODY, document.body().html());
+        fileContents.setBody(document.body().html());
     }
 
-    private static String getDocumentUri(Map<String, Object> fileContents) {
-        String uri = fileContents.get(Attributes.URI).toString();
+    private static String getDocumentUri(DocumentModel fileContents) {
+        String uri = fileContents.getUri();
 
-        if (fileContents.get(Attributes.NO_EXTENSION_URI) != null) {
-            uri = fileContents.get(Attributes.NO_EXTENSION_URI).toString();
+        if (fileContents.getNoExtensionUri() != null) {
+            uri = fileContents.getNoExtensionUri();
             uri = removeTrailingSlash(uri);
         }
 

--- a/jbake-core/src/test/java/org/jbake/FakeDocumentBuilder.java
+++ b/jbake-core/src/test/java/org/jbake/FakeDocumentBuilder.java
@@ -11,8 +11,8 @@ import java.util.Random;
 
 public class FakeDocumentBuilder {
 
-    DocumentModel fileModel = new DocumentModel();
-    String type;
+    private DocumentModel fileModel = new DocumentModel();
+    private String type;
     private boolean hasSourceUri = false;
     private boolean hasSha1 = false;
     private boolean hasDate = false;

--- a/jbake-core/src/test/java/org/jbake/FakeDocumentBuilder.java
+++ b/jbake-core/src/test/java/org/jbake/FakeDocumentBuilder.java
@@ -1,20 +1,17 @@
 package org.jbake;
 
 import com.orientechnologies.orient.core.record.impl.ODocument;
-import org.jbake.app.Crawler;
-import org.jbake.model.DocumentAttributes;
+import org.jbake.model.DocumentModel;
 
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Random;
 
 public class FakeDocumentBuilder {
 
-    Map<String, Object> fileModel = new HashMap<String, Object>();
+    DocumentModel fileModel = new DocumentModel();
     String type;
     private boolean hasSourceUri = false;
     private boolean hasSha1 = false;
@@ -25,53 +22,53 @@ public class FakeDocumentBuilder {
     }
 
     public FakeDocumentBuilder withName(String name) {
-        fileModel.put(DocumentAttributes.NAME.toString(), name);
+        fileModel.setName(name);
         return this;
     }
 
     public FakeDocumentBuilder withStatus(String status) {
-        fileModel.put(DocumentAttributes.STATUS.toString(), status);
+        fileModel.setStatus(status);
         return this;
     }
 
     public FakeDocumentBuilder withRandomSha1() throws NoSuchAlgorithmException {
-        fileModel.put(DocumentAttributes.SHA1.toString(), getRandomSha1());
+        fileModel.setSha1(getRandomSha1());
         hasSha1 = true;
         return this;
     }
 
     public FakeDocumentBuilder withDate(Date date) {
-        fileModel.put(Crawler.Attributes.DATE, date);
+        fileModel.setDate(date);
         hasDate = true;
         return this;
     }
 
     private FakeDocumentBuilder withCurrentDate() {
-        fileModel.put(Crawler.Attributes.DATE, new Date() );
+        fileModel.setDate(new Date());
         return this;
     }
 
     private FakeDocumentBuilder withRandomSourceUri() throws NoSuchAlgorithmException {
         String path = "/tmp/" + getRandomSha1() + ".txt";
-        fileModel.put(DocumentAttributes.SOURCE_URI.toString(), path);
+        fileModel.setSourceUri(path);
         return this;
     }
 
     public FakeDocumentBuilder withCached(boolean cached) {
-        fileModel.put(DocumentAttributes.CACHED.toString(), cached);
+        fileModel.setCached(cached);
         return this;
     }
 
     public void build() {
 
         try {
-            if ( ! hasSourceUri() ) {
+            if (!hasSourceUri()) {
                 this.withRandomSourceUri();
             }
-            if ( ! hasSha1() ) {
+            if (!hasSha1()) {
                 this.withRandomSha1();
             }
-            if ( ! hasDate() ) {
+            if (!hasDate()) {
                 this.withCurrentDate();
             }
             ODocument document = new ODocument(type).fromMap(fileModel);

--- a/jbake-core/src/test/java/org/jbake/FakeDocumentBuilder.java
+++ b/jbake-core/src/test/java/org/jbake/FakeDocumentBuilder.java
@@ -21,11 +21,6 @@ public class FakeDocumentBuilder {
         this.type = type;
     }
 
-    public FakeDocumentBuilder withName(String name) {
-        fileModel.setName(name);
-        return this;
-    }
-
     public FakeDocumentBuilder withStatus(String status) {
         fileModel.setStatus(status);
         return this;

--- a/jbake-core/src/test/java/org/jbake/app/AsciidocParserTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/AsciidocParserTest.java
@@ -4,6 +4,7 @@ import org.jbake.TestUtils;
 import org.jbake.app.configuration.ConfigUtil;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.jbake.app.configuration.JBakeProperty;
+import org.jbake.model.DocumentModel;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -134,76 +135,76 @@ public class AsciidocParserTest {
     public void parseAsciidocFileWithPrettifyAttribute() {
 
         config.setProperty(JBakeProperty.ASCIIDOCTOR_ATTRIBUTES,"source-highlighter=prettify");
-        Map<String, Object> map = parser.processFile(asciidocWithSource);
+        DocumentModel map = parser.processFile(asciidocWithSource);
         Assert.assertNotNull(map);
-        Assert.assertEquals("draft", map.get("status"));
-        Assert.assertEquals("post", map.get("type"));
-        assertThat(map.get("body").toString())
+        Assert.assertEquals("draft", map.getStatus());
+        Assert.assertEquals("post", map.getType());
+        assertThat(map.getBody())
                 .contains("class=\"paragraph\"")
                 .contains("<p>JBake now supports AsciiDoc.</p>")
                 .contains("class=\"prettyprint highlight\"");
 
-        assertThat(map.get("body").toString()).doesNotContain("I Love Jbake");
-        System.out.println(map.get("body").toString());
+        assertThat(map.getBody()).doesNotContain("I Love Jbake");
+        System.out.println(map.getBody());
     }
 
     @Test
     public void parseAsciidocFileWithCustomAttribute() {
 
         config.setProperty(JBakeProperty.ASCIIDOCTOR_ATTRIBUTES,"source-highlighter=prettify,testattribute=I Love Jbake");
-        Map<String, Object> map = parser.processFile(asciidocWithSource);
+        DocumentModel map = parser.processFile(asciidocWithSource);
         Assert.assertNotNull(map);
-        Assert.assertEquals("draft", map.get("status"));
-        Assert.assertEquals("post", map.get("type"));
-        assertThat(map.get("body").toString())
+        Assert.assertEquals("draft", map.getStatus());
+        Assert.assertEquals("post", map.getType());
+        assertThat(map.getBody())
                 .contains("I Love Jbake")
                 .contains("class=\"prettyprint highlight\"");
 
-        System.out.println(map.get("body").toString());
+        System.out.println(map.getBody());
     }
 
     @Test
     public void parseValidAsciiDocFile() {
-        Map<String, Object> map = parser.processFile(validAsciidocFile);
+        DocumentModel map = parser.processFile(validAsciidocFile);
         Assert.assertNotNull(map);
-        Assert.assertEquals("draft", map.get("status"));
-        Assert.assertEquals("post", map.get("type"));
-        assertThat(map.get("body").toString())
+        Assert.assertEquals("draft", map.getStatus());
+        Assert.assertEquals("post", map.getType());
+        assertThat(map.getBody())
             .contains("class=\"paragraph\"")
             .contains("<p>JBake now supports AsciiDoc.</p>");
     }
 
     @Test
     public void parseInvalidAsciiDocFile() {
-        Map<String, Object> map = parser.processFile(invalidAsciiDocFile);
+        DocumentModel map = parser.processFile(invalidAsciiDocFile);
         Assert.assertNull(map);
     }
 
     @Test
     public void parseValidAsciiDocFileWithoutHeader() {
-        Map<String, Object> map = parser.processFile(validAsciiDocFileWithoutHeader);
+        DocumentModel map = parser.processFile(validAsciiDocFileWithoutHeader);
         Assert.assertNotNull(map);
         Assert.assertEquals("Hello: AsciiDoc!", map.get("title"));
-        Assert.assertEquals("published", map.get("status"));
-        Assert.assertEquals("page", map.get("type"));
-        assertThat(map.get("body").toString())
+        Assert.assertEquals("published", map.getStatus());
+        Assert.assertEquals("page", map.getType());
+        assertThat(map.getBody())
             .contains("class=\"paragraph\"")
             .contains("<p>JBake now supports AsciiDoc.</p>");
     }
 
     @Test
     public void parseInvalidAsciiDocFileWithoutHeader() {
-        Map<String, Object> map = parser.processFile(invalidAsciiDocFileWithoutHeader);
+        DocumentModel map = parser.processFile(invalidAsciiDocFileWithoutHeader);
         Assert.assertNull(map);
     }
 
     @Test
     public void parseValidAsciiDocFileWithExampleHeaderInContent() {
-        Map<String, Object> map = parser.processFile(validAsciiDocFileWithHeaderInContent);
+        DocumentModel map = parser.processFile(validAsciiDocFileWithHeaderInContent);
         Assert.assertNotNull(map);
-        Assert.assertEquals("published", map.get("status"));
-        Assert.assertEquals("page", map.get("type"));
-        assertThat(map.get("body").toString())
+        Assert.assertEquals("published", map.getStatus());
+        Assert.assertEquals("page", map.getType());
+        assertThat(map.getBody())
             .contains("class=\"paragraph\"")
             .contains("<p>JBake now supports AsciiDoc.</p>")
             .contains("class=\"listingblock\"")
@@ -219,11 +220,11 @@ public class AsciidocParserTest {
         config.setDefaultStatus("published");
         config.setDefaultType("page");
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(validAsciiDocFileWithoutJBakeMetaData);
+        DocumentModel map = parser.processFile(validAsciiDocFileWithoutJBakeMetaData);
         Assert.assertNotNull(map);
-        Assert.assertEquals("published", map.get("status"));
-        Assert.assertEquals("page", map.get("type"));
-        assertThat(map.get("body").toString())
+        Assert.assertEquals("published", map.getStatus());
+        Assert.assertEquals("page", map.getType());
+        assertThat(map.getBody())
             .contains("<p>JBake now supports AsciiDoc documents without JBake meta data.</p>");
     }
 

--- a/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
@@ -1,26 +1,20 @@
 package org.jbake.app;
 
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import org.jbake.FakeDocumentBuilder;
+import org.jbake.model.DocumentModel;
+import org.jbake.model.DocumentTypes;
+import org.jbake.model.ModelAttributes.Status;
+import org.junit.Test;
+
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
-
-import org.assertj.core.api.Assertions;
-import org.jbake.FakeDocumentBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jbake.app.ContentStore.quoteIdentifier;
-
-import org.jbake.app.Crawler.Attributes.Status;
-import org.jbake.model.DocumentModel;
-import org.jbake.model.DocumentTypes;
 import static org.junit.Assert.assertEquals;
-
-import org.jbake.model.ModelAttributes;
 import static org.junit.Assert.assertNull;
-import org.junit.Test;
 
 public class ContentStoreTest extends ContentStoreIntegrationTest {
 
@@ -50,9 +44,9 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
         final String uri = "test/testMergeDocument";
 
         ODocument doc = new ODocument(DOC_TYPE_POST);
-        Map<String, String> values = new HashMap();
-        values.put(ModelAttributes.TYPE.toString(), DOC_TYPE_POST);
-        values.put(ModelAttributes.SOURCE_URI.toString(), uri);
+        DocumentModel values = new DocumentModel();
+        values.setType(DOC_TYPE_POST);
+        values.setSourceUri(uri);
         values.put("foo", "originalValue");
         doc.fromMap(values);
         doc.save();
@@ -61,7 +55,7 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
         values.put("foo", "newValue");
         db.mergeDocument(values);
 
-        DocumentList docs = db.getDocumentByUri(DOC_TYPE_POST, uri);
+        DocumentList<DocumentModel> docs = db.getDocumentByUri(DOC_TYPE_POST, uri);
         assertEquals(1, docs.size());
         assertEquals("newValue", docs.get(0).get("foo"));
 
@@ -101,15 +95,15 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
         doc.fromMap(model);
         doc.save();
 
-        DocumentList documentList1 = db.getAllContent(typeWithHyphen);
+        DocumentList<DocumentModel> documentList1 = db.getAllContent(typeWithHyphen);
 
         assertEquals(1, documentList1.size());
 
-        DocumentList documentList2 = db.getAllContent(typeWithHyphen, true);
+        DocumentList<DocumentModel> documentList2 = db.getAllContent(typeWithHyphen, true);
 
         assertEquals(1, documentList2.size());
 
-        DocumentList documentList3 =  db.getDocumentByUri(typeWithHyphen, uri);
+        DocumentList<DocumentModel> documentList3 =  db.getDocumentByUri(typeWithHyphen, uri);
 
         assertEquals(1, documentList3.size());
 
@@ -117,44 +111,44 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
 
         assertEquals(1L, documentCount1);
 
-        DocumentList documentList4 = db.getDocumentStatus(typeWithHyphen, uri);
+        DocumentList<DocumentModel> documentList4 = db.getDocumentStatus(typeWithHyphen, uri);
 
         assertEquals(1, documentList4.size());
-        assertEquals(Boolean.FALSE, documentList4.get(0).get(String.valueOf(ModelAttributes.RENDERED)));
+        assertEquals(Boolean.FALSE, documentList4.get(0).getRendered());
 
         long documentCount2 = db.getPublishedCount(typeWithHyphen);
         assertEquals(0, documentCount2);
 
-        Map<String,Object> published = new HashMap<>();
-        published.put(ModelAttributes.SOURCE_URI.toString(), uri);
-        published.put(ModelAttributes.TYPE.toString(), typeWithHyphen);
-        published.put(ModelAttributes.STATUS.toString(), Status.PUBLISHED);
+        DocumentModel published = new DocumentModel();
+        published.setSourceUri(uri);
+        published.setType(typeWithHyphen);
+        published.setStatus(Status.PUBLISHED);
         db.mergeDocument(published);
 
-        DocumentList documentList5 = db.getUnrenderedContent(typeWithHyphen);
+        DocumentList<DocumentModel> documentList5 = db.getUnrenderedContent(typeWithHyphen);
         assertEquals(1, documentList5.size());
-        assertEquals(Boolean.FALSE, documentList5.get(0).get(String.valueOf(ModelAttributes.RENDERED)));
-        assertEquals(typeWithHyphen, documentList5.get(0).get(ModelAttributes.TYPE.toString()));
-        assertThat((String[])documentList5.get(0).get(ModelAttributes.TAGS.toString())).contains(tagWithHyphen);
+        assertEquals(Boolean.FALSE, documentList5.get(0).getRendered());
+        assertEquals(typeWithHyphen, documentList5.get(0).getType());
+        assertThat(documentList5.get(0).getTags()).contains(tagWithHyphen);
 
         long documentCount3 = db.getPublishedCount(typeWithHyphen);
         assertEquals(1, documentCount3);
 
         db.markContentAsRendered(typeWithHyphen);
 
-        DocumentList documentList6 = db.getPublishedContent(typeWithHyphen);
+        DocumentList<DocumentModel> documentList6 = db.getPublishedContent(typeWithHyphen);
         assertEquals(1, documentList6.size());
-        assertEquals(Boolean.TRUE, documentList6.get(0).get(String.valueOf(ModelAttributes.RENDERED)));
-        assertEquals(typeWithHyphen, documentList6.get(0).get(ModelAttributes.TYPE.toString()));
-        assertThat((String[])documentList6.get(0).get(ModelAttributes.TAGS.toString())).contains(tagWithHyphen);
+        assertEquals(Boolean.TRUE, documentList6.get(0).getRendered());
+        assertEquals(typeWithHyphen, documentList6.get(0).getType());
+        assertThat(documentList6.get(0).getTags()).contains(tagWithHyphen);
 
-        DocumentList documentList7 = db.getPublishedDocumentsByTag(tagWithHyphen);
+        DocumentList<DocumentModel> documentList7 = db.getPublishedDocumentsByTag(tagWithHyphen);
         assertEquals(1, documentList7.size());
-        assertEquals(Boolean.TRUE, documentList7.get(0).get(String.valueOf(ModelAttributes.RENDERED)));
-        assertEquals(typeWithHyphen, documentList7.get(0).get(ModelAttributes.TYPE.toString()));
-        assertThat((String[])documentList7.get(0).get(ModelAttributes.TAGS.toString())).contains(tagWithHyphen);
+        assertEquals(Boolean.TRUE, documentList7.get(0).getRendered());
+        assertEquals(typeWithHyphen, documentList7.get(0).getType());
+        assertThat(documentList7.get(0).getTags()).contains(tagWithHyphen);
 
-        DocumentList documentList8 = db.getPublishedPostsByTag(tagWithHyphen);
+        DocumentList<DocumentModel> documentList8 = db.getPublishedPostsByTag(tagWithHyphen);
         assertEquals(0, documentList8.size());
 
         Set<String> tags = db.getAllTags();

--- a/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
@@ -6,14 +6,19 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import org.assertj.core.api.Assertions;
 import org.jbake.FakeDocumentBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jbake.app.ContentStore.quoteIdentifier;
 
 import org.jbake.app.Crawler.Attributes.Status;
-import org.jbake.model.DocumentAttributes;
 import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import static org.junit.Assert.assertEquals;
+
+import org.jbake.model.ModelAttributes;
 import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
@@ -26,15 +31,13 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
 
         for (int i = 0; i < 5; i++) {
             FakeDocumentBuilder builder = new FakeDocumentBuilder(DOC_TYPE_POST);
-            builder.withName("dummyfile" + i)
-                    .withStatus("published")
+            builder.withStatus("published")
                     .withRandomSha1()
                     .build();
         }
 
         FakeDocumentBuilder builder = new FakeDocumentBuilder(DOC_TYPE_POST);
-        builder.withName("draftdummy")
-                .withStatus("draft")
+        builder.withStatus("draft")
                 .withRandomSha1()
                 .build();
 
@@ -48,8 +51,8 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
 
         ODocument doc = new ODocument(DOC_TYPE_POST);
         Map<String, String> values = new HashMap();
-        values.put(DocumentAttributes.TYPE.toString(), DOC_TYPE_POST);
-        values.put(DocumentAttributes.SOURCE_URI.toString(), uri);
+        values.put(ModelAttributes.TYPE.toString(), DOC_TYPE_POST);
+        values.put(ModelAttributes.SOURCE_URI.toString(), uri);
         values.put("foo", "originalValue");
         doc.fromMap(values);
         doc.save();
@@ -86,7 +89,6 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
 
         DocumentModel model = new DocumentModel();
         model.setType(typeWithHyphen);
-        model.setTag(tagWithHyphen);
         model.setTags(new String[]{tagWithHyphen});
         model.setStatus(Status.DRAFT);
         model.setDate(new Date());
@@ -118,22 +120,22 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
         DocumentList documentList4 = db.getDocumentStatus(typeWithHyphen, uri);
 
         assertEquals(1, documentList4.size());
-        assertEquals(Boolean.FALSE, documentList4.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
+        assertEquals(Boolean.FALSE, documentList4.get(0).get(String.valueOf(ModelAttributes.RENDERED)));
 
         long documentCount2 = db.getPublishedCount(typeWithHyphen);
         assertEquals(0, documentCount2);
 
         Map<String,Object> published = new HashMap<>();
-        published.put(DocumentAttributes.SOURCE_URI.toString(), uri);
-        published.put(DocumentAttributes.TYPE.toString(), typeWithHyphen);
-        published.put(DocumentAttributes.STATUS.toString(), Status.PUBLISHED);
+        published.put(ModelAttributes.SOURCE_URI.toString(), uri);
+        published.put(ModelAttributes.TYPE.toString(), typeWithHyphen);
+        published.put(ModelAttributes.STATUS.toString(), Status.PUBLISHED);
         db.mergeDocument(published);
 
         DocumentList documentList5 = db.getUnrenderedContent(typeWithHyphen);
         assertEquals(1, documentList5.size());
-        assertEquals(Boolean.FALSE, documentList5.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
-        assertEquals(typeWithHyphen, documentList5.get(0).get(DocumentAttributes.TYPE.toString()));
-        assertEquals(tagWithHyphen, documentList5.get(0).get(DocumentAttributes.TAG.toString()));
+        assertEquals(Boolean.FALSE, documentList5.get(0).get(String.valueOf(ModelAttributes.RENDERED)));
+        assertEquals(typeWithHyphen, documentList5.get(0).get(ModelAttributes.TYPE.toString()));
+        assertThat((String[])documentList5.get(0).get(ModelAttributes.TAGS.toString())).contains(tagWithHyphen);
 
         long documentCount3 = db.getPublishedCount(typeWithHyphen);
         assertEquals(1, documentCount3);
@@ -142,15 +144,15 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
 
         DocumentList documentList6 = db.getPublishedContent(typeWithHyphen);
         assertEquals(1, documentList6.size());
-        assertEquals(Boolean.TRUE, documentList6.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
-        assertEquals(typeWithHyphen, documentList6.get(0).get(DocumentAttributes.TYPE.toString()));
-        assertEquals(tagWithHyphen, documentList6.get(0).get(DocumentAttributes.TAG.toString()));
+        assertEquals(Boolean.TRUE, documentList6.get(0).get(String.valueOf(ModelAttributes.RENDERED)));
+        assertEquals(typeWithHyphen, documentList6.get(0).get(ModelAttributes.TYPE.toString()));
+        assertThat((String[])documentList6.get(0).get(ModelAttributes.TAGS.toString())).contains(tagWithHyphen);
 
         DocumentList documentList7 = db.getPublishedDocumentsByTag(tagWithHyphen);
         assertEquals(1, documentList7.size());
-        assertEquals(Boolean.TRUE, documentList7.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
-        assertEquals(typeWithHyphen, documentList7.get(0).get(DocumentAttributes.TYPE.toString()));
-        assertEquals(tagWithHyphen, documentList7.get(0).get(DocumentAttributes.TAG.toString()));
+        assertEquals(Boolean.TRUE, documentList7.get(0).get(String.valueOf(ModelAttributes.RENDERED)));
+        assertEquals(typeWithHyphen, documentList7.get(0).get(ModelAttributes.TYPE.toString()));
+        assertThat((String[])documentList7.get(0).get(ModelAttributes.TAGS.toString())).contains(tagWithHyphen);
 
         DocumentList documentList8 = db.getPublishedPostsByTag(tagWithHyphen);
         assertEquals(0, documentList8.size());

--- a/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
@@ -11,6 +11,7 @@ import static org.jbake.app.ContentStore.quoteIdentifier;
 
 import org.jbake.app.Crawler.Attributes.Status;
 import org.jbake.model.DocumentAttributes;
+import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -83,20 +84,19 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
         final String tagWithHyphen = "tag-with-hyphen";
         final String uri = "test/testMergeDocument";
 
-        Map<String, Object> values = new HashMap();
-        values.put(DocumentAttributes.TYPE.toString(), typeWithHyphen);
-        values.put(Crawler.Attributes.TAG, tagWithHyphen);
-        values.put(DocumentAttributes.TAGS.toString(), new String[]{tagWithHyphen});
-        values.put(DocumentAttributes.STATUS.toString(), Status.DRAFT);
-        values.put(DocumentAttributes.DATE.toString(), new Date());
-        values.put(DocumentAttributes.RENDERED.toString(), false);
-        values.put(DocumentAttributes.SOURCE_URI.toString(), uri);
-        values.put(DocumentAttributes.CACHED.toString(), true);
-        values.put(DocumentAttributes.RENDERED.toString(), false);
-        values.put("foo", "originalValue");
+        DocumentModel model = new DocumentModel();
+        model.setType(typeWithHyphen);
+        model.setTag(tagWithHyphen);
+        model.setTags(new String[]{tagWithHyphen});
+        model.setStatus(Status.DRAFT);
+        model.setDate(new Date());
+        model.setRendered(false);
+        model.setSourceUri(uri);
+        model.setCached(true);
+        model.put("foo", "originalValue");
 
         ODocument doc = new ODocument(typeWithHyphen);
-        doc.fromMap(values);
+        doc.fromMap(model);
         doc.save();
 
         DocumentList documentList1 = db.getAllContent(typeWithHyphen);
@@ -133,7 +133,7 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
         assertEquals(1, documentList5.size());
         assertEquals(Boolean.FALSE, documentList5.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
         assertEquals(typeWithHyphen, documentList5.get(0).get(DocumentAttributes.TYPE.toString()));
-        assertEquals(tagWithHyphen, documentList5.get(0).get(Crawler.Attributes.TAG));
+        assertEquals(tagWithHyphen, documentList5.get(0).get(DocumentAttributes.TAG.toString()));
 
         long documentCount3 = db.getPublishedCount(typeWithHyphen);
         assertEquals(1, documentCount3);
@@ -144,13 +144,13 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
         assertEquals(1, documentList6.size());
         assertEquals(Boolean.TRUE, documentList6.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
         assertEquals(typeWithHyphen, documentList6.get(0).get(DocumentAttributes.TYPE.toString()));
-        assertEquals(tagWithHyphen, documentList6.get(0).get(Crawler.Attributes.TAG));
+        assertEquals(tagWithHyphen, documentList6.get(0).get(DocumentAttributes.TAG.toString()));
 
         DocumentList documentList7 = db.getPublishedDocumentsByTag(tagWithHyphen);
         assertEquals(1, documentList7.size());
         assertEquals(Boolean.TRUE, documentList7.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
         assertEquals(typeWithHyphen, documentList7.get(0).get(DocumentAttributes.TYPE.toString()));
-        assertEquals(tagWithHyphen, documentList7.get(0).get(Crawler.Attributes.TAG));
+        assertEquals(tagWithHyphen, documentList7.get(0).get(DocumentAttributes.TAG.toString()));
 
         DocumentList documentList8 = db.getPublishedPostsByTag(tagWithHyphen);
         assertEquals(0, documentList8.size());

--- a/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import org.jbake.FakeDocumentBuilder;
 import static org.jbake.app.ContentStore.quoteIdentifier;
+
 import org.jbake.app.Crawler.Attributes.Status;
 import org.jbake.model.DocumentAttributes;
 import org.jbake.model.DocumentTypes;
@@ -46,7 +47,7 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
 
         ODocument doc = new ODocument(DOC_TYPE_POST);
         Map<String, String> values = new HashMap();
-        values.put(Crawler.Attributes.TYPE, DOC_TYPE_POST);
+        values.put(DocumentAttributes.TYPE.toString(), DOC_TYPE_POST);
         values.put(DocumentAttributes.SOURCE_URI.toString(), uri);
         values.put("foo", "originalValue");
         doc.fromMap(values);
@@ -83,11 +84,11 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
         final String uri = "test/testMergeDocument";
 
         Map<String, Object> values = new HashMap();
-        values.put(Crawler.Attributes.TYPE, typeWithHyphen);
+        values.put(DocumentAttributes.TYPE.toString(), typeWithHyphen);
         values.put(Crawler.Attributes.TAG, tagWithHyphen);
-        values.put(Crawler.Attributes.TAGS, new String[]{tagWithHyphen});
-        values.put(Crawler.Attributes.STATUS, Status.DRAFT);
-        values.put(Crawler.Attributes.DATE, new Date());
+        values.put(DocumentAttributes.TAGS.toString(), new String[]{tagWithHyphen});
+        values.put(DocumentAttributes.STATUS.toString(), Status.DRAFT);
+        values.put(DocumentAttributes.DATE.toString(), new Date());
         values.put(DocumentAttributes.RENDERED.toString(), false);
         values.put(DocumentAttributes.SOURCE_URI.toString(), uri);
         values.put(DocumentAttributes.CACHED.toString(), true);
@@ -124,14 +125,14 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
 
         Map<String,Object> published = new HashMap<>();
         published.put(DocumentAttributes.SOURCE_URI.toString(), uri);
-        published.put(Crawler.Attributes.TYPE, typeWithHyphen);
-        published.put(Crawler.Attributes.STATUS, Status.PUBLISHED);
+        published.put(DocumentAttributes.TYPE.toString(), typeWithHyphen);
+        published.put(DocumentAttributes.STATUS.toString(), Status.PUBLISHED);
         db.mergeDocument(published);
 
         DocumentList documentList5 = db.getUnrenderedContent(typeWithHyphen);
         assertEquals(1, documentList5.size());
         assertEquals(Boolean.FALSE, documentList5.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
-        assertEquals(typeWithHyphen, documentList5.get(0).get(Crawler.Attributes.TYPE));
+        assertEquals(typeWithHyphen, documentList5.get(0).get(DocumentAttributes.TYPE.toString()));
         assertEquals(tagWithHyphen, documentList5.get(0).get(Crawler.Attributes.TAG));
 
         long documentCount3 = db.getPublishedCount(typeWithHyphen);
@@ -142,13 +143,13 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
         DocumentList documentList6 = db.getPublishedContent(typeWithHyphen);
         assertEquals(1, documentList6.size());
         assertEquals(Boolean.TRUE, documentList6.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
-        assertEquals(typeWithHyphen, documentList6.get(0).get(Crawler.Attributes.TYPE));
+        assertEquals(typeWithHyphen, documentList6.get(0).get(DocumentAttributes.TYPE.toString()));
         assertEquals(tagWithHyphen, documentList6.get(0).get(Crawler.Attributes.TAG));
 
         DocumentList documentList7 = db.getPublishedDocumentsByTag(tagWithHyphen);
         assertEquals(1, documentList7.size());
         assertEquals(Boolean.TRUE, documentList7.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
-        assertEquals(typeWithHyphen, documentList7.get(0).get(Crawler.Attributes.TYPE));
+        assertEquals(typeWithHyphen, documentList7.get(0).get(DocumentAttributes.TYPE.toString()));
         assertEquals(tagWithHyphen, documentList7.get(0).get(Crawler.Attributes.TAG));
 
         DocumentList documentList8 = db.getPublishedPostsByTag(tagWithHyphen);

--- a/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
@@ -3,7 +3,6 @@ package org.jbake.app;
 import org.apache.commons.io.FilenameUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
-import org.jbake.model.BaseModel;
 import org.jbake.model.DocumentModel;
 import org.jbake.model.ModelAttributes;
 import org.junit.Assert;
@@ -26,7 +25,7 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
         Assert.assertEquals(4, db.getDocumentCount("post"));
         Assert.assertEquals(3, db.getDocumentCount("page"));
 
-        DocumentList results = db.getPublishedPosts();
+        DocumentList<DocumentModel> results = db.getPublishedPosts();
 
         assertThat(results.size()).isEqualTo(3);
 
@@ -36,19 +35,18 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
                     .containsValue("../../../");
         }
 
-        DocumentList allPosts = db.getAllContent("post");
+        DocumentList<DocumentModel> allPosts = db.getAllContent("post");
 
         assertThat(allPosts.size()).isEqualTo(4);
 
-        for (BaseModel content : allPosts) {
-            DocumentModel documentModel = (DocumentModel) content;
-            if (documentModel.getTitle().equals("Draft Post")) {
+        for (DocumentModel content : allPosts) {
+            if (content.getTitle().equals("Draft Post")) {
                 assertThat(content).containsKey(ModelAttributes.DATE);
             }
         }
 
         // covers bug #213
-        DocumentList publishedPostsByTag = db.getPublishedPostsByTag("blog");
+        DocumentList<DocumentModel> publishedPostsByTag = db.getPublishedPostsByTag("blog");
         Assert.assertEquals(3, publishedPostsByTag.size());
     }
 
@@ -64,15 +62,14 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
         Assert.assertEquals(4, db.getDocumentCount("post"));
         Assert.assertEquals(3, db.getDocumentCount("page"));
 
-        DocumentList documents = db.getPublishedPosts();
+        DocumentList<DocumentModel> documents = db.getPublishedPosts();
 
-        for (BaseModel model : documents) {
-            DocumentModel documentModel = (DocumentModel) model;
-            String noExtensionUri = "blog/\\d{4}/" + FilenameUtils.getBaseName(documentModel.getFile()) + "/";
+        for (DocumentModel model : documents) {
+            String noExtensionUri = "blog/\\d{4}/" + FilenameUtils.getBaseName(model.getFile()) + "/";
 
-            Assert.assertThat(documentModel.getNoExtensionUri(), RegexMatcher.matches(noExtensionUri));
-            Assert.assertThat(documentModel.getUri(), RegexMatcher.matches(noExtensionUri + "index\\.html"));
-            Assert.assertThat(documentModel.getRootPath(), is("../../../"));
+            Assert.assertThat(model.getNoExtensionUri(), RegexMatcher.matches(noExtensionUri));
+            Assert.assertThat(model.getUri(), RegexMatcher.matches(noExtensionUri + "index\\.html"));
+            Assert.assertThat(model.getRootPath(), is("../../../"));
         }
     }
 

--- a/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
@@ -3,7 +3,7 @@ package org.jbake.app;
 import org.apache.commons.io.FilenameUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
-import org.jbake.model.DocumentAttributes;
+import org.jbake.model.ModelAttributes;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -29,7 +29,7 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
 
         for (Map<String, Object> content : results) {
             assertThat(content)
-                    .containsKey(DocumentAttributes.ROOTPATH.toString())
+                    .containsKey(ModelAttributes.ROOTPATH.toString())
                     .containsValue("../../../");
         }
 
@@ -38,8 +38,8 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
         assertThat(allPosts.size()).isEqualTo(4);
 
         for (Map<String, Object> content : allPosts) {
-            if (content.get(DocumentAttributes.TITLE.toString()).equals("Draft Post")) {
-                assertThat(content).containsKey(DocumentAttributes.DATE.toString());
+            if (content.get(ModelAttributes.TITLE.toString()).equals("Draft Post")) {
+                assertThat(content).containsKey(ModelAttributes.DATE.toString());
             }
         }
 
@@ -49,7 +49,7 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
     }
 
     @Test
-    public void renderWithPrettyUrls() throws Exception {
+    public void renderWithPrettyUrls() {
 
         config.setUriWithoutExtension(true);
         config.setPrefixForUriWithoutExtension("/blog");

--- a/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
@@ -3,6 +3,7 @@ package org.jbake.app;
 import org.apache.commons.io.FilenameUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.jbake.model.DocumentAttributes;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -28,7 +29,7 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
 
         for (Map<String, Object> content : results) {
             assertThat(content)
-                    .containsKey(Crawler.Attributes.ROOTPATH)
+                    .containsKey(DocumentAttributes.ROOTPATH.toString())
                     .containsValue("../../../");
         }
 
@@ -37,8 +38,8 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
         assertThat(allPosts.size()).isEqualTo(4);
 
         for (Map<String, Object> content : allPosts) {
-            if (content.get(Crawler.Attributes.TITLE).equals("Draft Post")) {
-                assertThat(content).containsKey(Crawler.Attributes.DATE);
+            if (content.get(DocumentAttributes.TITLE.toString()).equals("Draft Post")) {
+                assertThat(content).containsKey(DocumentAttributes.DATE.toString());
             }
         }
 

--- a/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
@@ -3,6 +3,8 @@ package org.jbake.app;
 import org.apache.commons.io.FilenameUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.jbake.model.BaseModel;
+import org.jbake.model.DocumentModel;
 import org.jbake.model.ModelAttributes;
 import org.junit.Assert;
 import org.junit.Before;
@@ -12,6 +14,7 @@ import org.junit.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 
 public class CrawlerTest extends ContentStoreIntegrationTest {
 
@@ -29,7 +32,7 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
 
         for (Map<String, Object> content : results) {
             assertThat(content)
-                    .containsKey(ModelAttributes.ROOTPATH.toString())
+                    .containsKey(ModelAttributes.ROOTPATH)
                     .containsValue("../../../");
         }
 
@@ -37,9 +40,10 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
 
         assertThat(allPosts.size()).isEqualTo(4);
 
-        for (Map<String, Object> content : allPosts) {
-            if (content.get(ModelAttributes.TITLE.toString()).equals("Draft Post")) {
-                assertThat(content).containsKey(ModelAttributes.DATE.toString());
+        for (BaseModel content : allPosts) {
+            DocumentModel documentModel = (DocumentModel) content;
+            if (documentModel.getTitle().equals("Draft Post")) {
+                assertThat(content).containsKey(ModelAttributes.DATE);
             }
         }
 
@@ -62,13 +66,13 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
 
         DocumentList documents = db.getPublishedPosts();
 
-        for (Map<String, Object> model : documents) {
-            String noExtensionUri = "blog/\\d{4}/" + FilenameUtils.getBaseName((String) model.get("file")) + "/";
+        for (BaseModel model : documents) {
+            DocumentModel documentModel = (DocumentModel) model;
+            String noExtensionUri = "blog/\\d{4}/" + FilenameUtils.getBaseName(documentModel.getFile()) + "/";
 
-            Assert.assertThat(model.get("noExtensionUri"), RegexMatcher.matches(noExtensionUri));
-            Assert.assertThat(model.get("uri"), RegexMatcher.matches(noExtensionUri + "index\\.html"));
-
-            assertThat(model).containsEntry("rootpath", "../../../");
+            Assert.assertThat(documentModel.getNoExtensionUri(), RegexMatcher.matches(noExtensionUri));
+            Assert.assertThat(documentModel.getUri(), RegexMatcher.matches(noExtensionUri + "index\\.html"));
+            Assert.assertThat(documentModel.getRootPath(), is("../../../"));
         }
     }
 

--- a/jbake-core/src/test/java/org/jbake/app/MdParserTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/MdParserTest.java
@@ -1,9 +1,9 @@
-
 package org.jbake.app;
 
 import org.jbake.TestUtils;
 import org.jbake.app.configuration.ConfigUtil;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
+import org.jbake.model.DocumentModel;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -12,14 +12,13 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.PrintWriter;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests basic Markdown syntax and the extensions supported by the Markdown
  * processor (Pegdown).
- * 
+ *
  * @author Jonathan Bullock <jonbullock@gmail.com>
  * @author Kevin S. Clarke <ksclarke@gmail.com>
  */
@@ -232,440 +231,440 @@ public class MdParserTest {
     }
 
     @Test
-    public void parseValidMarkdownFileBasic() throws Exception {
+    public void parseValidMarkdownFileBasic() {
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(validMdFileBasic);
-        Assert.assertNotNull(map);
-        Assert.assertEquals("draft", map.get("status"));
-        Assert.assertEquals("post", map.get("type"));
-        Assert.assertEquals("<h1>This is a test</h1>\n", map.get("body"));
+        DocumentModel documentModel = parser.processFile(validMdFileBasic);
+        Assert.assertNotNull(documentModel);
+        Assert.assertEquals("draft", documentModel.getStatus());
+        Assert.assertEquals("post", documentModel.getType());
+        Assert.assertEquals("<h1>This is a test</h1>\n", documentModel.getBody());
     }
 
     @Test
     public void parseInvalidMarkdownFileBasic() {
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(invalidMdFileBasic);
-        Assert.assertNull(map);
+        DocumentModel documentModel = parser.processFile(invalidMdFileBasic);
+        Assert.assertNull(documentModel);
     }
 
     @Test
-    public void parseValidMdFileHardWraps() throws Exception {
+    public void parseValidMdFileHardWraps() {
         config.setMarkdownExtensions("HARDWRAPS");
 
         // Test with HARDWRAPS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileHardWraps);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>First line<br />\nSecond line</p>\n");
+        DocumentModel documentModel = parser.processFile(mdFileHardWraps);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>First line<br />\nSecond line</p>\n");
 
         // Test without HARDWRAPS
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileHardWraps);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>First line Second line</p>");
+        documentModel = parser.processFile(mdFileHardWraps);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>First line Second line</p>");
     }
 
     @Test
-    public void parseWithInvalidExtension() throws Exception {
+    public void parseWithInvalidExtension() {
         config.setMarkdownExtensions("HARDWRAPS,UNDEFINED_EXTENSION");
 
         // Test with HARDWRAPS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileHardWraps);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>First line<br />\nSecond line</p>\n");
+        DocumentModel documentModel = parser.processFile(mdFileHardWraps);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>First line<br />\nSecond line</p>\n");
     }
 
     @Test
-    public void parseValidMdFileAbbreviations() throws Exception {
+    public void parseValidMdFileAbbreviations() {
         config.setMarkdownExtensions("ABBREVIATIONS");
 
         // Test with ABBREVIATIONS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileAbbreviations);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        DocumentModel documentModel = parser.processFile(mdFileAbbreviations);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<p><abbr title=\"Hyper Text Markup Language\">HTML</abbr></p>"
         );
 
         // Test without ABBREVIATIONS
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileAbbreviations);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>*[HTML]: Hyper Text Markup Language HTML</p>");
+        documentModel = parser.processFile(mdFileAbbreviations);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>*[HTML]: Hyper Text Markup Language HTML</p>");
     }
 
     @Test
-    public void parseValidMdFileAutolinks() throws Exception {
+    public void parseValidMdFileAutolinks() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("AUTOLINKS");
 
         // Test with AUTOLINKS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileAutolinks);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        DocumentModel documentModel = parser.processFile(mdFileAutolinks);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<p><a href=\"http://github.com\">http://github.com</a></p>"
         );
 
         // Test without AUTOLINKS
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileAutolinks);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>http://github.com</p>");
+        documentModel = parser.processFile(mdFileAutolinks);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>http://github.com</p>");
     }
 
     @Test
-    public void parseValidMdFileDefinitions() throws Exception {
+    public void parseValidMdFileDefinitions() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("DEFINITIONS");
 
         // Test with DEFINITIONS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileDefinitions);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        DocumentModel documentModel = parser.processFile(mdFileDefinitions);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<dl>\n<dt>Apple</dt>\n<dd>Pomaceous fruit</dd>\n</dl>"
         );
 
         // Test without DEFNITIONS
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileDefinitions);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>Apple :   Pomaceous fruit</p>");
+        documentModel = parser.processFile(mdFileDefinitions);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>Apple :   Pomaceous fruit</p>");
     }
 
     @Test
-    public void parseValidMdFileFencedCodeBlocks() throws Exception {
+    public void parseValidMdFileFencedCodeBlocks() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("FENCED_CODE_BLOCKS");
 
         // Test with FENCED_CODE_BLOCKS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileFencedCodeBlocks);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        DocumentModel documentModel = parser.processFile(mdFileFencedCodeBlocks);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<pre><code>function test() {\n  console.log(&quot;!&quot;);\n}\n</code></pre>"
         );
 
         // Test without FENCED_CODE_BLOCKS
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileFencedCodeBlocks);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        documentModel = parser.processFile(mdFileFencedCodeBlocks);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<p><code>function test() { console.log(&quot;!&quot;); }</code></p>"
         );
     }
 
     @Test
-    public void parseValidMdFileQuotes() throws Exception {
+    public void parseValidMdFileQuotes() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("QUOTES");
 
         // Test with QUOTES
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileQuotes);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>&ldquo;quotes&rdquo;</p>");
+        DocumentModel documentModel = parser.processFile(mdFileQuotes);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>&ldquo;quotes&rdquo;</p>");
 
         // Test without QUOTES
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileQuotes);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>&quot;quotes&quot;</p>");
+        documentModel = parser.processFile(mdFileQuotes);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>&quot;quotes&quot;</p>");
     }
 
     @Test
-    public void parseValidMdFileSmarts() throws Exception {
+    public void parseValidMdFileSmarts() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("SMARTS");
 
         // Test with SMARTS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileSmarts);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>&hellip;</p>");
+        DocumentModel documentModel = parser.processFile(mdFileSmarts);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>&hellip;</p>");
 
         // Test without SMARTS
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileSmarts);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>...</p>");
+        documentModel = parser.processFile(mdFileSmarts);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>...</p>");
     }
 
     @Test
-    public void parseValidMdFileSmartypants() throws Exception {
+    public void parseValidMdFileSmartypants() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("SMARTYPANTS");
 
         // Test with SMARTYPANTS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileSmartypants);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>&ldquo;&hellip;&rdquo;</p>");
+        DocumentModel documentModel = parser.processFile(mdFileSmartypants);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>&ldquo;&hellip;&rdquo;</p>");
 
         // Test without SMARTYPANTS
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileSmartypants);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>&quot;...&quot;</p>");
+        documentModel = parser.processFile(mdFileSmartypants);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>&quot;...&quot;</p>");
     }
 
     @Test
-    public void parseValidMdFileSuppressAllHTML() throws Exception {
+    public void parseValidMdFileSuppressAllHTML() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("SUPPRESS_ALL_HTML");
 
         // Test with SUPPRESS_ALL_HTML
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileSuppressAllHTML);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("");
+        DocumentModel documentModel = parser.processFile(mdFileSuppressAllHTML);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("");
 
         // Test without SUPPRESS_ALL_HTML
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileSuppressAllHTML);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<div>!</div><em>!</em>");
+        documentModel = parser.processFile(mdFileSuppressAllHTML);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<div>!</div><em>!</em>");
     }
 
     @Test
-    public void parseValidMdFileSuppressHTMLBlocks() throws Exception {
+    public void parseValidMdFileSuppressHTMLBlocks() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("SUPPRESS_HTML_BLOCKS");
 
         // Test with SUPPRESS_HTML_BLOCKS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileSuppressHTMLBlocks);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("");
+        DocumentModel documentModel = parser.processFile(mdFileSuppressHTMLBlocks);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("");
 
         // Test without SUPPRESS_HTML_BLOCKS
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileSuppressHTMLBlocks);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<div>!</div><em>!</em>");
+        documentModel = parser.processFile(mdFileSuppressHTMLBlocks);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<div>!</div><em>!</em>");
     }
 
     @Test
-    public void parseValidMdFileSuppressInlineHTML() throws Exception {
+    public void parseValidMdFileSuppressInlineHTML() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("SUPPRESS_INLINE_HTML");
 
         // Test with SUPPRESS_INLINE_HTML
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileSuppressInlineHTML);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>This is the first paragraph.  with  inline html</p>");
+        DocumentModel documentModel = parser.processFile(mdFileSuppressInlineHTML);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>This is the first paragraph.  with  inline html</p>");
 
         // Test without SUPPRESS_INLINE_HTML
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileSuppressInlineHTML);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>This is the first paragraph. <span> with </span> inline html</p>");
+        documentModel = parser.processFile(mdFileSuppressInlineHTML);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>This is the first paragraph. <span> with </span> inline html</p>");
     }
 
     @Test
-    public void parseValidMdFileTables() throws Exception {
+    public void parseValidMdFileTables() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("TABLES");
 
         // Test with TABLES
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileTables);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        DocumentModel documentModel = parser.processFile(mdFileTables);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<table>\n" +
-                "<thead>\n" +
-                "<tr><th>First Header</th><th>Second Header</th></tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr><td>Content Cell</td><td>Content Cell</td></tr>\n" +
-                "<tr><td>Content Cell</td><td>Content Cell</td></tr>\n" +
-                "</tbody>\n" +
-                "</table>"
+                        "<thead>\n" +
+                        "<tr><th>First Header</th><th>Second Header</th></tr>\n" +
+                        "</thead>\n" +
+                        "<tbody>\n" +
+                        "<tr><td>Content Cell</td><td>Content Cell</td></tr>\n" +
+                        "<tr><td>Content Cell</td><td>Content Cell</td></tr>\n" +
+                        "</tbody>\n" +
+                        "</table>"
         );
 
         // Test without TABLES
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileTables);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        documentModel = parser.processFile(mdFileTables);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<p>First Header|Second Header -------------|------------- Content Cell|Content Cell Content Cell|Content Cell</p>"
         );
     }
 
     @Test
-    public void parseValidMdFileWikilinks() throws Exception {
+    public void parseValidMdFileWikilinks() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("WIKILINKS");
 
         // Test with WIKILINKS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileWikilinks);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        DocumentModel documentModel = parser.processFile(mdFileWikilinks);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<p><a href=\"Wiki-style-links\">Wiki-style links</a></p>"
         );
 
         // Test without WIKILINKS
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileWikilinks);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>[[Wiki-style links]]</p>");
+        documentModel = parser.processFile(mdFileWikilinks);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>[[Wiki-style links]]</p>");
     }
 
     @Test
-    public void parseValidMdFileAtxheaderspace() throws Exception {
+    public void parseValidMdFileAtxheaderspace() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("ATXHEADERSPACE");
 
         // Test with ATXHEADERSPACE
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileAtxheaderspace);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<p>#Test</p>");
+        DocumentModel documentModel = parser.processFile(mdFileAtxheaderspace);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<p>#Test</p>");
 
         // Test without ATXHEADERSPACE
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileAtxheaderspace);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<h1>Test</h1>");
+        documentModel = parser.processFile(mdFileAtxheaderspace);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<h1>Test</h1>");
     }
 
     @Test
-    public void parseValidMdFileForcelistitempara() throws Exception {
+    public void parseValidMdFileForcelistitempara() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("FORCELISTITEMPARA");
 
         // Test with FORCELISTITEMPARA
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileForcelistitempara);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        DocumentModel documentModel = parser.processFile(mdFileForcelistitempara);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<ol>\n" +
-                "<li>\n" +
-                "<p>Item 1 Item 1 lazy continuation</p>\n" +
-                "<p>Item 1 paragraph 1 Item 1 paragraph 1 lazy continuation Item 1 paragraph 1 continuation</p>\n" +
-                "</li>\n" +
-                "</ol>");
+                        "<li>\n" +
+                        "<p>Item 1 Item 1 lazy continuation</p>\n" +
+                        "<p>Item 1 paragraph 1 Item 1 paragraph 1 lazy continuation Item 1 paragraph 1 continuation</p>\n" +
+                        "</li>\n" +
+                        "</ol>");
 
         // Test without FORCELISTITEMPARA
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileForcelistitempara);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        documentModel = parser.processFile(mdFileForcelistitempara);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<ol>\n" +
-                "<li>Item 1 Item 1 lazy continuation\n" +
-                "<p>Item 1 paragraph 1 Item 1 paragraph 1 lazy continuation Item 1 paragraph 1 continuation</p>\n" +
-                "</li>\n" +
-                "</ol>"
+                        "<li>Item 1 Item 1 lazy continuation\n" +
+                        "<p>Item 1 paragraph 1 Item 1 paragraph 1 lazy continuation Item 1 paragraph 1 continuation</p>\n" +
+                        "</li>\n" +
+                        "</ol>"
         );
     }
 
     @Test
-    public void parseValidMdFileRelaxedhrules() throws Exception {
+    public void parseValidMdFileRelaxedhrules() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("RELAXEDHRULES");
 
         // Test with RELAXEDHRULES
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdFileRelaxedhrules);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        DocumentModel documentModel = parser.processFile(mdFileRelaxedhrules);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<h2>Hello World</h2>\n" +
-                "<hr />\n" +
-                "<hr />\n" +
-                "<p>Hello World</p>\n" +
-                "<hr />\n" +
-                "<hr />\n" +
-                "<hr />\n" +
-                "<p>Hello World</p>\n" +
-                "<hr />\n" +
-                "<hr />\n" +
-                "<hr />"
+                        "<hr />\n" +
+                        "<hr />\n" +
+                        "<p>Hello World</p>\n" +
+                        "<hr />\n" +
+                        "<hr />\n" +
+                        "<hr />\n" +
+                        "<p>Hello World</p>\n" +
+                        "<hr />\n" +
+                        "<hr />\n" +
+                        "<hr />"
         );
 
         // Test without RELAXEDHRULES
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdFileRelaxedhrules);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        documentModel = parser.processFile(mdFileRelaxedhrules);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<h2>Hello World</h2>\n" +
-                "<hr />\n" +
-                "<hr />\n" +
-                "<h2>Hello World ***</h2>\n" +
-                "<hr />\n" +
-                "<h2>Hello World ___</h2>\n" +
-                "<hr />"
+                        "<hr />\n" +
+                        "<hr />\n" +
+                        "<h2>Hello World ***</h2>\n" +
+                        "<hr />\n" +
+                        "<h2>Hello World ___</h2>\n" +
+                        "<hr />"
         );
     }
 
     @Test
-    public void parseValidMdFileTasklistitems() throws Exception {
+    public void parseValidMdFileTasklistitems() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("TASKLISTITEMS");
 
         // Test with TASKLISTITEMS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdTasklistitems);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        DocumentModel documentModel = parser.processFile(mdTasklistitems);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<ul>\n" +
-                "<li>loose bullet item 3</li>\n" +
-                "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"disabled\" readonly=\"readonly\" />&nbsp;open task item</li>\n" +
-                "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"checked\" disabled=\"disabled\" readonly=\"readonly\" />&nbsp;closed task item</li>\n" +
-                "</ul>"
+                        "<li>loose bullet item 3</li>\n" +
+                        "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"disabled\" readonly=\"readonly\" />&nbsp;open task item</li>\n" +
+                        "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"checked\" disabled=\"disabled\" readonly=\"readonly\" />&nbsp;closed task item</li>\n" +
+                        "</ul>"
         );
 
         // Test without TASKLISTITEMS
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdTasklistitems);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        documentModel = parser.processFile(mdTasklistitems);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<ul>\n" +
-                "<li>loose bullet item 3</li>\n" +
-                "<li>[ ] open task item</li>\n" +
-                "<li>[x] closed task item</li>\n" +
-                "</ul>");
+                        "<li>loose bullet item 3</li>\n" +
+                        "<li>[ ] open task item</li>\n" +
+                        "<li>[x] closed task item</li>\n" +
+                        "</ul>");
     }
 
     @Test
-    public void parseValidMdFileExtanchorlinks() throws Exception {
+    public void parseValidMdFileExtanchorlinks() {
         config.setMarkdownExtensions("");
         config.setMarkdownExtensions("EXTANCHORLINKS");
 
         // Test with EXTANCHORLINKS
         Parser parser = new Parser(config);
-        Map<String, Object> map = parser.processFile(mdExtanchorlinks);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains(
+        DocumentModel documentModel = parser.processFile(mdExtanchorlinks);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains(
                 "<h1><a href=\"#header-some-formatting-chars\" id=\"header-some-formatting-chars\"></a>header &amp; some <em>formatting</em> ~~chars~~</h1>"
         );
 
         // Test without EXTANCHORLINKS
         config.setMarkdownExtensions("");
         parser = new Parser(config);
-        map = parser.processFile(mdExtanchorlinks);
-        Assert.assertNotNull(map);
-        assertThat(map.get("body").toString()).contains("<h1>header &amp; some <em>formatting</em> ~~chars~~</h1>");
+        documentModel = parser.processFile(mdExtanchorlinks);
+        Assert.assertNotNull(documentModel);
+        assertThat(documentModel.getBody()).contains("<h1>header &amp; some <em>formatting</em> ~~chars~~</h1>");
     }
 
 

--- a/jbake-core/src/test/java/org/jbake/app/PaginationTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/PaginationTest.java
@@ -63,8 +63,7 @@ public class PaginationTest extends ContentStoreIntegrationTest {
         for (int i = 1; i <= TOTAL_POSTS; i++) {
             cal.add(Calendar.SECOND, 5);
             FakeDocumentBuilder builder = new FakeDocumentBuilder("post");
-            builder.withName("dummyfile" + i)
-                    .withCached(true)
+            builder.withCached(true)
                     .withStatus("published")
                     .withDate(cal.getTime())
                     .build();

--- a/jbake-core/src/test/java/org/jbake/app/PaginationTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/PaginationTest.java
@@ -24,6 +24,7 @@
 package org.jbake.app;
 
 import org.jbake.FakeDocumentBuilder;
+import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,7 +32,6 @@ import org.junit.Test;
 import org.junit.BeforeClass;
 
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -80,7 +80,10 @@ public class PaginationTest extends ContentStoreIntegrationTest {
             assertThat(posts.size()).isLessThanOrEqualTo(2);
 
             if (posts.size() > 1) {
-                assertThat((Date) posts.get(0).get("date")).isAfter((Date) posts.get(1).get("date"));
+                DocumentModel post = (DocumentModel) posts.get(0);
+                DocumentModel nextPost = (DocumentModel) posts.get(1);
+
+                assertThat(post.getDate()).isAfter(nextPost.getDate());
             }
 
             pageCount++;

--- a/jbake-core/src/test/java/org/jbake/app/ParserTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/ParserTest.java
@@ -4,6 +4,7 @@ import org.jbake.TestUtils;
 import org.jbake.app.configuration.ConfigUtil;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.jbake.app.configuration.JBakeProperty;
+import org.jbake.model.DocumentModel;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.junit.Assert;
@@ -17,8 +18,6 @@ import java.io.PrintWriter;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Date;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -209,14 +208,14 @@ public class ParserTest {
 
     @Test
     public void parseValidHTMLFile() {
-        Map<String, Object> map = parser.processFile(validHTMLFile);
-        Assert.assertNotNull(map);
-        Assert.assertEquals("draft", map.get("status"));
-        Assert.assertEquals("post", map.get("type"));
-        Assert.assertEquals("This is a Title = This is a valid Title", map.get("title"));
-        Assert.assertNotNull(map.get("date"));
+        DocumentModel documentModel = parser.processFile(validHTMLFile);
+        Assert.assertNotNull(documentModel);
+        Assert.assertEquals("draft", documentModel.getStatus());
+        Assert.assertEquals("post", documentModel.getType());
+        Assert.assertEquals("This is a Title = This is a valid Title", documentModel.getTitle());
+        Assert.assertNotNull(documentModel.getDate());
         Calendar cal = Calendar.getInstance();
-        cal.setTime((Date) map.get("date"));
+        cal.setTime(documentModel.getDate());
         Assert.assertEquals(8, cal.get(Calendar.MONTH));
         Assert.assertEquals(2, cal.get(Calendar.DAY_OF_MONTH));
         Assert.assertEquals(2013, cal.get(Calendar.YEAR));
@@ -225,14 +224,14 @@ public class ParserTest {
 
     @Test
     public void parseInvalidHTMLFile() {
-        Map<String, Object> map = parser.processFile(invalidHTMLFile);
-        Assert.assertNull(map);
+        DocumentModel documentModel = parser.processFile(invalidHTMLFile);
+        Assert.assertNull(documentModel);
     }
 
     @Test
     public void parseInvalidExtension(){
-        Map<String, Object> map = parser.processFile(invalidExtensionFile);
-        Assert.assertNull(map);
+        DocumentModel documentModel = parser.processFile(invalidExtensionFile);
+        Assert.assertNull(documentModel);
     }
 
 
@@ -240,11 +239,11 @@ public class ParserTest {
     public void parseMarkdownFileWithCustomHeaderSeparator() {
         config.setHeaderSeparator(customHeaderSeparator);
 
-        Map<String, Object> map = parser.processFile(validMarkdownFileWithCustomHeader);
-        Assert.assertNotNull(map);
-        Assert.assertEquals("draft", map.get("status"));
-        Assert.assertEquals("post", map.get("type"));
-        assertThat(map.get("body").toString())
+        DocumentModel documentModel = parser.processFile(validMarkdownFileWithCustomHeader);
+        Assert.assertNotNull(documentModel);
+        Assert.assertEquals("draft", documentModel.getStatus());
+        Assert.assertEquals("post", documentModel.getType());
+        assertThat(documentModel.getBody())
                 .contains("<p>A paragraph</p>");
 
     }
@@ -253,10 +252,10 @@ public class ParserTest {
     public void parseMarkdownFileWithDefaultStatus() {
         config.setDefaultStatus("published");
 
-        Map<String, Object> map = parser.processFile(validMarkdownFileWithDefaultStatus);
-        Assert.assertNotNull(map);
-        Assert.assertEquals("published", map.get("status"));
-        Assert.assertEquals("post", map.get("type"));
+        DocumentModel documentModel = parser.processFile(validMarkdownFileWithDefaultStatus);
+        Assert.assertNotNull(documentModel);
+        Assert.assertEquals("published", documentModel.getStatus());
+        Assert.assertEquals("post", documentModel.getType());
     }
 
     @Test
@@ -264,10 +263,10 @@ public class ParserTest {
         config.setDefaultStatus("published");
         config.setDefaultType("page");
 
-        Map<String, Object> map = parser.processFile(validMarkdownFileWithDefaultTypeAndStatus);
-        Assert.assertNotNull(map);
-        Assert.assertEquals("published", map.get("status"));
-        Assert.assertEquals("page", map.get("type"));
+        DocumentModel documentModel = parser.processFile(validMarkdownFileWithDefaultTypeAndStatus);
+        Assert.assertNotNull(documentModel);
+        Assert.assertEquals("published", documentModel.getStatus());
+        Assert.assertEquals("page", documentModel.getType());
     }
 
     @Test
@@ -275,52 +274,52 @@ public class ParserTest {
         config.setDefaultStatus("");
         config.setDefaultType("page");
 
-        Map<String, Object> map = parser.processFile(invalidMarkdownFileWithoutDefaultStatus);
-        Assert.assertNull(map);
+        DocumentModel documentModel = parser.processFile(invalidMarkdownFileWithoutDefaultStatus);
+        Assert.assertNull(documentModel);
     }
 
     @Test
     public void parseInvalidMarkdownFile() {
-        Map<String, Object> map = parser.processFile(invalidMDFile);
-        Assert.assertNull(map);
+        DocumentModel documentModel = parser.processFile(invalidMDFile);
+        Assert.assertNull(documentModel);
     }
 
     @Test
     public void sanitizeKeysAndValues() {
-        Map<String, Object> map = parser.processFile(validaAsciidocWithUnsanitizedHeader);
+        DocumentModel map = parser.processFile(validaAsciidocWithUnsanitizedHeader);
 
-        assertThat(map.get("status")).isEqualTo("draft");
-        assertThat(map.get("title")).isEqualTo("Title");
-        assertThat(map.get("type")).isEqualTo("post");
+        assertThat(map.getStatus()).isEqualTo("draft");
+        assertThat(map.getTitle()).isEqualTo("Title");
+        assertThat(map.getType()).isEqualTo("post");
         assertThat(map.get("custom")).isEqualTo("custom without bom's");
-        assertThat(map.get("tags")).isEqualTo(Arrays.asList("jbake", "java", "tag with space").toArray());
+        assertThat(map.getTags()).isEqualTo(Arrays.asList("jbake", "java", "tag with space").toArray());
     }
 
     @Test
     public void sanitizeTags() {
         config.setProperty(JBakeProperty.TAG_SANITIZE, true);
-        Map<String, Object> map = parser.processFile(validaAsciidocWithUnsanitizedHeader);
+        DocumentModel map = parser.processFile(validaAsciidocWithUnsanitizedHeader);
 
-        assertThat(map.get("tags")).isEqualTo(Arrays.asList("jbake", "java", "tag-with-space").toArray());
+        assertThat(map.getTags()).isEqualTo(Arrays.asList("jbake", "java", "tag-with-space").toArray());
     }
 
 
     @Test
     public void parseValidHTMLWithJSONFile() {
-        Map<String, Object> map = parser.processFile(validHTMLWithJSONFile);
-        assertJSONExtracted(map.get("jsondata"));
+        DocumentModel documentModel = parser.processFile(validHTMLWithJSONFile);
+        assertJSONExtracted(documentModel.get("jsondata"));
     }
 
     @Test
     public void parseValidAsciiDocWithJSONFile() {
-        Map<String, Object> map = parser.processFile(validAsciiDocWithJSONFile);
-        assertJSONExtracted(map.get("jsondata"));
+        DocumentModel documentModel = parser.processFile(validAsciiDocWithJSONFile);
+        assertJSONExtracted(documentModel.get("jsondata"));
     }
 
     @Test
     public void testValidAsciiDocWithADHeaderJSONFile() {
-        Map<String, Object> map = parser.processFile(validAsciiDocWithADHeaderJSONFile);
-        assertJSONExtracted(map.get("jsondata"));
+        DocumentModel documentModel = parser.processFile(validAsciiDocWithADHeaderJSONFile);
+        assertJSONExtracted(documentModel.get("jsondata"));
     }
 
     private void assertJSONExtracted(Object jsonDataEntry) {

--- a/jbake-core/src/test/java/org/jbake/app/ParserTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/ParserTest.java
@@ -105,6 +105,7 @@ public class ParserTest {
 
         out = new PrintWriter(validMarkdownFileWithDefaultTypeAndStatus);
         out.println("title=Custom Header separator");
+        out.println("cached=false");
         out.println(config.getHeaderSeparator());
         out.println("# Hello Markdown!");
         out.println("");
@@ -256,6 +257,7 @@ public class ParserTest {
         Assert.assertNotNull(documentModel);
         Assert.assertEquals("published", documentModel.getStatus());
         Assert.assertEquals("post", documentModel.getType());
+        Assert.assertEquals(true, documentModel.getCached());
     }
 
     @Test
@@ -267,6 +269,15 @@ public class ParserTest {
         Assert.assertNotNull(documentModel);
         Assert.assertEquals("published", documentModel.getStatus());
         Assert.assertEquals("page", documentModel.getType());
+    }
+
+    @Test
+    public void parseMarkdownFileWithDisabledCache() {
+        config.setDefaultStatus("published");
+        config.setDefaultType("page");
+
+        DocumentModel documentModel = parser.processFile(validMarkdownFileWithDefaultTypeAndStatus);
+        Assert.assertEquals(false, documentModel.getCached());
     }
 
     @Test

--- a/jbake-core/src/test/java/org/jbake/app/template/AbstractTemplateEngineRenderingTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/template/AbstractTemplateEngineRenderingTest.java
@@ -28,6 +28,7 @@ import org.jbake.app.ContentStoreIntegrationTest;
 import org.jbake.app.Crawler;
 import org.jbake.app.Parser;
 import org.jbake.app.Renderer;
+import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import org.jbake.template.ModelExtractors;
 import org.jbake.template.ModelExtractorsDocumentTypeListener;
@@ -40,11 +41,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -161,8 +158,8 @@ public abstract class AbstractTemplateEngineRenderingTest extends ContentStoreIn
 
         File sampleFile = new File(sourceFolder.getPath() + File.separator + "content"
                 + File.separator + "blog" + File.separator + "2013" + File.separator + filename);
-        Map<String, Object> content = parser.processFile(sampleFile);
-        content.put(Crawler.Attributes.URI, "/" + filename);
+        DocumentModel content = parser.processFile(sampleFile);
+        content.setUri("/" + filename);
         renderer.render(content);
         File outputFile = new File(destinationFolder, filename);
         Assert.assertTrue(outputFile.exists());
@@ -180,8 +177,8 @@ public abstract class AbstractTemplateEngineRenderingTest extends ContentStoreIn
         String filename = "about.html";
 
         File sampleFile = new File(sourceFolder.getPath() + File.separator + "content" + File.separator + filename);
-        Map<String, Object> content = parser.processFile(sampleFile);
-        content.put(Crawler.Attributes.URI, "/" + filename);
+        DocumentModel content = parser.processFile(sampleFile);
+        content.setUri("/" + filename);
         renderer.render(content);
         File outputFile = new File(destinationFolder, filename);
         Assert.assertTrue(outputFile.exists());

--- a/jbake-core/src/test/java/org/jbake/app/template/GroovyMarkupTemplateEngineRenderingTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/template/GroovyMarkupTemplateEngineRenderingTest.java
@@ -5,6 +5,7 @@ import org.jbake.app.Crawler;
 import org.jbake.app.DBUtil;
 import org.jbake.app.Parser;
 import org.jbake.app.Renderer;
+import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -13,7 +14,6 @@ import org.junit.Test;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,8 +75,8 @@ public class GroovyMarkupTemplateEngineRenderingTest extends AbstractTemplateEng
         String filename = "published-paper.html";
 
         File sampleFile = new File(sourceFolder.getPath() + File.separator + "content" + File.separator + "papers" + File.separator + filename);
-        Map<String, Object> content = parser.processFile(sampleFile);
-        content.put(Crawler.Attributes.URI, "/" + filename);
+        DocumentModel content = parser.processFile(sampleFile);
+        content.setUri("/" + filename);
         renderer.render(content);
         File outputFile = new File(destinationFolder, filename);
         Assert.assertTrue(outputFile.exists());

--- a/jbake-core/src/test/java/org/jbake/render/DocumentsRendererTest.java
+++ b/jbake-core/src/test/java/org/jbake/render/DocumentsRendererTest.java
@@ -127,20 +127,20 @@ public class DocumentsRendererTest {
         int renderResponse = documentsRenderer.render(renderer, db, configuration);
 
         DocumentModel fourthDoc = simpleDocument(fourth);
-        fourthDoc.put("previousContent", simpleDocument(third));
-        fourthDoc.put("nextContent", null);
+        fourthDoc.setPreviousContent(simpleDocument(third));
+        fourthDoc.setNextContent(null);
 
         DocumentModel thirdDoc = simpleDocument(third);
-        thirdDoc.put("nextContent", simpleDocument(fourth));
-        thirdDoc.put("previousContent", simpleDocument(second));
+        thirdDoc.setNextContent(simpleDocument(fourth));
+        thirdDoc.setPreviousContent(simpleDocument(second));
 
         DocumentModel secondDoc = simpleDocument(second);
-        secondDoc.put("nextContent", simpleDocument(third));
-        secondDoc.put("previousContent", simpleDocument(first));
+        secondDoc.setNextContent(simpleDocument(third));
+        secondDoc.setPreviousContent(simpleDocument(first));
 
         DocumentModel firstDoc = simpleDocument(first);
-        firstDoc.put("nextContent", simpleDocument(second));
-        firstDoc.put("previousContent", null);
+        firstDoc.setNextContent(simpleDocument(second));
+        firstDoc.setPreviousContent(null);
 
         verify(renderer, times(4)).render(argument.capture());
 

--- a/jbake-core/src/test/java/org/jbake/render/DocumentsRendererTest.java
+++ b/jbake-core/src/test/java/org/jbake/render/DocumentsRendererTest.java
@@ -29,7 +29,7 @@ public class DocumentsRendererTest {
     private ContentStore db;
     private Renderer renderer;
     private JBakeConfiguration configuration;
-    private DocumentList emptyDocumentList;
+    private DocumentList emptyTemplateModelList;
 
     @Captor
     private ArgumentCaptor<DocumentModel> argument;
@@ -44,13 +44,13 @@ public class DocumentsRendererTest {
         db = mock(ContentStore.class);
         renderer = mock(Renderer.class);
         configuration = mock(JBakeConfiguration.class);
-        emptyDocumentList = new DocumentList();
+        emptyTemplateModelList = new DocumentList();
     }
 
     @Test
     public void shouldReturnZeroIfNothingHasRendered() throws Exception {
 
-        when(db.getUnrenderedContent(anyString())).thenReturn(emptyDocumentList);
+        when(db.getUnrenderedContent(anyString())).thenReturn(emptyTemplateModelList);
 
         int renderResponse = documentsRenderer.render(renderer, db, configuration);
 
@@ -63,14 +63,14 @@ public class DocumentsRendererTest {
         // given:
         DocumentTypes.addDocumentType("customType");
 
-        DocumentList documentList = new DocumentList();
-        documentList.add(emptyDocument());
-        documentList.add(emptyDocument());
+        DocumentList templateModelList = new DocumentList();
+        templateModelList.add(emptyDocument());
+        templateModelList.add(emptyDocument());
 
         // return empty DocumentList independent from DocumentType
-        when(db.getUnrenderedContent(anyString())).thenReturn(emptyDocumentList);
+        when(db.getUnrenderedContent(anyString())).thenReturn(emptyTemplateModelList);
         // return given DocumentList for DocumentType 'custom type'
-        when(db.getUnrenderedContent("customType")).thenReturn(documentList);
+        when(db.getUnrenderedContent("customType")).thenReturn(templateModelList);
 
         // when:
         int renderResponse = documentsRenderer.render(renderer, db, configuration);
@@ -89,16 +89,16 @@ public class DocumentsRendererTest {
         // given
         DocumentTypes.addDocumentType("customType");
 
-        DocumentList documentList = new DocumentList();
+        DocumentList templateModelList = new DocumentList();
         DocumentModel document = emptyDocument();
         DocumentModel document2 = emptyDocument();
-        documentList.add(document);
-        documentList.add(document2);
+        templateModelList.add(document);
+        templateModelList.add(document2);
 
         // throw an exception for every call of renderer's render method
         doThrow(new Exception(fakeExceptionMessage)).when(renderer).render(any(DocumentModel.class));
-        when(db.getUnrenderedContent(anyString())).thenReturn(emptyDocumentList);
-        when(db.getUnrenderedContent("customType")).thenReturn(documentList);
+        when(db.getUnrenderedContent(anyString())).thenReturn(emptyTemplateModelList);
+        when(db.getUnrenderedContent("customType")).thenReturn(templateModelList);
 
         // when
         int renderResponse = documentsRenderer.render(renderer, db, configuration);

--- a/jbake-core/src/test/java/org/jbake/render/DocumentsRendererTest.java
+++ b/jbake-core/src/test/java/org/jbake/render/DocumentsRendererTest.java
@@ -12,13 +12,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -35,7 +32,7 @@ public class DocumentsRendererTest {
     private DocumentList emptyDocumentList;
 
     @Captor
-    private ArgumentCaptor<Map<String, Object>> argument;
+    private ArgumentCaptor<DocumentModel> argument;
 
     @Before
     public void setUp() {
@@ -93,13 +90,13 @@ public class DocumentsRendererTest {
         DocumentTypes.addDocumentType("customType");
 
         DocumentList documentList = new DocumentList();
-        HashMap<String, Object> document = emptyDocument();
-        HashMap<String, Object> document2 = emptyDocument();
+        DocumentModel document = emptyDocument();
+        DocumentModel document2 = emptyDocument();
         documentList.add(document);
         documentList.add(document2);
 
         // throw an exception for every call of renderer's render method
-        doThrow(new Exception(fakeExceptionMessage)).when(renderer).render(ArgumentMatchers.<String, Object>anyMap());
+        doThrow(new Exception(fakeExceptionMessage)).when(renderer).render(any(DocumentModel.class));
         when(db.getUnrenderedContent(anyString())).thenReturn(emptyDocumentList);
         when(db.getUnrenderedContent("customType")).thenReturn(documentList);
 
@@ -129,25 +126,25 @@ public class DocumentsRendererTest {
 
         int renderResponse = documentsRenderer.render(renderer, db, configuration);
 
-        Map<String, Object> fourthDoc = simpleDocument(fourth);
+        DocumentModel fourthDoc = simpleDocument(fourth);
         fourthDoc.put("previousContent", simpleDocument(third));
         fourthDoc.put("nextContent", null);
 
-        Map<String, Object> thirdDoc = simpleDocument(third);
+        DocumentModel thirdDoc = simpleDocument(third);
         thirdDoc.put("nextContent", simpleDocument(fourth));
         thirdDoc.put("previousContent", simpleDocument(second));
 
-        Map<String, Object> secondDoc = simpleDocument(second);
+        DocumentModel secondDoc = simpleDocument(second);
         secondDoc.put("nextContent", simpleDocument(third));
         secondDoc.put("previousContent", simpleDocument(first));
 
-        Map<String, Object> firstDoc = simpleDocument(first);
+        DocumentModel firstDoc = simpleDocument(first);
         firstDoc.put("nextContent", simpleDocument(second));
         firstDoc.put("previousContent", null);
 
         verify(renderer, times(4)).render(argument.capture());
 
-        List<Map<String, Object>> maps = argument.getAllValues();
+        List<DocumentModel> maps = argument.getAllValues();
 
         assertThat(maps).contains(fourthDoc);
 
@@ -160,8 +157,8 @@ public class DocumentsRendererTest {
         assertThat(renderResponse).isEqualTo(4);
     }
 
-    private HashMap<String, Object> emptyDocument() {
-        return new HashMap<>();
+    private DocumentModel emptyDocument() {
+        return new DocumentModel();
     }
 
     private DocumentModel simpleDocument(String title) {

--- a/jbake-core/src/test/java/org/jbake/render/DocumentsRendererTest.java
+++ b/jbake-core/src/test/java/org/jbake/render/DocumentsRendererTest.java
@@ -29,7 +29,7 @@ public class DocumentsRendererTest {
     private ContentStore db;
     private Renderer renderer;
     private JBakeConfiguration configuration;
-    private DocumentList emptyTemplateModelList;
+    private DocumentList<DocumentModel> emptyTemplateModelList;
 
     @Captor
     private ArgumentCaptor<DocumentModel> argument;
@@ -44,7 +44,7 @@ public class DocumentsRendererTest {
         db = mock(ContentStore.class);
         renderer = mock(Renderer.class);
         configuration = mock(JBakeConfiguration.class);
-        emptyTemplateModelList = new DocumentList();
+        emptyTemplateModelList = new DocumentList<>();
     }
 
     @Test
@@ -63,7 +63,7 @@ public class DocumentsRendererTest {
         // given:
         DocumentTypes.addDocumentType("customType");
 
-        DocumentList templateModelList = new DocumentList();
+        DocumentList<DocumentModel> templateModelList = new DocumentList<>();
         templateModelList.add(emptyDocument());
         templateModelList.add(emptyDocument());
 
@@ -89,7 +89,7 @@ public class DocumentsRendererTest {
         // given
         DocumentTypes.addDocumentType("customType");
 
-        DocumentList templateModelList = new DocumentList();
+        DocumentList<DocumentModel> templateModelList = new DocumentList<>();
         DocumentModel document = emptyDocument();
         DocumentModel document2 = emptyDocument();
         templateModelList.add(document);
@@ -116,7 +116,7 @@ public class DocumentsRendererTest {
         String third = "Third Document";
         String fourth = "Fourth Document";
 
-        DocumentList documents = new DocumentList();
+        DocumentList<DocumentModel> documents = new DocumentList<>();
         documents.add(simpleDocument(fourth));
         documents.add(simpleDocument(third));
         documents.add(simpleDocument(second));

--- a/jbake-core/src/test/java/org/jbake/render/DocumentsRendererTest.java
+++ b/jbake-core/src/test/java/org/jbake/render/DocumentsRendererTest.java
@@ -1,10 +1,10 @@
 package org.jbake.render;
 
 import org.jbake.app.ContentStore;
-import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.DocumentList;
 import org.jbake.app.Renderer;
 import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentModel;
 import org.jbake.model.DocumentTypes;
 import org.jbake.template.RenderingException;
 import org.junit.Before;
@@ -22,11 +22,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class DocumentsRendererTest {
 
@@ -168,12 +164,12 @@ public class DocumentsRendererTest {
         return new HashMap<>();
     }
 
-    private Map<String, Object> simpleDocument(String title) {
-        Map<String, Object> simpleDoc = new HashMap<>();
+    private DocumentModel simpleDocument(String title) {
+        DocumentModel simpleDoc = new DocumentModel();
         String uri = title.replace(" ", "_");
-        simpleDoc.put(Attributes.NO_EXTENSION_URI, uri);
-        simpleDoc.put(Attributes.URI, uri);
-        simpleDoc.put(Attributes.TITLE, title);
+        simpleDoc.setNoExtensionUri(uri);
+        simpleDoc.setUri(uri);
+        simpleDoc.setTitle(title);
         return simpleDoc;
     }
 

--- a/jbake-core/src/test/java/org/jbake/render/RendererTest.java
+++ b/jbake-core/src/test/java/org/jbake/render/RendererTest.java
@@ -2,10 +2,10 @@ package org.jbake.render;
 
 import org.jbake.TestUtils;
 import org.jbake.app.ContentStore;
-import org.jbake.app.Crawler;
 import org.jbake.app.Renderer;
 import org.jbake.app.configuration.ConfigUtil;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
+import org.jbake.model.DocumentModel;
 import org.jbake.template.DelegatingTemplateEngine;
 import org.junit.Assume;
 import org.junit.Before;
@@ -18,8 +18,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,10 +63,10 @@ public class RendererTest {
         config.setTemplateFolder(folder.newFolder("templates"));
         Renderer renderer = new Renderer(db, config, renderingEngine);
 
-        Map<String, Object> content = new HashMap<>();
-        content.put(Crawler.Attributes.TYPE, "page");
-        content.put(Crawler.Attributes.URI, "/" + FOLDER + "/" + FILENAME);
-        content.put(Crawler.Attributes.STATUS, "published");
+        DocumentModel content = new DocumentModel();
+        content.setType("page");
+        content.setUri("/" + FOLDER + "/" + FILENAME);
+        content.setStatus("published");
 
         renderer.render(content);
 

--- a/jbake-core/src/test/java/org/jbake/util/HtmlUtilTest.java
+++ b/jbake-core/src/test/java/org/jbake/util/HtmlUtilTest.java
@@ -1,14 +1,11 @@
 package org.jbake.util;
 
 import org.jbake.TestUtils;
-import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.configuration.ConfigUtil;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.jbake.model.DocumentModel;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jbake-core/src/test/java/org/jbake/util/HtmlUtilTest.java
+++ b/jbake-core/src/test/java/org/jbake/util/HtmlUtilTest.java
@@ -4,12 +4,11 @@ import org.jbake.TestUtils;
 import org.jbake.app.Crawler.Attributes;
 import org.jbake.app.configuration.ConfigUtil;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
+import org.jbake.model.DocumentModel;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,14 +24,14 @@ public class HtmlUtilTest {
 
     @Test
     public void shouldNotAddBodyHTMLElement() {
-        Map<String, Object> fileContent = new HashMap<String, Object>();
-        fileContent.put(Attributes.ROOTPATH, "../../../");
-        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
-        fileContent.put(Attributes.BODY, "<div> Test <img src='/blog/2017/05/first.jpg' /></div>");
+        DocumentModel fileContent = new DocumentModel();
+        fileContent.setRootPath("../../../");
+        fileContent.setUri("blog/2017/05/first_post.html");
+        fileContent.setBody("<div> Test <img src='/blog/2017/05/first.jpg' /></div>");
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 
-        String body = fileContent.get(Attributes.BODY).toString();
+        String body = fileContent.getBody();
 
         assertThat(body).doesNotContain("<body>");
         assertThat(body).doesNotContain("</body>");
@@ -41,15 +40,15 @@ public class HtmlUtilTest {
 
     @Test
     public void shouldNotAddSiteHost() {
-        Map<String, Object> fileContent = new HashMap<String, Object>();
-        fileContent.put(Attributes.ROOTPATH, "../../../");
-        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
-        fileContent.put(Attributes.BODY, "<div> Test <img src='./first.jpg' /></div>");
+        DocumentModel fileContent = new DocumentModel();
+        fileContent.setRootPath("../../../");
+        fileContent.setUri("blog/2017/05/first_post.html");
+        fileContent.setBody("<div> Test <img src='./first.jpg' /></div>");
         config.setImgPathPrependHost(false);
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 
-        String body = fileContent.get(Attributes.BODY).toString();
+        String body = fileContent.getBody();
 
         assertThat(body).contains("src=\"blog/2017/05/first.jpg\"");
 
@@ -57,29 +56,30 @@ public class HtmlUtilTest {
 
     @Test
     public void shouldAddSiteHostWithRelativeImageToDocument() {
-        Map<String, Object> fileContent = new HashMap<>();
-        fileContent.put(Attributes.ROOTPATH, "../../../");
-        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
-        fileContent.put(Attributes.BODY, "<div> Test <img src='img/deeper/underground.jpg' /></div>");
+        DocumentModel fileContent = new DocumentModel();
+        fileContent.setRootPath("../../../");
+        fileContent.setUri("blog/2017/05/first_post.html");
+        fileContent.setBody("<div> Test <img src='img/deeper/underground.jpg' /></div>");
         config.setImgPathPrependHost(true);
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 
-        String body = fileContent.get(Attributes.BODY).toString();
+        String body = fileContent.getBody();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/img/deeper/underground.jpg\"");
     }
 
     @Test
     public void shouldAddContentPath() {
-        Map<String, Object> fileContent = new HashMap<String, Object>();
-        fileContent.put(Attributes.ROOTPATH, "../../../");
-        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
-        fileContent.put(Attributes.BODY, "<div> Test <img src='./first.jpg' /></div>");
+        DocumentModel fileContent = new DocumentModel();
+        fileContent.setRootPath("../../../");
+        fileContent.setUri("blog/2017/05/first_post.html");
+        fileContent.setBody("<div> Test <img src='./first.jpg' /></div>");
+        config.setImgPathPrependHost(true);
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 
-        String body = fileContent.get(Attributes.BODY).toString();
+        String body = fileContent.getBody();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 
@@ -87,14 +87,15 @@ public class HtmlUtilTest {
 
     @Test
     public void shouldAddContentPathForCurrentDirectory() {
-        Map<String, Object> fileContent = new HashMap<String, Object>();
-        fileContent.put(Attributes.ROOTPATH, "../../../");
-        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
-        fileContent.put(Attributes.BODY, "<div> Test <img src='first.jpg' /></div>");
+        DocumentModel fileContent = new DocumentModel();
+        fileContent.setRootPath("../../../");
+        fileContent.setUri("blog/2017/05/first_post.html");
+        fileContent.setBody("<div> Test <img src='first.jpg' /></div>");
+        config.setImgPathPrependHost(true);
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 
-        String body = fileContent.get(Attributes.BODY).toString();
+        String body = fileContent.getBody();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 
@@ -102,14 +103,14 @@ public class HtmlUtilTest {
 
     @Test
     public void shouldNotAddRootPath() {
-        Map<String, Object> fileContent = new HashMap<String, Object>();
-        fileContent.put(Attributes.ROOTPATH, "../../../");
-        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
-        fileContent.put(Attributes.BODY, "<div> Test <img src='/blog/2017/05/first.jpg' /></div>");
+        DocumentModel fileContent = new DocumentModel();
+        fileContent.setRootPath("../../../");
+        fileContent.setUri("blog/2017/05/first_post.html");
+        fileContent.setBody("<div> Test <img src='/blog/2017/05/first.jpg' /></div>");
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 
-        String body = fileContent.get(Attributes.BODY).toString();
+        String body = fileContent.getBody();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 
@@ -117,15 +118,15 @@ public class HtmlUtilTest {
 
     @Test
     public void shouldNotAddRootPathForNoExtension() {
-        Map<String, Object> fileContent = new HashMap<String, Object>();
-        fileContent.put(Attributes.ROOTPATH, "../../../");
-        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
-        fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
-        fileContent.put(Attributes.BODY, "<div> Test <img src='/blog/2017/05/first.jpg' /></div>");
+        DocumentModel fileContent = new DocumentModel();
+        fileContent.setRootPath("../../../");
+        fileContent.setUri("blog/2017/05/first_post.html");
+        fileContent.setNoExtensionUri("blog/2017/05/first_post/");
+        fileContent.setBody("<div> Test <img src='/blog/2017/05/first.jpg' /></div>");
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 
-        String body = fileContent.get(Attributes.BODY).toString();
+        String body = fileContent.getBody();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 
@@ -133,30 +134,30 @@ public class HtmlUtilTest {
 
     @Test
     public void shouldAddContentPathForNoExtension() {
-        Map<String, Object> fileContent = new HashMap<String, Object>();
-        fileContent.put(Attributes.ROOTPATH, "../../../");
-        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
-        fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
-        fileContent.put(Attributes.BODY, "<div> Test <img src='./first.jpg' /></div>");
+        DocumentModel fileContent = new DocumentModel();
+        fileContent.setRootPath("../../../");
+        fileContent.setUri("blog/2017/05/first_post.html");
+        fileContent.setNoExtensionUri("blog/2017/05/first_post/");
+        fileContent.setBody("<div> Test <img src='./first.jpg' /></div>");
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 
-        String body = fileContent.get(Attributes.BODY).toString();
+        String body = fileContent.getBody();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
     }
 
     @Test
     public void shouldNotChangeForHTTP() {
-        Map<String, Object> fileContent = new HashMap<String, Object>();
-        fileContent.put(Attributes.ROOTPATH, "../../../");
-        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
-        fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
-        fileContent.put(Attributes.BODY, "<div> Test <img src='http://example.com/first.jpg' /></div>");
+        DocumentModel fileContent = new DocumentModel();
+        fileContent.setRootPath("../../../");
+        fileContent.setUri("blog/2017/05/first_post.html");
+        fileContent.setNoExtensionUri("blog/2017/05/first_post/");
+        fileContent.setBody("<div> Test <img src='http://example.com/first.jpg' /></div>");
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 
-        String body = fileContent.get(Attributes.BODY).toString();
+        String body = fileContent.getBody();
 
         assertThat(body).contains("src=\"http://example.com/first.jpg\"");
 
@@ -164,15 +165,15 @@ public class HtmlUtilTest {
 
     @Test
     public void shouldNotChangeForHTTPS() {
-        Map<String, Object> fileContent = new HashMap<String, Object>();
-        fileContent.put(Attributes.ROOTPATH, "../../../");
-        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
-        fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
-        fileContent.put(Attributes.BODY, "<div> Test <img src='https://example.com/first.jpg' /></div>");
+        DocumentModel fileContent = new DocumentModel();
+        fileContent.setRootPath("../../../");
+        fileContent.setUri("blog/2017/05/first_post.html");
+        fileContent.setNoExtensionUri("blog/2017/05/first_post/");
+        fileContent.setBody("<div> Test <img src='https://example.com/first.jpg' /></div>");
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 
-        String body = fileContent.get(Attributes.BODY).toString();
+        String body = fileContent.getBody();
 
         assertThat(body).contains("src=\"https://example.com/first.jpg\"");
     }


### PR DESCRIPTION
A little refactoring to introduce a kind of a model abstraction.

A DocumentModel is basically a HashMap with content specific content collected during crawling with explicit getters and setters.

A TemplateModel is a Hashmap with content needed during the rendering phase. It contains a DocumentModel as content.

From there on, we can extend the TemplateModel to add different kind of helper classes for use in different template engines.