### PR TITLE
feat: allow config file to be specified on command line

### DIFF
--- a/jbake-core/src/main/java/org/jbake/app/configuration/ConfigUtil.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/ConfigUtil.java
@@ -10,8 +10,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Provides Configuration related functions.
@@ -25,7 +23,7 @@ public class ConfigUtil {
     private static final String CONFIG_FILE = "jbake.properties";
     private static final String DEFAULT_CONFIG_FILE = "default.properties";
 
-    private CompositeConfiguration load(File source) throws ConfigurationException {
+    private CompositeConfiguration load(File source, File propertiesFile) throws ConfigurationException {
 
         if (!source.exists()) {
             throw new JBakeException("The given source folder '" + source.getAbsolutePath() + "' does not exist.");
@@ -41,7 +39,7 @@ public class ConfigUtil {
             displayLegacyConfigFileWarningIfRequired();
             config.addConfiguration(new PropertiesConfiguration(customConfigFile));
         }
-        customConfigFile = new File(source, CONFIG_FILE);
+        customConfigFile = propertiesFile != null ? propertiesFile : new File(source, CONFIG_FILE);
         if (customConfigFile.exists()) {
             config.addConfiguration(new PropertiesConfiguration(customConfigFile));
         }
@@ -56,9 +54,30 @@ public class ConfigUtil {
         LOGGER.warn("Usage of this file is being deprecated, please rename this file to: {} to remove this warning", CONFIG_FILE);
     }
 
-    public JBakeConfiguration loadConfig(File source) throws ConfigurationException {
-        CompositeConfiguration configuration = load(source);
+    /**
+     * Load a configuration.
+     *
+     * @param source the source directory of the project
+     * @param propertiesFile the properties file for the project
+     * @return the configuration
+     * @throws ConfigurationException if unable to configure
+     */
+    public JBakeConfiguration loadConfig(File source, File propertiesFile) throws ConfigurationException {
+        CompositeConfiguration configuration = load(source, propertiesFile);
         return new DefaultJBakeConfiguration(source, configuration);
+    }
+
+    /**
+     * Load a configuration.
+     *
+     * @param source the source directory of the project
+     * @return the configuration
+     * @throws ConfigurationException if unable to configure
+     * @deprecated use {@link #loadConfig(File, File)} instead
+     */
+    @Deprecated
+    public JBakeConfiguration loadConfig(File source) throws ConfigurationException {
+        return loadConfig(source, null);
     }
 
 }

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfigurationFactory.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfigurationFactory.java
@@ -23,10 +23,25 @@ public class JBakeConfigurationFactory {
      * @param isClearCache Whether to clear database cache or not
      * @return A configuration by given parameters
      * @throws ConfigurationException if loading the configuration fails
+     * @deprecated use {@link #createDefaultJbakeConfiguration(File, File, File, boolean)} instead
      */
+    @Deprecated
     public DefaultJBakeConfiguration createDefaultJbakeConfiguration(File sourceFolder, File destination, boolean isClearCache) throws ConfigurationException {
+        return createDefaultJbakeConfiguration(sourceFolder, destination, (File) null, isClearCache);
+    }
 
-        DefaultJBakeConfiguration configuration = (DefaultJBakeConfiguration) getConfigUtil().loadConfig(sourceFolder);
+    /**
+     * Creates a {@link DefaultJBakeConfiguration}
+     * @param sourceFolder The source folder of the project
+     * @param destination The destination folder to render and copy files to
+     * @param propertiesFile The properties file for the project
+     * @param isClearCache Whether to clear database cache or not
+     * @return A configuration by given parameters
+     * @throws ConfigurationException if loading the configuration fails
+     */
+    public DefaultJBakeConfiguration createDefaultJbakeConfiguration(File sourceFolder, File destination, File propertiesFile, boolean isClearCache) throws ConfigurationException {
+
+        DefaultJBakeConfiguration configuration = (DefaultJBakeConfiguration) getConfigUtil().loadConfig(sourceFolder, propertiesFile);
         configuration.setDestinationFolder(destination);
         configuration.setClearCache(isClearCache);
 
@@ -89,9 +104,32 @@ public class JBakeConfigurationFactory {
      * @param isClearCache Whether to clear database cache or not
      * @return A configuration by given parameters
      * @throws ConfigurationException if loading the configuration fails
+     * @deprecated use {@link #createDefaultJbakeConfiguration(File, File, File, boolean)} instead
      */
+    @Deprecated
     public DefaultJBakeConfiguration createJettyJbakeConfiguration(File sourceFolder, File destinationFolder, boolean isClearCache) throws ConfigurationException {
         DefaultJBakeConfiguration configuration = (DefaultJBakeConfiguration) getConfigUtil().loadConfig(sourceFolder);
+        configuration.setDestinationFolder(destinationFolder);
+        configuration.setClearCache(isClearCache);
+        configuration.setSiteHost("http://localhost:"+configuration.getServerPort());
+        return configuration;
+    }
+
+
+    /**
+     * Creates a {@link DefaultJBakeConfiguration} with value site.host replaced
+     * by http://localhost:[server.port].
+     * The server.port is read from the project properties file.
+     *
+     * @param sourceFolder The source folder of the project
+     * @param destinationFolder The destination folder to render and copy files to
+     * @param propertiesFile The properties file for the project
+     * @param isClearCache Whether to clear database cache or not
+     * @return A configuration by given parameters
+     * @throws ConfigurationException if loading the configuration fails
+     */
+    public DefaultJBakeConfiguration createJettyJbakeConfiguration(File sourceFolder, File destinationFolder, File propertiesFile, boolean isClearCache) throws ConfigurationException {
+        DefaultJBakeConfiguration configuration = (DefaultJBakeConfiguration) getConfigUtil().loadConfig(sourceFolder, propertiesFile);
         configuration.setDestinationFolder(destinationFolder);
         configuration.setClearCache(isClearCache);
         configuration.setSiteHost("http://localhost:"+configuration.getServerPort());

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfigurationFactory.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfigurationFactory.java
@@ -104,7 +104,7 @@ public class JBakeConfigurationFactory {
      * @param isClearCache Whether to clear database cache or not
      * @return A configuration by given parameters
      * @throws ConfigurationException if loading the configuration fails
-     * @deprecated use {@link #createDefaultJbakeConfiguration(File, File, File, boolean)} instead
+     * @deprecated use {@link #createJettyJbakeConfiguration(File, File, File, boolean)} instead
      */
     @Deprecated
     public DefaultJBakeConfiguration createJettyJbakeConfiguration(File sourceFolder, File destinationFolder, boolean isClearCache) throws ConfigurationException {

--- a/jbake-core/src/main/java/org/jbake/launcher/LaunchOptions.java
+++ b/jbake-core/src/main/java/org/jbake/launcher/LaunchOptions.java
@@ -24,6 +24,9 @@ public class LaunchOptions {
     @Option(name = "-s", aliases = {"--server"}, usage = "runs HTTP server to serve out baked site, if no <value> is supplied will default to a folder called \"output\" in the current directory")
     private boolean runServer;
 
+    @Option(name = "-c", aliases = {"--config"}, usage = "use specified file for configuration, (defaults to \"jbake.properties\" in the source folder if not supplied)")
+    private String properties;
+
     @Option(name = "-h", aliases = {"--help"}, usage = "prints this message")
     private boolean helpNeeded;
 
@@ -60,6 +63,18 @@ public class LaunchOptions {
 
     public String getDestinationValue() {
         return destination;
+    }
+
+    public File getProperties() {
+        if (properties != null) {
+            return new File(properties);
+        } else {
+            return new File(getSource(), "jbake.properties");
+        }
+    }
+
+    public String getPropertiesValue() {
+        return properties;
     }
 
     public boolean isHelpNeeded() {

--- a/jbake-core/src/main/java/org/jbake/launcher/Main.java
+++ b/jbake-core/src/main/java/org/jbake/launcher/Main.java
@@ -73,9 +73,9 @@ public class Main {
         final JBakeConfiguration config;
         try {
             if (res.isRunServer()) {
-                config = getJBakeConfigurationFactory().createJettyJbakeConfiguration(res.getSource(), res.getDestination(), res.isClearCache());
+                config = getJBakeConfigurationFactory().createJettyJbakeConfiguration(res.getSource(), res.getDestination(), res.getProperties(), res.isClearCache());
             } else {
-                config = getJBakeConfigurationFactory().createDefaultJbakeConfiguration(res.getSource(), res.getDestination(), res.isClearCache());
+                config = getJBakeConfigurationFactory().createDefaultJbakeConfiguration(res.getSource(), res.getDestination(), res.getProperties(), res.isClearCache());
             }
         } catch (final ConfigurationException e) {
             throw new JBakeException("Configuration error: " + e.getMessage(), e);

--- a/jbake-core/src/test/java/org/jbake/launcher/LaunchOptionsTest.java
+++ b/jbake-core/src/test/java/org/jbake/launcher/LaunchOptionsTest.java
@@ -108,6 +108,7 @@ public class LaunchOptionsTest {
         assertThat(res.isBake()).isFalse();
         assertThat(res.getSource().getPath()).isEqualTo(System.getProperty("user.dir"));
         assertThat(res.getDestination().getPath()).isEqualTo(System.getProperty("user.dir") + File.separator + "output");
+        assertThat(res.getProperties().getPath()).isEqualTo(System.getProperty("user.dir") + File.separator + "jbake.properties");
     }
 
     @Test
@@ -123,5 +124,16 @@ public class LaunchOptionsTest {
         assertThat(res.isBake()).isTrue();
         assertThat(res.getSource()).isEqualTo(new File("/tmp/source"));
         assertThat(res.getDestination()).isEqualTo(new File("/tmp/destination"));
+        assertThat(res.getProperties()).isEqualTo(new File("/tmp/source/jbake.properties"));
+    }
+
+    @Test
+    public void testConfigArgs() throws Exception {
+        String[] args = {"-c", "foo"};
+        LaunchOptions res = new LaunchOptions();
+        CmdLineParser parser = new CmdLineParser(res);
+        parser.parseArgument(args);
+
+        assertThat(res.getProperties().getAbsolutePath()).isEqualTo(System.getProperty("user.dir") + File.separator + "foo");
     }
 }

--- a/jbake-core/src/test/java/org/jbake/launcher/MainTest.java
+++ b/jbake-core/src/test/java/org/jbake/launcher/MainTest.java
@@ -62,7 +62,7 @@ public class MainTest {
 
         verify(mockJetty).run(expectedOutput.getPath(),"8820");
     }
-    
+
     @Test
     public void launchBakeAndJetty() throws Exception {
         File sourceFolder = folder.newFolder("src", "jbake");
@@ -74,7 +74,7 @@ public class MainTest {
 
         verify(mockJetty).run(expectedOutput.getPath(),"8820");
     }
-    
+
     @Test
     public void launchBakeAndJettyWithCustomDirForJetty() throws ConfigurationException, IOException {
         mockValidSourceFolder("src/jbake", true);
@@ -171,16 +171,16 @@ public class MainTest {
     }
 
     private void mockDefaultJbakeConfiguration(File sourceFolder) throws ConfigurationException {
-        DefaultJBakeConfiguration configuration = new JBakeConfigurationFactory().createJettyJbakeConfiguration(sourceFolder,null,false);
+        DefaultJBakeConfiguration configuration = new JBakeConfigurationFactory().createJettyJbakeConfiguration(sourceFolder,null,null,false);
         System.setProperty("user.dir", sourceFolder.getPath());
 
-        when(factory.createJettyJbakeConfiguration(any(File.class),any(File.class),anyBoolean())).thenReturn( configuration );
+        when(factory.createJettyJbakeConfiguration(any(File.class),any(File.class),any(File.class),anyBoolean())).thenReturn( configuration );
     }
 
     private void mockJettyConfiguration(File sourceFolder, File destinationFolder) throws ConfigurationException {
-        DefaultJBakeConfiguration configuration = new JBakeConfigurationFactory().createJettyJbakeConfiguration(sourceFolder,destinationFolder,false);
+        DefaultJBakeConfiguration configuration = new JBakeConfigurationFactory().createJettyJbakeConfiguration(sourceFolder,destinationFolder,null,false);
         System.setProperty("user.dir", sourceFolder.getPath());
 
-        when(factory.createJettyJbakeConfiguration(any(File.class),any(File.class),anyBoolean())).thenReturn( configuration );
+        when(factory.createJettyJbakeConfiguration(any(File.class),any(File.class),any(File.class),anyBoolean())).thenReturn( configuration );
     }
 }


### PR DESCRIPTION
Adds the `-c VAL` or `--config VAL` command line arguments to allow VAL to be used as a configuration file instead of `jbake.properties`.

Combined with #639, this allows a single source to be used for multiple purposes (for example, the help content of an app could be packaged for a site using one set of templates and for the app using a different set of templates).