### PR TITLE
Parse "jbake-" prefixed asciidoc headers like normal metadata

### DIFF
--- a/jbake-core/src/main/java/org/jbake/parser/AsciidoctorEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/AsciidoctorEngine.java
@@ -98,7 +98,11 @@ public class AsciidoctorEngine extends MarkupEngine {
 
             if (hasJBakePrefix(key)) {
                 String pKey = key.substring(6);
-                documentModel.put(pKey, value);
+                if(value instanceof String) {
+                    processHeader(pKey, (String) value, documentModel);
+                } else {
+                    documentModel.put(pKey, value);
+                }
             }
             if (hasRevdate(key) && canCastToString(value)) {
 

--- a/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/MarkupEngine.java
@@ -253,33 +253,35 @@ public abstract class MarkupEngine implements ParserEngine {
             if (hasHeaderSeparator(line)) {
                 break;
             }
-            processLine(line, context.getDocumentModel());
+            processHeaderLine(line, context.getDocumentModel());
         }
     }
 
-    private void processLine(String line, Map<String, Object> content) {
+    private void processHeaderLine(String line, Map<String, Object> content) {
         String[] parts = line.split("=", 2);
         if (!line.isEmpty() && parts.length == 2) {
+            processHeader(parts[0], parts[1], content);
+        }
+    }
 
+    void processHeader(String inputKey, String inputValue, Map<String, Object> content) {
+        String key = sanitizeKey(inputKey);
+        String value = sanitizeValue(inputValue);
 
-            String key = sanitizeKey(parts[0]);
-            String value = sanitizeValue(parts[1]);
-
-            if (key.equalsIgnoreCase(Crawler.Attributes.DATE)) {
-                DateFormat df = new SimpleDateFormat(configuration.getDateFormat());
-                try {
-                    Date date = df.parse(value);
-                    content.put(key, date);
-                } catch (ParseException e) {
-                    LOGGER.error("unable to parse date {}", value);
-                }
-            } else if (key.equalsIgnoreCase(Crawler.Attributes.TAGS)) {
-                content.put(key, getTags(value));
-            } else if (isJson(value)) {
-                content.put(key, JSONValue.parse(value));
-            } else {
-                content.put(key, value);
+        if (key.equalsIgnoreCase(Crawler.Attributes.DATE)) {
+            DateFormat df = new SimpleDateFormat(configuration.getDateFormat());
+            try {
+                Date date = df.parse(value);
+                content.put(key, date);
+            } catch (ParseException e) {
+                LOGGER.error("unable to parse date {}", value);
             }
+        } else if (key.equalsIgnoreCase(Crawler.Attributes.TAGS)) {
+            content.put(key, getTags(value));
+        } else if (isJson(value)) {
+            content.put(key, JSONValue.parse(value));
+        } else {
+            content.put(key, value);
         }
     }
 


### PR DESCRIPTION
JBake explicitly supports adding complex metadata in the form of string
encoded JSON objects. This support was missing from metadata sourced
from native asciidoc headers. The support is only added for explicit
"jbake-" headers, to not interfere with normal asciidoc operation.