### PR TITLE
fix jbake-dist upload to bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,8 +80,6 @@ subprojects {
         if ( project.name != "jbake-dist" ) {
             apply from: "$rootDir/gradle/maven-publishing.gradle"
         }
-        // bintray setup
-        apply from: "$rootDir/gradle/publishing.gradle"
     }
 
     // add source and target compatibility for all JavaCompile tasks

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -11,76 +11,75 @@ if (project.name == "jbake-dist") {
      * We just need the distribution packages from the project with signatures if they are present.
      * Notice the repository. It's a generic one. You can configure it with -PbintrayBinaryRepo=whatever
      */
-    afterEvaluate {
-        bintray {
-            user = bintrayUsername
-            key = bintrayKey
+    bintray {
+        user = bintrayUsername
+        key = bintrayKey
 
-            if ( !project.hasProperty('skipSigning') ) {
-                filesSpec {
-                    from signArchives.outputs.files.filter { !it.name.endsWith(".jar") }
-                    from signArchives.signatureFiles.filter { !it.name.endsWith(".jar.asc") }
+        if (!project.hasProperty('skipSigning')) {
+            filesSpec {
+                from distZip
+                from distTar
+                from signArchives.signatureFiles.filter { !it.name.endsWith(".jar.asc") }
 
-                    into "."
-                }
-            }
-            else {
-                filesSpec {
-                    from distZip
-                    from distTar
-
-                    into "."
-                }
+                into "."
             }
 
-            dryRun = bintrayDryRun.toBoolean()
+            _bintrayRecordingCopy.dependsOn signArchives
 
-            pkg {
-                userOrg = bintrayOrg
-                repo = bintrayBinaryRepo
-                name = applicationName
-                desc = project.description
-                licenses = ['MIT']
-                labels = ['jbake', 'site-generator']
-                websiteUrl = project.website
-                issueTrackerUrl = project.issues
-                vcsUrl = project.vcs
-                publicDownloadNumbers = true
+        } else {
+            filesSpec {
+                from distZip
+                from distTar
+
+                into "."
             }
+        }
+
+        dryRun = bintrayDryRun.toBoolean()
+
+        pkg {
+            userOrg = bintrayOrg
+            repo = bintrayBinaryRepo
+            name = applicationName
+            desc = project.description
+            licenses = ['MIT']
+            labels = ['jbake', 'site-generator']
+            websiteUrl = project.website
+            issueTrackerUrl = project.issues
+            vcsUrl = project.vcs
+            publicDownloadNumbers = true
         }
     }
 
 } else {
 
-    afterEvaluate {
-        bintray {
-            user = bintrayUsername
-            key = bintrayKey
-            configurations = ['archives']
+    bintray {
+        user = bintrayUsername
+        key = bintrayKey
+        configurations = ['archives']
 
-            if (!project.hasProperty('skipSigning')) {
-                // Copy the signed pom to bintrayDestination
-                filesSpec {
-                    from signPom
-                    into signPom.bintrayDestination
-                }
-                signPom.dependsOn install
-                bintrayUpload.dependsOn signPom
+        if (!project.hasProperty('skipSigning')) {
+            // Copy the signed pom to bintrayDestination
+            filesSpec {
+                from signPom
+                into signPom.bintrayDestination
             }
+            signPom.dependsOn install
+            bintrayUpload.dependsOn signPom
+        }
 
-            dryRun = bintrayDryRun.toBoolean()
-            pkg {
-                userOrg = bintrayOrg
-                repo = bintrayRepo
-                name = project.name
-                desc = project.description
-                licenses = ['MIT']
-                labels = ['jbake', 'site-generator']
-                websiteUrl = project.website
-                issueTrackerUrl = project.issues
-                vcsUrl = project.vcs
-                publicDownloadNumbers = true
-            }
+        dryRun = bintrayDryRun.toBoolean()
+        pkg {
+            userOrg = bintrayOrg
+            repo = bintrayRepo
+            name = project.name
+            desc = project.description
+            licenses = ['MIT']
+            labels = ['jbake', 'site-generator']
+            websiteUrl = project.website
+            issueTrackerUrl = project.issues
+            vcsUrl = project.vcs
+            publicDownloadNumbers = true
         }
     }
 

--- a/jbake-core/build.gradle
+++ b/jbake-core/build.gradle
@@ -2,6 +2,11 @@ import java.text.SimpleDateFormat
 
 apply from: "$rootDir/gradle/sonarqube.gradle"
 
+if( JavaVersion.current().java7Compatible ) {
+    apply from: "$rootDir/gradle/publishing.gradle"
+}
+
+
 description = "The core library of JBake"
 
 dependencies {

--- a/jbake-dist/build.gradle
+++ b/jbake-dist/build.gradle
@@ -1,6 +1,10 @@
 apply from: "$rootDir/gradle/application.gradle"
 apply from: "$rootDir/gradle/sdkman.gradle"
 
+if( JavaVersion.current().java7Compatible ) {
+    apply from: "$rootDir/gradle/publishing.gradle"
+}
+
 description = "The binary distribution package that bundles JBake cli"
 
 sourceSets {


### PR DESCRIPTION
The bintrayUpload task for the binary distribution was broken with >1.8.0 of the bintray gradle plugin.
This small modifications fix the problem.

run `./gradlew clean -PbintrayDryRun=true bU --info`

and expect an output like:

```
> Task :jbake-dist:bintrayUpload
Task ':jbake-dist:bintrayUpload' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
Gradle Bintray Plugin version: 1.8.4
Version 'jbake/binary/jbake/2.7.0-SNAPSHOT' does not exist. Attempting to create it...
(Dry run) Created version 'jbake/binary/jbake/2.7.0-SNAPSHOT'.
Uploading to https://api.bintray.com/content/jbake/binary/jbake/2.7.0-SNAPSHOT/./jbake-2.7.0-SNAPSHOT-bin.zip...
(Dry run) Uploaded to 'https://api.bintray.com/content/jbake/binary/jbake/2.7.0-SNAPSHOT/./jbake-2.7.0-SNAPSHOT-bin.zip'.
Uploading to https://api.bintray.com/content/jbake/binary/jbake/2.7.0-SNAPSHOT/./jbake-2.7.0-SNAPSHOT.tar...
(Dry run) Uploaded to 'https://api.bintray.com/content/jbake/binary/jbake/2.7.0-SNAPSHOT/./jbake-2.7.0-SNAPSHOT.tar'.
Uploading to https://api.bintray.com/content/jbake/binary/jbake/2.7.0-SNAPSHOT/./jbake-2.7.0-SNAPSHOT-bin.zip.asc...
(Dry run) Uploaded to 'https://api.bintray.com/content/jbake/binary/jbake/2.7.0-SNAPSHOT/./jbake-2.7.0-SNAPSHOT-bin.zip.asc'.
Uploading to https://api.bintray.com/content/jbake/binary/jbake/2.7.0-SNAPSHOT/./jbake-2.7.0-SNAPSHOT.tar.asc...
(Dry run) Uploaded to 'https://api.bintray.com/content/jbake/binary/jbake/2.7.0-SNAPSHOT/./jbake-2.7.0-SNAPSHOT.tar.asc'.
:jbake-dist:bintrayUpload (Thread[Daemon worker Thread 3,5,main]) completed. Took 1.968 secs.
```