### PR TITLE
sonarcloud configuration for github pullrequests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 os: linux
-dist: trusty
+dist: xenial
 
 addons:
   hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,18 @@ after_success:
 
 jdk:
   - openjdk11
-  - openjdk10
   - oraclejdk9
   - oraclejdk8
   - openjdk8
 
 jobs:
   include:
+
+  - script: "./gradlew check"
+    jdk: openjdk10
+    before_install:
+    - rm "${JAVA_HOME}/lib/security/cacerts"
+    - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
 
   - script: "./gradlew check"
     jdk: openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 os: linux
-dist: xenial
+dist: trusty
 
 addons:
   hosts:

--- a/gradle/sonarqube.gradle
+++ b/gradle/sonarqube.gradle
@@ -32,6 +32,7 @@ if ( JavaVersion.current().isJava8Compatible() ) {
                     property "sonar.pullrequest.key", pullRequestId
                     property "sonar.pullrequest.provider", "github"
                     property "sonar.pullrequest.github.repository", System.getenv('TRAVIS_PULL_REQUEST_SLUG')
+                    property "sonar.pullrequest.github.endpoint", "https://api.github.com/"
 
                 } else {
                     logger.error("Cannot use sonar github plugin without GITHUBTOKEN (oauth token) and GITHUBREPO (e.g. jbake-org/jbake) environment variables. See https://docs.sonarqube.org/display/PLUG/GitHub+Plugin")

--- a/gradle/sonarqube.gradle
+++ b/gradle/sonarqube.gradle
@@ -38,7 +38,9 @@ if ( JavaVersion.current().isJava8Compatible() ) {
                 }
             }
             else {
-                logger.info("This is not a travis build. Skipping pullrequest configuration.")
+                logger.info("This is not a travis build. Skipping pullrequest configuration.") 
+                logger.info("isTravis: {}, isTravisPullRequest: {}. Env TRAVIS: {}, Env TRAVIS_PULL_REQUEST", isTravis, isTravisPullRequest, System.getenv("TRAVIS"), System.getenv("TRAVIS_PULL_REQUEST"))
+                
             }
 
         }

--- a/gradle/sonarqube.gradle
+++ b/gradle/sonarqube.gradle
@@ -20,13 +20,25 @@ if ( JavaVersion.current().isJava8Compatible() ) {
             if (isTravis && isTravisPullRequest) {
 
                 if (hasGithub) {
-                    property "sonar.analysis.mode", "preview"
-                    property "sonar.github.oauth", System.getenv("GITHUBTOKEN")
-                    property "sonar.github.repository", System.getenv("GITHUBREPO")
-                    property "sonar.github.pullRequest", pullRequestId
+
+                    /**
+                     * For further information see:
+                     * - https://sonarcloud.io/documentation/analysis/pull-request/
+                     * - https://sonarcloud.io/documentation/integrations/github/
+                     * - https://docs.travis-ci.com/user/environment-variables/
+                     */
+                    property "sonar.pullrequest.base", System.getenv('TRAVIS_BRANCH')
+                    property "sonar.pullrequest.branch", System.getenv('TRAVIS_PULL_REQUEST_BRANCH')
+                    property "sonar.pullrequest.key", pullRequestId
+                    property "sonar.pullrequest.provider", "github"
+                    property "sonar.pullrequest.github.repository", System.getenv('TRAVIS_PULL_REQUEST_SLUG')
+
                 } else {
                     logger.error("Cannot use sonar github plugin without GITHUBTOKEN (oauth token) and GITHUBREPO (e.g. jbake-org/jbake) environment variables. See https://docs.sonarqube.org/display/PLUG/GitHub+Plugin")
                 }
+            }
+            else {
+                logger.info("This is not a travis build. Skipping pullrequest configuration.")
             }
 
         }


### PR DESCRIPTION
The configuration options changed. Adjusted them according the documentation:

* https://sonarcloud.io/documentation/analysis/pull-request/
* https://sonarcloud.io/documentation/integrations/github/
* https://docs.travis-ci.com/user/environment-variables/

If everything works out, this PR should be the first activating PR Analysis with sonarcloud.