### PR TITLE
add checkstyle rules

### DIFF
--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -219,6 +219,15 @@ plugin:: https://docs.gradle.org/current/userguide/signing_plugin.html
 
 == Other useful tasks
 
+=== check code convention violations
+
+The Checkstyle Plugin is configured to use our code conventions defined in `config/checkstyle/checkstyle.xml`.
+
+It gets executed with the `check` Task and prints warnings about violations to the console.
+A report can be found at jbake-core/build/reports/checkstyle/.
+
+plugin:: https://docs.gradle.org/current/userguide/checkstyle_plugin.html
+
 === keep the dependencies up-to-date
 
 It's sometimes hard to keep track of the latest versions for your dependencies.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -68,6 +68,39 @@ This will build a ZIP file in the `/build/distributions` folder.
 
 For more information see link:BUILD.adoc[Test, Build and Deploy]
 
+== Coding conventions
+
+The project uses a basic set of http://checkstyle.sourceforge.net/[checkstyle] rules to keep the Code in shape.
+
+We configured the gradle checkstyle Plugin to run with the `check` task.
+It does not break the build if convention violations are found. But prints a warning and generates a report.
+
+For more information see link:BUILD.adoc[Test, Build and Deploy]
+
+=== Setup Intellij
+
+* Install https://github.com/jshiell/checkstyle-idea[checkstyle-idea plugin]
++
+Settings -> Plugins -> CheckStyle-IDEA
+
+* Configure
++
+Settings -> Other Settings -> Checksytle
++
+Add a new _Configuration File_.
+Enter a Description like "jbake Checkstyle" and choose "Use a local Checkstyle file".
+The checkstyle File is located at the project root path `config/checkstyle/checkstyle.xml`
+
+* Add to Editor Code Style Scheme
++
+Settings -> Editor -> Code Style
++
+Click the gear Symbol besides the "Scheme:" drop-down.
++
+Import Scheme -> Checkstyle Configuration
++
+Pick the project checkstyle file `config/checkstyle/checkstyle.xml`
+
 == Tools & Libraries Used
 
 * http://commons.apache.org/[Apache Commons IO, Configuration, Lang & Logging]

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,19 @@ apply plugin: 'com.github.kt3k.coveralls'
  */
 allprojects {
     apply plugin: 'jacoco'
-    apply plugin: 'checkstyle'
+
+    if ( JavaVersion.current().isJava8Compatible() ) {
+
+        apply plugin: 'checkstyle'
+
+        tasks.withType(Checkstyle) {
+            reports {
+                xml.enabled false
+                html.enabled true
+            }
+        }
+
+    }
 
     repositories {
         jcenter()
@@ -63,13 +75,6 @@ allprojects {
 
     jacoco {
         toolVersion = jacocoVersion
-    }
-
-    tasks.withType(Checkstyle) {
-        reports {
-            xml.enabled false
-            html.enabled true
-        }
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ apply plugin: 'com.github.kt3k.coveralls'
  */
 allprojects {
     apply plugin: 'jacoco'
+    apply plugin: 'checkstyle'
 
     repositories {
         jcenter()
@@ -62,6 +63,13 @@ allprojects {
 
     jacoco {
         toolVersion = jacocoVersion
+    }
+
+    tasks.withType(Checkstyle) {
+        reports {
+            xml.enabled false
+            html.enabled true
+        }
     }
 
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the jbake coding conventions
+
+    For a full list of modules and configuration options see
+    http://checkstyle.sourceforge.net/checks.html
+ -->
+
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="warning"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <module name="TreeWalker">
+        <module name="Indentation"/>
+        <module name="AvoidStarImport"/>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly">
+            <property name="option" value="eol"/>
+        </module>
+        <module name="RightCurly"/>
+    </module>
+
+</module>
+


### PR DESCRIPTION
A simple set of codestyle rules for jbake.

Uses default configurations for
* [Indentation](http://checkstyle.sourceforge.net/config_misc.html#Indentation)
* [AvoidStarImport](http://checkstyle.sourceforge.net/config_imports.html#AvoidStarImport)
* [NeedBraces](http://checkstyle.sourceforge.net/config_blocks.html#NeedBraces)
* [LeftCurly](http://checkstyle.sourceforge.net/config_blocks.html#LeftCurly) with `option=eol`
* [RightCurly](http://checkstyle.sourceforge.net/config_blocks.html#RightCurly)

