### PR TITLE
Support Chinese characters in jbake.properties file by using UTF-8 encoding

### DIFF
--- a/jbake-core/build.gradle
+++ b/jbake-core/build.gradle
@@ -7,8 +7,12 @@ description = "The core library of JBake"
 
 dependencies {
     compile "commons-io:commons-io:$commonsIoVersion"
-    compile "commons-configuration:commons-configuration:$commonsConfigurationVersion"
-    compile "org.apache.commons:commons-vfs2:$commonsVfs2Version", optional
+    compile("commons-configuration:commons-configuration:$commonsConfigurationVersion") {
+        exclude group: "commons-logging", module: "commons-logging"
+    }
+    compile("org.apache.commons:commons-vfs2:$commonsVfs2Version") {
+        exclude group: "commons-logging", module: "commons-logging"
+    }
     compile "org.apache.commons:commons-lang3:$commonsLangVersion"
     compile("com.googlecode.json-simple:json-simple:$jsonSimpleVersion") {
         exclude group: "junit", module: "junit"
@@ -19,7 +23,9 @@ dependencies {
     compile "org.codehaus.groovy:groovy-dateutil:$groovyVersion", optional
     compile "org.freemarker:freemarker:$freemarkerVersion", optional
     compile "org.thymeleaf:thymeleaf:$thymeleafVersion", optional
-    compile "de.neuland-bfi:jade4j:$jade4jVersion", optional
+    compile("de.neuland-bfi:jade4j:$jade4jVersion") {
+        exclude group: "commons-logging", module: "commons-logging"
+    }
     compile "com.vladsch.flexmark:flexmark:$flexmarkVersion", optional
     compile "com.vladsch.flexmark:flexmark-profile-pegdown:$flexmarkVersion", optional
     compile "org.jsoup:jsoup:$jsoupVersion"
@@ -34,7 +40,7 @@ processResources {
     from("src/main/resources") {
         include 'default.properties'
         expand jbakeVersion: project.version,
-                timestamp: new SimpleDateFormat("yyyy-MM-dd HH:mm:ssa").format(new Date())
+            timestamp: new SimpleDateFormat("yyyy-MM-dd HH:mm:ssa").format(new Date())
     }
 }
 

--- a/jbake-core/src/main/java/org/jbake/app/configuration/ConfigUtil.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/ConfigUtil.java
@@ -2,7 +2,6 @@ package org.jbake.app.configuration;
 
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.configuration.SystemConfiguration;
 import org.jbake.app.JBakeException;
 import org.slf4j.Logger;
@@ -10,8 +9,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Provides Configuration related functions.
@@ -39,14 +36,14 @@ public class ConfigUtil {
         File customConfigFile = new File(source, LEGACY_CONFIG_FILE);
         if (customConfigFile.exists()) {
             displayLegacyConfigFileWarningIfRequired();
-            config.addConfiguration(new PropertiesConfiguration(customConfigFile));
+            config.addConfiguration(new Utf8PropertiesConfiguration(customConfigFile));
         }
         customConfigFile = new File(source, CONFIG_FILE);
         if (customConfigFile.exists()) {
-            config.addConfiguration(new PropertiesConfiguration(customConfigFile));
+            config.addConfiguration(new Utf8PropertiesConfiguration(customConfigFile));
         }
         URL defaultPropertiesLocation = this.getClass().getClassLoader().getResource(DEFAULT_CONFIG_FILE);
-        config.addConfiguration(new PropertiesConfiguration(defaultPropertiesLocation));
+        config.addConfiguration(new Utf8PropertiesConfiguration(defaultPropertiesLocation));
         config.addConfiguration(new SystemConfiguration());
         return config;
     }

--- a/jbake-core/src/main/java/org/jbake/app/configuration/Utf8PropertiesConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/Utf8PropertiesConfiguration.java
@@ -1,0 +1,27 @@
+package org.jbake.app.configuration;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+
+import java.io.File;
+import java.net.URL;
+
+public class Utf8PropertiesConfiguration extends PropertiesConfiguration {
+    /**
+     * The default encoding (UTF-8 as specified by http://java.sun.com/j2se/1.5.0/docs/api/java/util/Properties.html)
+     */
+    private static final String DEFAULT_ENCODING = "UTF-8";
+
+    public Utf8PropertiesConfiguration(File file) throws ConfigurationException {
+        super(file);
+    }
+
+    public Utf8PropertiesConfiguration(URL url) throws ConfigurationException {
+        super(url);
+    }
+
+    @Override
+    public String getEncoding() {
+        return DEFAULT_ENCODING;
+    }
+}

--- a/jbake-core/src/test/java/org/jbake/app/configuration/ConfigUtilTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/configuration/ConfigUtilTest.java
@@ -15,15 +15,13 @@ import java.io.File;
 import java.io.FileWriter;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.util.Iterator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(TempDirectory.class)
 public class ConfigUtilTest extends LoggingTest {
@@ -328,4 +326,18 @@ public class ConfigUtilTest extends LoggingTest {
         }
     }
 
+    @Test
+    public void loadPropertiesUtf8Encoding() throws Exception {
+        File sourceFolder = TestUtils.getTestResourcesAsSourceFolder();
+        DefaultJBakeConfiguration config = (DefaultJBakeConfiguration) util.loadConfig(sourceFolder);
+        boolean yes = false;
+        Iterator<String> it = config.getKeys();
+        while (it.hasNext()) {
+            String key = it.next();
+            if ((yes = "site.about".equals(key))) {
+                break;
+            }
+        }
+        assertThat(yes).isTrue();
+    }
 }

--- a/jbake-core/src/test/resources/fixture/jbake.properties
+++ b/jbake-core/src/test/resources/fixture/jbake.properties
@@ -16,3 +16,4 @@ site.host=http://www.jbake.org
 template.feed.thymeleaf.mode=XML
 template.sitemap.thymeleaf.mode=XML
 template.allcontent.file=allcontent.ftl
+site.about=中文属性使用默认Properties编码(Property value in Chinese will let property `site.about` missing due to Apache Configuration implementation.)

--- a/jbake-core/src/test/resources/logback.xml
+++ b/jbake-core/src/test/resources/logback.xml
@@ -12,11 +12,12 @@
   <logger name="org.thymeleaf" level="WARN"/>
   <logger name="org.asciidoctor" level="INFO"/>
   <logger name="org.jbake" level="DEBUG"/>
+  <logger name="org.jbake.app.configuration.Utf8PropertiesConfiguration" level="INFO"/>
 
   <!-- Strictly speaking, the level attribute is not necessary since -->
   <!-- the level of the root level is set to DEBUG by default.       -->
   <root level="DEBUG">
     <appender-ref ref="CONSOLE" />
   </root>
-  
+
 </configuration>


### PR DESCRIPTION
JBake use Apache Configuration to load multi-properties files and also system properties. But right now PropertiesConfiguration reads the properties files in encoding ISO-8859-1, which is not support Chinese by default. Then when PropertiesConfiguration read property value in Chinese will cause the property missing due to not supported character encoding, it cannot decode key and value in lines containing Chinese characters.

In this change, I create `Utf8PropertiesConfiguration` class and override the `String getEncoding()` method and return UTF-8 to make it works.  The default `PropertiesConfiguration` load the file in the constructor, and there are no chances for us to specify a custom encoding before that.

And also, I excludes commons-logging from some deps.

 