### PR TITLE
Configuration fixes

### DIFF
--- a/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
@@ -47,7 +47,6 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
         this.compositeConfiguration = configuration;
         setSourceFolder(sourceFolder);
         setupDefaultDestination();
-        setupPathsRelativeToSourceFile();
     }
 
     @Override

--- a/jbake-core/src/main/java/org/jbake/launcher/LaunchOptions.java
+++ b/jbake-core/src/main/java/org/jbake/launcher/LaunchOptions.java
@@ -54,7 +54,7 @@ public class LaunchOptions {
         if (destination != null) {
             return new File(destination);
         } else {
-            return new File(getSource(), "output");
+            return null;
         }
     }
 


### PR DESCRIPTION
A combination of a bug in DefaultJBakeConfiguration's constructor and overagressive defaults in LaunchOptions mean that values of destination.folder, content.folder, asset.folder, & template.folder provided in jbake.properties where always ignored.

DefaultJBakeConfiguration constructor was 
```
public DefaultJBakeConfiguration(File sourceFolder, CompositeConfiguration configuration) {
        this.compositeConfiguration = configuration;
        setSourceFolder(sourceFolder);
        setupDefaultDestination();
        setupPathsRelativeToSourceFile();
}
```
setSourceFolder calls setupPathsRelativeToSourceFile as part of its work. Calling setupPathsRelativeToSourceFile a second time causes assets/content/template folder to be misconfigured if they are defined in jbake.properties as anything other than an
immediate child of the source folder. Remedy is to remove the second call.

LaunchOptions.getDestination always overrides destination.folder provided in jbake.properties/default.properties. If no destination folder is provided on the command line, LaunchOptions default's to 'output', which will always squash whatever might be in jbake.properties.
    
To remedy this, LaunchOptions.getDestination should return null and allow the value from jbake.properties, or default.properties below that to come through.
    
The default.properties have destination.folder=output, so there is no change in behaviour for those relying on this value.

