### PR TITLE
update to groovy 2.5.3 for JDK 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ after_success:
 - "./gradlew -PskipSigning jacocoRootReport coveralls || ./gradlew clean"
 
 jdk:
+  - openjdk11
   - openjdk10
   - oraclejdk9
   - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     flexmarkVersion = '0.34.48'
     jettyServerVersion = '9.2.24.v20180105'
     orientDbVersion = '2.2.37'
-    groovyVersion = '2.5.2'
+    groovyVersion = '2.5.3'
     slf4jVersion = '1.7.25'
     logbackVersion = '1.2.3'
     assertjCoreVersion = '2.9.1'

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
     thymeleafVersion = '3.0.9.RELEASE'
     jsonSimpleVersion = '1.1.1'
     jade4jVersion = '1.2.7'
-    mockitoVersion = '2.16.0'
+    mockitoVersion = '2.23.0'
     jsoupVersion = '1.11.3'
 
     isTravis = (System.getenv("TRAVIS") == "true")

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ website=http://jbake.org
 issues=https://github.com/jbake-org/jbake/issues
 vcs=https://github.com/jbake-org/jbake/
 
-jacocoVersion=0.8.1
+jacocoVersion=0.8.2
 
 bintrayDryRun=false
 bintrayOrg=jbake


### PR DESCRIPTION
* update to groovy 2.5.3
* enable jdk 11 build at travis