### PR TITLE
update dependencies compatible with jdk 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,15 +4,15 @@ plugins {
     id "io.sdkman.vendors"              version "1.1.1"     apply false
     id "com.jfrog.bintray"              version "1.8.4"     apply false
     id "com.github.kt3k.coveralls"      version "2.8.2"     apply false
-    id "org.sonarqube"                  version "2.6.2"     apply false
+    id "org.sonarqube"                  version "2.7"     apply false
     id 'com.github.ben-manes.versions'  version '0.20.0'
-    id "nebula.optional-base"           version "4.0.1"     apply false
+    id "nebula.optional-base"           version "5.0.0"     apply false
 }
 
 // common variables
 ext {
     asciidoctorjVersion = '1.5.8.1'
-    asciidoctorjDiagramVersion = '1.5.10'
+    asciidoctorjDiagramVersion = '1.5.11'
     commonsIoVersion = '2.6'
     commonsConfigurationVersion = '1.10'
     commonsLangVersion = '3.8.1'
@@ -20,17 +20,17 @@ ext {
     args4jVersion = '2.33'
     freemarkerVersion = '2.3.28'
     junit4Version = '4.12'
-    flexmarkVersion = '0.34.48'
+    flexmarkVersion = '0.40.8'
     jettyServerVersion = '9.2.26.v20180806'
     orientDbVersion = '2.2.37'
-    groovyVersion = '2.5.3'
+    groovyVersion = '2.5.5'
     slf4jVersion = '1.7.25'
     logbackVersion = '1.2.3'
     assertjCoreVersion = '2.9.1'
-    thymeleafVersion = '3.0.9.RELEASE'
+    thymeleafVersion = '3.0.11.RELEASE'
     jsonSimpleVersion = '1.1.1'
     jade4jVersion = '1.2.7'
-    mockitoVersion = '2.23.0'
+    mockitoVersion = '2.23.4'
     jsoupVersion = '1.11.3'
 
     isTravis = (System.getenv("TRAVIS") == "true")

--- a/jbake-core/src/main/java/org/jbake/parser/MarkdownEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/MarkdownEngine.java
@@ -1,10 +1,10 @@
 package org.jbake.parser;
 
-import com.vladsch.flexmark.ast.Node;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.profiles.pegdown.Extensions;
 import com.vladsch.flexmark.profiles.pegdown.PegdownOptionsAdapter;
+import com.vladsch.flexmark.util.ast.Document;
 import com.vladsch.flexmark.util.options.DataHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +44,7 @@ public class MarkdownEngine extends MarkupEngine {
         Parser parser = Parser.builder(options).build();
         HtmlRenderer renderer = HtmlRenderer.builder(options).build();
 
-        Node document = parser.parse(context.getBody());
+        Document document = parser.parse(context.getBody());
         context.setBody(renderer.render(document));
     }
 

--- a/jbake-core/src/test/java/org/jbake/launcher/MainTest.java
+++ b/jbake-core/src/test/java/org/jbake/launcher/MainTest.java
@@ -19,8 +19,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.io.File;
 import java.io.IOException;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/jbake-dist/build.gradle
+++ b/jbake-dist/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     if ( JavaVersion.current().isJava7() ) {
         smokeTestCompile'org.eclipse.jgit:org.eclipse.jgit:4.5.3.201708160445-r'
     } else {
-        smokeTestCompile'org.eclipse.jgit:org.eclipse.jgit:5.1.2.201810061102-r'
+        smokeTestCompile'org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r'
     }
     smokeTestCompile configurations.testCompile
     smokeTestCompile sourceSets.test.output


### PR DESCRIPTION
A last update for the 2.6.4 milestone.

Plugins:

* sonarqube 2.6.2 -> 2.7
* nebula optional-base 4.0.1 -> 5.0.0

Dependencies:

* asciidoctorj-diagram 1.5.10 -> 1.5.11
* flexmark 0.34.48 -> 0.40.8
* groovy 2.5.3 -> 2.5.5
* thymeleaf 3.0.9.RELEASE -> 3.0.11.RELEASE
* mockito 2.23.0 -> 2.24.0
* grgit 5.1.2.201810061102-r -> 5.2.1.201812262042-r