### PR TITLE
Fix more relative paths in html content

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id "eclipse"
     id "idea"
-    id "io.sdkman.vendors"              version "1.1.1"     apply false
-    id "com.jfrog.bintray"              version "1.8.4"     apply false
-    id "com.github.kt3k.coveralls"      version "2.8.2"     apply false
-    id "org.sonarqube"                  version "2.7"     apply false
-    id 'com.github.ben-manes.versions'  version '0.20.0'
-    id "nebula.optional-base"           version "5.0.0"     apply false
+    id "io.sdkman.vendors" version "1.1.1" apply false
+    id "com.jfrog.bintray" version "1.8.4" apply false
+    id "com.github.kt3k.coveralls" version "2.8.2" apply false
+    id "org.sonarqube" version "2.7" apply false
+    id 'com.github.ben-manes.versions' version '0.20.0'
+    id "nebula.optional-base" version "5.0.0" apply false
 }
 
 // common variables
@@ -59,7 +59,7 @@ apply plugin: 'com.github.kt3k.coveralls'
 allprojects {
     apply plugin: 'jacoco'
 
-    if ( JavaVersion.current().isJava8Compatible() ) {
+    if (JavaVersion.current().isJava8Compatible()) {
 
         apply plugin: 'checkstyle'
 
@@ -73,6 +73,10 @@ allprojects {
     }
 
     repositories {
+        maven {
+            url "https://maven.aliyun.com/repository/central"
+        }
+        mavenCentral()
         jcenter()
     }
 
@@ -92,8 +96,8 @@ subprojects {
 
     apply from: "$rootDir/gradle/signing.gradle"
     // We do not publish any jars from the jbake-dist project
-    if ( project.name != "jbake-dist" ) {
-      apply from: "$rootDir/gradle/maven-publishing.gradle"
+    if (project.name != "jbake-dist") {
+        apply from: "$rootDir/gradle/maven-publishing.gradle"
     }
 
     // add source and target compatibility for all JavaCompile tasks
@@ -106,7 +110,7 @@ subprojects {
          *  See https://stackoverflow.com/questions/42599422/warning-options-bootstrap-class-path-not-set-in-conjunction-with-source-1-7
          */
         File file = file("${System.properties.getProperty("java.home")}/lib/rt.jar")
-        if ( file.exists() ) {
+        if (file.exists()) {
             options.setBootstrapClasspath(files(file))
         }
     }
@@ -150,12 +154,12 @@ subprojects {
     //set jvm for all Test tasks (like test and smokeTest)
     tasks.withType(Test) {
 
-        def args = ['-Xms512m', '-Xmx3g', '-Dorientdb.installCustomFormatter=false=false','-Djna.nosys=true']
+        def args = ['-Xms512m', '-Xmx3g', '-Dorientdb.installCustomFormatter=false=false', '-Djna.nosys=true']
 
         /**
          * AppVeyor breaks with mockito throwing a java.lang.OutOfMemoryError: PermGen space
          */
-        if ( JavaVersion.current().java7 ) {
+        if (JavaVersion.current().java7) {
             args << '-XX:MaxPermSize=2g'
         }
 
@@ -163,7 +167,7 @@ subprojects {
          * jdk9 build is unable to determine the amount of MaxDirectMemorySize
          * See https://pastebin.com/ECvQeHx0
          */
-        if ( JavaVersion.current().java9Compatible ) {
+        if (JavaVersion.current().java9Compatible) {
             args << '-XX:MaxDirectMemorySize=2g'
         }
         jvmArgs args
@@ -182,7 +186,7 @@ subprojects {
 task jacocoMerge(type: JacocoMerge) {
     description 'Merge all testreport execution data from subprojects excluding jbake-dist'
     dependsOn subprojects.test
-    executionData subprojects.findAll{it.name!="jbake-dist"}.jacocoTestReport.executionData
+    executionData subprojects.findAll { it.name != "jbake-dist" }.jacocoTestReport.executionData
 }
 
 task jacocoRootReport(type: JacocoReport, group: 'Coverage reports') {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jbake-core/src/main/java/org/jbake/app/Crawler.java
+++ b/jbake-core/src/main/java/org/jbake/app/Crawler.java
@@ -213,9 +213,9 @@ public class Crawler {
                     fileContents.put(Attributes.NO_EXTENSION_URI, uri.replace("/index.html", "/"));
                 }
 
-                if (config.getImgPathUpdate()) {
-                    // Prevent image source url's from breaking
-                    HtmlUtil.fixImageSourceUrls(fileContents, config);
+                if (config.getImgPathUpdate() || config.getRelativePathUpdate()) {
+                    // Prevent relative source(image or href) url's from breaking
+                    HtmlUtil.fixRelativeSourceUrls(fileContents, config);
                 }
 
                 ODocument doc = new ODocument(documentType);

--- a/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
@@ -541,6 +541,24 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
         return getAsBoolean(JBakeProperty.IMG_PATH_UPDATE);
     }
 
+    @Override
+    public boolean getRelativePathUpdate() {
+        return getAsBoolean(JBakeProperty.RELATIVE_PATH_UPDATE);
+    }
+
+    public void setRelativePathUpdate(boolean relativePathUpdate) {
+        setProperty(JBakeProperty.RELATIVE_PATH_UPDATE, relativePathUpdate);
+    }
+
+    @Override
+    public boolean getRelativePathPrependHost() {
+        return getAsBoolean(JBakeProperty.RELATIVE_PATH_PREPEND_HOST);
+    }
+
+    public void setRelativePathPrependHost(boolean relativePathPrependHost) {
+        setProperty(JBakeProperty.RELATIVE_PATH_PREPEND_HOST, relativePathPrependHost);
+    }
+
     public void setImgPathUPdate(boolean imgPathUpdate) {
         setProperty(JBakeProperty.IMG_PATH_UPDATE, imgPathUpdate);
     }

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 /**
  * JBakeConfiguration gives you access to the project configuration. Typically located in a file called jbake.properties.
- *
+ * <p>
  * Use one of {@link JBakeConfigurationFactory} methods to create an instance.
  */
 public interface JBakeConfiguration {
@@ -293,6 +293,18 @@ public interface JBakeConfiguration {
      * see {@link #getImgPathUpdate()} which allows you to control the absolute path used
      */
     boolean getImgPathUpdate();
+
+    /**
+     * @return Flag indicating if relative paths like image or a link in content should be updated with absolute path (using URI value of content file),
+     * see {@link #getRelativePathUpdate()} which allows you to control the absolute path used
+     */
+    boolean getRelativePathUpdate();
+
+    /**
+     * @return Flag indicating if relative paths should be prepended with {@link #getSiteHost()} value - only has an effect if
+     * {@link #getRelativePathUpdate()} is set to true
+     */
+    boolean getRelativePathPrependHost();
 
     /**
      * @return Version of JBake

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeProperty.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeProperty.java
@@ -45,8 +45,11 @@ public class JBakeProperty {
     public static final String URI_NO_EXTENSION_PREFIX = "uri.noExtension.prefix";
     public static final String IMG_PATH_UPDATE = "img.path.update";
     public static final String IMG_PATH_PREPEND_HOST = "img.path.prepend.host";
+    public static final String RELATIVE_PATH_UPDATE = "relative.path.update";
+    public static final String RELATIVE_PATH_PREPEND_HOST = "relative.path.prepend.host";
     public static final String VERSION = "version";
 
-    private JBakeProperty() {}
+    private JBakeProperty() {
+    }
 
 }

--- a/jbake-core/src/main/resources/default.properties
+++ b/jbake-core/src/main/resources/default.properties
@@ -1,7 +1,7 @@
 # application version
 version=v${jbakeVersion}
 # build timestamp
-build.timestamp=${timestamp} 
+build.timestamp=${timestamp}
 # path to destination folder by default
 destination.folder=output
 # folder that contains all template files
@@ -28,7 +28,6 @@ content.folder=content
 asset.folder=assets
 # Flag indicating if hidden asset resources should be ignored
 asset.ignore=false
-
 # render index file?
 render.index=true
 # filename to use for index file
@@ -58,15 +57,13 @@ render.tagsindex=false
 # folder name to use for tag files
 tag.path=tags
 # sanitize tag value before it is used as filename (i.e. replace spaces with hyphens)
-tag.sanitize=false 
-
+tag.sanitize=false
 # file extension for output content files
 output.extension=.html
 # draft content suffix
 draft.suffix=-draft
 # default server port
 server.port=8820
-
 # zip file containing example project structure using freemarker templates
 example.project.freemarker=example_project_freemarker.zip
 # zip file containing example project structure using groovy templates
@@ -77,7 +74,6 @@ example.project.groovy-mte=example_project_groovy-mte.zip
 example.project.thymeleaf=example_project_thymeleaf.zip
 # zip file containing example project structure using jade templates
 example.project.jade=example_project_jade.zip
-
 # default asciidoctor options
 asciidoctor.option=
 # default asciidoctor attributes
@@ -92,20 +88,17 @@ date.format=yyyy-MM-dd
 default.status=draft
 # Default document type.
 default.type=
-
 # comma delimited default markdown extensions; for available extensions:
 # http://www.decodified.com/pegdown/api/org/pegdown/Extensions.html
 markdown.extensions=HARDWRAPS,AUTOLINKS,FENCED_CODE_BLOCKS,DEFINITIONS
 # millis to parse single markdown page. See PegDown Parse configuration for details
 markdown.maxParsingTimeInMillis=2000
-
 # database store (plocal, memory)
 db.store=memory
 # database path
 db.path=cache
 # clear cache
 db.clear.cache=false
-
 # enable extension-less URI option?
 uri.noExtension=false
 # Set to a prefix path (starting with a slash) for which to generate extension-less URI's (i.e. a folder with index.html in)
@@ -122,5 +115,9 @@ site.host=http://www.jbake.org
 header.separator=~~~~~~
 # update image path
 img.path.update=false
+# update relative path
+relative.path.update=false
 # Prepend site.host to image paths
 img.path.prepend.host=true
+# Prepend site.host to relative paths
+relative.path.prepend.host=true

--- a/jbake-core/src/test/java/org/jbake/util/HtmlUtilTest.java
+++ b/jbake-core/src/test/java/org/jbake/util/HtmlUtilTest.java
@@ -7,7 +7,6 @@ import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,6 +45,7 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
         fileContent.put(Attributes.BODY, "<div> Test <img src='./first.jpg' /></div>");
         config.setImgPathPrependHost(false);
+        config.setRelativePathPrependHost(false);
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 
@@ -62,6 +62,7 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
         fileContent.put(Attributes.BODY, "<div> Test <img src='img/deeper/underground.jpg' /></div>");
         config.setImgPathPrependHost(true);
+        config.setRelativePathPrependHost(true);
 
         HtmlUtil.fixImageSourceUrls(fileContent, config);
 


### PR DESCRIPTION
For now, JBake fix image paths to prevent url breaking. As asciidoc support cross reference, which introduce a html link `<a href=...>link</a>`, like **img** tag, this link should be fixed the same way.