### PR TITLE
Incremental asset baking while serving

### DIFF
--- a/jbake-core/src/main/java/org/jbake/app/Asset.java
+++ b/jbake-core/src/main/java/org/jbake/app/Asset.java
@@ -71,21 +71,78 @@ public class Asset {
         copy(path, config.getDestinationFolder(), filter);
     }
 
-    private void copy(File sourceFolder, File targetFolder, final FileFilter filter) {
+    /**
+     * Copy one asset file at a time.
+     *
+     * @param asset The asset file to copy
+     */
+    public void copySingleFile(File asset) {
+        try {
+            String targetPath = config.getDestinationFolder().getCanonicalPath() + File.separatorChar + assetSubPath(asset);
+            LOGGER.info("Copying single asset file to [" + targetPath + "]");
+            copyFile(asset, new File(targetPath));
+        } catch (IOException io) {
+            LOGGER.error("Failed to copy the asset file.", io);
+        }
+    }
 
+    /**
+     * Determine if a given file is an asset file.
+     * @param path to the file to validate.
+     * @return true if the path provided points to a file in the asset folder.
+     */
+    public boolean isAssetFile(File path) {
+        boolean isAsset = false;
+
+        try {
+            if(FileUtil.directoryOnlyIfNotIgnored(path.getParentFile())) {
+                if (FileUtil.isFileInDirectory(path, config.getAssetFolder())) {
+                    isAsset = true;
+                } else if (FileUtil.isFileInDirectory(path, config.getContentFolder())
+                    && FileUtil.getNotContentFileFilter().accept(path)) {
+                    isAsset = true;
+                }
+            }
+        } catch (IOException ioe) {
+            LOGGER.error("Unable to determine the path to asset file {}", path.getPath(), ioe);
+        }
+        return isAsset;
+    }
+
+    /**
+     * Responsible for copying any asset files that exist within the content directory.
+     *
+     * @param path of the content directory
+     */
+    public void copyAssetsFromContent(File path) {
+        copy(path, config.getDestinationFolder(), FileUtil.getNotContentFileFilter());
+    }
+
+    /**
+     * Accessor method to the collection of errors generated during the bake
+     *
+     * @return a list of errors.
+     */
+    public List<Throwable> getErrors() {
+        return new ArrayList<>(errors);
+    }
+
+    private String assetSubPath(File asset) throws IOException {
+        // First, strip asset folder from file path
+        String targetFolder = asset.getCanonicalPath().replace(config.getAssetFolder().getCanonicalPath() + File.separatorChar, "");
+        // And just to be sure, let's also remove the content folder, as some assets are copied from here.
+        targetFolder = targetFolder.replace(config.getContentFolder().getCanonicalPath() + File.separatorChar, "");
+        return targetFolder;
+    }
+
+    private void copy(File sourceFolder, File targetFolder, final FileFilter filter) {
         final File[] assets = sourceFolder.listFiles(filter);
         if (assets != null) {
             Arrays.sort(assets);
             for (File asset : assets) {
                 final File target = new File(targetFolder, asset.getName());
                 if (asset.isFile()) {
-                    try {
-                        FileUtils.copyFile(asset, target);
-                        LOGGER.info("Copying [{}]... done!", asset.getPath());
-                    } catch (IOException e) {
-                        LOGGER.error("Copying [{}]... failed!", asset.getPath(), e);
-                        errors.add(e);
-                    }
+                    copyFile(asset, target);
                 } else if (asset.isDirectory()) {
                     copy(asset, target, filter);
                 }
@@ -93,13 +150,13 @@ public class Asset {
         }
     }
 
-    public void copyAssetsFromContent(File path) {
-        copy(path, config.getDestinationFolder(), FileUtil.getNotContentFileFilter());
+    private void copyFile(File asset, File targetFolder) {
+        try {
+            FileUtils.copyFile(asset, targetFolder);
+            LOGGER.info("Copying [{}]... done!", asset.getPath());
+        } catch (IOException e) {
+            LOGGER.error("Copying [{}]... failed!", asset.getPath(), e);
+            errors.add(e);
+        }
     }
-
-
-    public List<Throwable> getErrors() {
-        return new ArrayList<>(errors);
-    }
-
 }

--- a/jbake-core/src/main/java/org/jbake/app/FileUtil.java
+++ b/jbake-core/src/main/java/org/jbake/app/FileUtil.java
@@ -181,4 +181,19 @@ public class FileUtil {
         }
         return path.replace(File.separator, "/");
     }
+
+    /**
+     * Utility method to determine if a given file is located somewhere in the directory provided.
+     *
+     * @param file used to check if it is located in the provided directory.
+     * @param directory to validate whether or not the provided file resides.
+     * @return true if the file is somewhere in the provided directory, false if it is not.
+     * @throws IOException if the canonical path for either of the input directories can't be determined.
+     */
+    public static boolean isFileInDirectory(File file, File directory) throws IOException {
+        return (file.exists()
+             && !file.isHidden()
+             && directory.isDirectory()
+             && file.getCanonicalPath().startsWith(directory.getCanonicalPath()));
+    }
 }

--- a/jbake-core/src/main/java/org/jbake/app/Oven.java
+++ b/jbake-core/src/main/java/org/jbake/app/Oven.java
@@ -115,6 +115,22 @@ public class Oven {
     }
 
     /**
+     * Responsible for incremental baking, typically a single file at a time.
+     *
+     * @param fileToBake The file to bake
+     */
+    public void bake(File fileToBake) {
+        Asset asset = utensils.getAsset();
+        if(asset.isAssetFile(fileToBake)) {
+            LOGGER.info("Baking a change to an asset [" + fileToBake.getPath() + "]");
+            asset.copySingleFile(fileToBake);
+        } else {
+            LOGGER.info("Playing it safe and running a full bake...");
+            bake();
+        }
+    }
+
+    /**
      * All the good stuff happens in here...
      */
     public void bake() {
@@ -194,7 +210,6 @@ public class Oven {
             }
         }
     }
-
 
     public List<Throwable> getErrors() {
         return new ArrayList<>(errors);

--- a/jbake-core/src/main/java/org/jbake/launcher/CustomFSChangeListener.java
+++ b/jbake-core/src/main/java/org/jbake/launcher/CustomFSChangeListener.java
@@ -2,10 +2,13 @@ package org.jbake.launcher;
 
 import org.apache.commons.vfs2.FileChangeEvent;
 import org.apache.commons.vfs2.FileListener;
+import org.apache.commons.vfs2.FileObject;
 import org.jbake.app.Oven;
 import org.jbake.app.configuration.JBakeConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
 
 public class CustomFSChangeListener implements FileListener {
 
@@ -20,24 +23,23 @@ public class CustomFSChangeListener implements FileListener {
     @Override
     public void fileCreated(FileChangeEvent event) throws Exception {
         LOGGER.info("File created event detected: {}", event.getFile().getURL());
-        exec();
+        exec(event.getFile());
     }
 
     @Override
     public void fileDeleted(FileChangeEvent event) throws Exception {
         LOGGER.info("File deleted event detected: {}", event.getFile().getURL());
-        exec();
+        exec(event.getFile());
     }
 
     @Override
     public void fileChanged(FileChangeEvent event) throws Exception {
         LOGGER.info("File changed event detected: {}", event.getFile().getURL());
-        exec();
+        exec(event.getFile());
     }
 
-    private void exec() {
+    private void exec(FileObject file) {
         final Oven oven = new Oven(config);
-        oven.bake();
+        oven.bake(new File(file.getName().getPath()));
     }
-
 }

--- a/jbake-core/src/test/java/org/jbake/app/FileUtilTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/FileUtilTest.java
@@ -4,7 +4,9 @@ import org.junit.Test;
 
 import java.io.File;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Created by frank on 28.03.16.
@@ -16,5 +18,18 @@ public class FileUtilTest {
 
         File path = FileUtil.getRunningLocation();
         assertEquals(new File("build/classes").getAbsolutePath(), path.getPath());
+    }
+
+    @Test
+    public void testIsFileInDirectory() throws Exception {
+        File fixtureDir = new File(this.getClass().getResource("/fixture").getFile());
+        File jbakeFile = new File(fixtureDir.getCanonicalPath() + File.separatorChar + "jbake.properties");
+        assertTrue("jbake.properties expected to be in /fixture directory", FileUtil.isFileInDirectory(jbakeFile, fixtureDir));
+
+        File contentFile = new File(fixtureDir.getCanonicalPath() + File.separatorChar + "content" + File.separatorChar + "projects.html");
+        assertTrue("projects.html expected to be nested in the /fixture directory", FileUtil.isFileInDirectory(contentFile, fixtureDir));
+
+        File contentDir = contentFile.getParentFile();
+        assertFalse("jbake.properties file should not be in the /fixture/content directory", FileUtil.isFileInDirectory(jbakeFile, contentDir));
     }
 }


### PR DESCRIPTION
This is the first step to improving bake performance. The scope of this change is focused solely on copying newly changed asset files while serving content. This should work per asset file as it is changed. It should also copy asset files that exist in the content directory.

This pull request is a portion of the work contributing to #391. 