### PR TITLE
Add current dir lib/* and lib/logging to classpath

### DIFF
--- a/gradle/application.gradle
+++ b/gradle/application.gradle
@@ -89,13 +89,15 @@ startScripts {
      * The startScripts produces scripts that contain `$APP_HOME/lib/lib` in the classpath
      * so we need to tweak it a bit to be able to add the whole lib directory to the classpath :|
      *
+     * While we are add it we add current dir + lib/logging and lib/* to allow user to setup logging
+     * and additional/override jar dependencies.
      * See https://stackoverflow.com/questions/10518603/adding-classpath-entries-using-gradles-application-plugin
      */
     doLast {
         def windowsScriptFile = file getWindowsScript()
         def unixScriptFile = file getUnixScript()
-        windowsScriptFile.text = windowsScriptFile.text.replace('%APP_HOME%\\lib\\lib', '%APP_HOME%\\lib\\*')
-        unixScriptFile.text = unixScriptFile.text.replace('$APP_HOME/lib/lib', '$APP_HOME/lib/*')
+        windowsScriptFile.text = windowsScriptFile.text.replace('%APP_HOME%\\lib\\lib', '%DIRNAME%\\lib\\logging;%DIRNAME%\\lib\\*;%APP_HOME%\\lib\\*')
+        unixScriptFile.text = unixScriptFile.text.replace('$APP_HOME/lib/lib', '$SAVED/lib/logging:$SAVED/lib/*:$APP_HOME/lib/*')
     }
 }
 


### PR DESCRIPTION
Why:

 *  when running jbake on cli there is no easy way to configure logging
    nor add additional jars.

This change addreses the need by:

 * extend current searh/replace of scripts to add `pwd`/lib
   and lib/logging


Note: I've tested the linux sh version on OSX, don't have a way
to test Windows nor pure linux right now but I have high confidence
that it will work :)