### PR TITLE
Fixes #538

### DIFF
--- a/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
@@ -167,10 +167,6 @@ public abstract class MarkupEngine implements ParserEngine {
         boolean statusFound = false;
         boolean typeFound = false;
 
-        if (!hasHeaderSeparatorInContent(contents)) {
-            return false;
-        }
-
         if (!headerSeparatorDemarcatesHeader(contents)) {
             return false;
         }
@@ -219,6 +215,7 @@ public abstract class MarkupEngine implements ParserEngine {
         List<String> subContents = null;
         int index = contents.indexOf(configuration.getHeaderSeparator());
         if (index != -1) {
+            // get every line above header separator
             subContents = contents.subList(0, index);
 
             for (String line : subContents) {

--- a/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
@@ -171,6 +171,10 @@ public abstract class MarkupEngine implements ParserEngine {
             return false;
         }
 
+        if (!headerSeparatorDemarcatesHeader(contents)) {
+            return false;
+        }
+
         for (String line : contents) {
             if (hasHeaderSeparator(line)) {
                 LOGGER.debug("Header separator found");
@@ -203,6 +207,30 @@ public abstract class MarkupEngine implements ParserEngine {
 
     private boolean hasHeaderSeparatorInContent(List<String> contents) {
         return contents.indexOf(configuration.getHeaderSeparator()) != -1;
+    }
+
+    /**
+     * Checks if header separator demarcates end of metadata header
+     *
+     * @param contents
+     * @return true if header separator resides at end of metadata header, false if not
+     */
+    private boolean headerSeparatorDemarcatesHeader(List<String> contents) {
+        List<String> subContents = null;
+        int index = contents.indexOf(configuration.getHeaderSeparator());
+        if (index != -1) {
+            subContents = contents.subList(0, index);
+
+            for (String line : subContents) {
+                // header should only contain empty lines or lines with '=' in
+                if (!line.contains("=") && !line.isEmpty())  {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
     }
 
     private boolean hasHeaderSeparator(String line) {


### PR DESCRIPTION
Adds check to make sure header separator found demarcates metadata header, and ignores if separator is found in content itself.