### PR TITLE
cleanup and build against openjdk 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ after_success:
 - "./gradlew -PskipSigning jacocoRootReport coveralls || ./gradlew clean"
 
 jdk:
+  - openjdk14
   - openjdk11
   - oraclejdk8
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 os: linux
-dist: trusty
+dist: bionic
 
 addons:
   hosts:
@@ -14,31 +14,34 @@ before_install:
 install: true
 
 script:
-- "./gradlew check"
-
-after_failure:
-- "./gradlew clean check -debug --stacktrace"
-
-after_success:
-- "./gradlew -PskipSigning jacocoRootReport coveralls || ./gradlew clean"
+- "./gradlew check --stacktrace"
 
 jdk:
   - openjdk14
   - openjdk11
-  - oraclejdk8
   - openjdk8
 
 jobs:
   include:
 
-  - script: "./gradlew check"
-    jdk:
+  - jdk: openjdk14
+    os: osx
+
+  - jdk: openjdk11
     os: osx
 
   - stage: Quality Check
-    jdk: oraclejdk8
+    name: sonarqube
+    jdk: openjdk11
     script:
     - "./gradlew jacocoRootReport sonarqube -i --stacktrace"
+
+  - stage: Quality Check
+    name: coveralls
+    jdk: openjdk11
+    script:
+    - "./gradlew -PskipSigning jacocoRootReport coveralls -i --stacktrace"
+    - curl -F 'json_file=@build/coveralls/report.json' 'https://coveralls.io/api/v1/jobs'
 
 notifications:
   irc: "irc.freenode.org#jbake"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image:
+    - Visual Studio 2019
 version: '{build}'
 skip_tags: true
 skip_commits:
@@ -8,6 +10,7 @@ environment:
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - JAVA_HOME: C:\Program Files\Java\jdk11
+    - JAVA_HOME: C:\Program Files\Java\jdk14
 
 install:
   - SET PATH=%JAVA_HOME%\bin;%PATH%

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,11 @@ subprojects {
 
     test {
         useJUnitPlatform()
+
+        testLogging {
+            events "passed", "skipped", "failed"
+            exceptionFormat "full"
+        }
     }
 
     dependencies {
@@ -180,6 +185,8 @@ task testReport(type: TestReport) {
 coveralls {
     sourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
     jacocoReportPath = "${buildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
+    saveAsFile = true
+    sendToCoveralls = false
 }
 
 tasks.coveralls {

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ assertjCoreVersion          = 3.15.0
 mockitoVersion              = 3.3.3
 
 # build dependencies
-jacocoVersion               = 0.8.3
+jacocoVersion               = 0.8.5
 grgitVersion                = 1.6.0
 
 

--- a/jbake-dist/build.gradle
+++ b/jbake-dist/build.gradle
@@ -44,4 +44,11 @@ task smokeTest(type: Test, dependsOn: installDist) {
     shouldRunAfter test
 }
 
+smokeTest {
+    testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
+    }
+}
+
 check.dependsOn smokeTest


### PR DESCRIPTION
adds openjdk 14 test jobs for linux and macosx. moves coveralls job to "Quality Check" stage.
test logging configuration to print tests and stacktraces to the console.