### PR TITLE
Honor nested path in tagspath

### DIFF
--- a/jbake-core/src/main/java/org/jbake/app/Crawler.java
+++ b/jbake-core/src/main/java/org/jbake/app/Crawler.java
@@ -6,6 +6,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.jbake.app.Crawler.Attributes.Status;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfigurationFactory;
+import org.jbake.app.configuration.ConfigUtil;
 import org.jbake.model.DocumentAttributes;
 import org.jbake.model.DocumentStatus;
 import org.jbake.model.DocumentTypes;
@@ -233,21 +234,7 @@ public class Crawler {
     }
 
     private String getPathToRoot(File sourceFile) {
-        File rootPath = config.getContentFolder();
-        File parentPath = sourceFile.getParentFile();
-        int parentCount = 0;
-        while (!parentPath.equals(rootPath)) {
-            parentPath = parentPath.getParentFile();
-            parentCount++;
-        }
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < parentCount; i++) {
-            sb.append("../");
-        }
-        if (config.getUriWithoutExtension()) {
-            sb.append("../");
-        }
-        return sb.toString();
+        return ConfigUtil.getPathToContentRoot(config, sourceFile);
     }
 
     private DocumentStatus findDocumentStatus(String docType, String uri, String sha1) {

--- a/jbake-core/src/main/java/org/jbake/app/FileUtil.java
+++ b/jbake-core/src/main/java/org/jbake/app/FileUtil.java
@@ -180,5 +180,6 @@ public class FileUtil {
 			return null;
 		}
 		return path.replace(File.separator, "/");
-	}
+    }
+    
 }

--- a/jbake-core/src/main/java/org/jbake/app/Renderer.java
+++ b/jbake-core/src/main/java/org/jbake/app/Renderer.java
@@ -2,6 +2,7 @@ package org.jbake.app;
 
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.jbake.app.Crawler.Attributes;
+import org.jbake.app.configuration.ConfigUtil;
 import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.jbake.app.configuration.JBakeConfigurationFactory;
@@ -272,10 +273,11 @@ public class Renderer {
                 model.put("renderer", renderingEngine);
                 model.put(Attributes.TAG, tag);
                 Map<String, Object> map = buildSimpleModel(Attributes.TAG);
-                map.put(Attributes.ROOTPATH, "../");
                 model.put("content", map);
 
                 File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + tag + config.getOutputExtension());
+                map.put(Attributes.ROOTPATH, ConfigUtil.getPathtoDestinationRoot(config, path));
+                
                 render(new ModelRenderingConfig(path, Attributes.TAG, model, findTemplateName(Attributes.TAG)));
 
                 renderedCount++;
@@ -292,10 +294,10 @@ public class Renderer {
                 Map<String, Object> model = new HashMap<String, Object>();
                 model.put("renderer", renderingEngine);
                 Map<String, Object> map = buildSimpleModel(Attributes.TAGS);
-                map.put(Attributes.ROOTPATH, "../");
                 model.put("content", map);
 
                 File path = new File(config.getDestinationFolder() + File.separator + tagPath + File.separator + "index" + config.getOutputExtension());
+                map.put(Attributes.ROOTPATH, ConfigUtil.getPathToContentRoot(config, path));
                 render(new ModelRenderingConfig(path, "tagindex", model, findTemplateName("tagsindex")));
                 renderedCount++;
             } catch (Exception e) {

--- a/jbake-core/src/main/java/org/jbake/app/configuration/ConfigUtil.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/ConfigUtil.java
@@ -56,4 +56,38 @@ public class ConfigUtil {
         CompositeConfiguration configuration = load(source);
         return new DefaultJBakeConfiguration(source, configuration);
     }
+
+     /**
+     * Given a file inside content it return
+     * the relative path to get to the root.
+     * 
+     * Example: /content and /content/tags/blog will return '../..'
+     * 
+     * @param sourceFile the file to calculate relative path for
+     * @return
+     */
+    static public String getPathToRoot(JBakeConfiguration config, File rootPath, File sourceFile) {
+        File parentPath = sourceFile.getParentFile();
+        int parentCount = 0;
+        while (!parentPath.equals(rootPath) && parentPath.getParentFile()!=null) {
+            parentPath = parentPath.getParentFile();
+            parentCount++;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < parentCount; i++) {
+            sb.append("../");
+        }
+        if (config.getUriWithoutExtension()) {
+            sb.append("../");
+        }
+        return sb.toString();
+    }
+
+    static public String getPathtoDestinationRoot(JBakeConfiguration config, File sourceFile) {
+        return getPathToRoot(config, config.getDestinationFolder(), sourceFile);
+    }   
+    
+    static public String getPathToContentRoot(JBakeConfiguration config, File sourceFile) {
+        return getPathToRoot(config, config.getContentFolder(), sourceFile);
+    }
 }

--- a/jbake-core/src/test/java/org/jbake/app/configuration/ConfigUtilTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/configuration/ConfigUtilTest.java
@@ -334,4 +334,21 @@ public class ConfigUtilTest extends LoggingTest {
         return new File(this.getClass().getResource("/fixture").getFile());
     }
 
+    @Test
+    public void testGetContentRoothPath() throws Exception {
+        File source = getTestResourcesAsSourceFolder();
+        DefaultJBakeConfiguration config = (DefaultJBakeConfiguration) util.loadConfig(source);
+
+        String path = ConfigUtil.getPathToContentRoot(config, new File(config.getContentFolder(), "index.html"));
+
+        assertThat(path).isEqualTo("");
+        
+        path = ConfigUtil.getPathToContentRoot(config, new File(config.getContentFolder(), "/blog/index.html"));
+
+        assertThat(path).isEqualTo("../");
+
+        path = ConfigUtil.getPathToContentRoot(config, new File(config.getDestinationFolder(), "/blog/index.html"));
+
+        assertThat(path).isEqualTo("/somethingelse");
+    }
 }


### PR DESCRIPTION
This is a first cut on fixing #563.
Looking on feedback on where to actually put the utility method to
calculate relative path.

Why:

 * when using a path like /blogs/tags for tag.path result in wrong
   content root. its always ../

This change addreses the need by:

 * move utility method to calculate relative root to a place that
   can be shared
 * call this method during tags generation.

TODO: the getPathToRoot should honor uirExtension prefix.

Fixes #563