### PR TITLE
Don't assume document types are valid identifiers in OrientDB

### DIFF
--- a/jbake-core/src/main/java/org/jbake/app/ContentStore.java
+++ b/jbake-core/src/main/java/org/jbake/app/ContentStore.java
@@ -55,6 +55,7 @@ import java.util.Set;
 public class ContentStore {
 
     private static final String STATEMENT_GET_PUBLISHED_POST_BY_TYPE_AND_TAG = "select * from %s where status='published' and ? in tags order by date desc";
+    private static final String STATEMENT_GET_POST_BY_TYPE_AND_URI = "select * from %s where sourceuri=?";
     private static final String STATEMENT_GET_DOCUMENT_STATUS_BY_DOCTYPE_AND_URI = "select sha1,rendered from %s where sourceuri=?";
     private static final String STATEMENT_GET_PUBLISHED_COUNT = "select count(*) as count from %s where status='published'";
     private static final String STATEMENT_MARK_CONTENT_AS_RENDERD = "update %s set rendered=true where rendered=false and cached=true";
@@ -206,7 +207,7 @@ public class ContentStore {
         }
 
         // Get a document by sourceUri
-        String sql = "SELECT * FROM " + docType + " WHERE sourceuri=?";
+        String sql = String.format(STATEMENT_GET_POST_BY_TYPE_AND_URI, quoteIdentifier(docType));
         activateOnCurrentThread();
         List<ODocument> results = db.command(new OSQLSynchQuery<ODocument>(sql)).execute(sourceUri);
         if (results.isEmpty()) {
@@ -227,7 +228,7 @@ public class ContentStore {
     }
 
     public long getPublishedCount(String docType) {
-        String statement = String.format(STATEMENT_GET_PUBLISHED_COUNT, docType);
+        String statement = String.format(STATEMENT_GET_PUBLISHED_COUNT, quoteIdentifier(docType));
         return (Long) query(statement).get(0).get("count");
     }
 
@@ -235,11 +236,11 @@ public class ContentStore {
      * In fact, the URI should be the only input as there can only be one document at given URI; but the DB is split per document type for some reason.
      */
     public DocumentList getDocumentByUri(String docType, String uri) {
-        return query("select * from " + docType + " where sourceuri=?", uri);
+        return query(String.format(STATEMENT_GET_POST_BY_TYPE_AND_URI, quoteIdentifier(docType)), uri);
     }
 
     public DocumentList getDocumentStatus(String docType, String uri) {
-        String statement = String.format(STATEMENT_GET_DOCUMENT_STATUS_BY_DOCTYPE_AND_URI, docType);
+        String statement = String.format(STATEMENT_GET_DOCUMENT_STATUS_BY_DOCTYPE_AND_URI, quoteIdentifier(docType));
         return query(statement, uri);
     }
 
@@ -259,7 +260,7 @@ public class ContentStore {
         final DocumentList documents = new DocumentList();
 
         for (final String docType : DocumentTypes.getDocumentTypes()) {
-            String statement = String.format(STATEMENT_GET_PUBLISHED_POST_BY_TYPE_AND_TAG, docType);
+            String statement = String.format(STATEMENT_GET_PUBLISHED_POST_BY_TYPE_AND_TAG, quoteIdentifier(docType));
             DocumentList documentsByTag = query(statement, tag);
             documents.addAll(documentsByTag);
         }
@@ -275,7 +276,7 @@ public class ContentStore {
     }
 
     private DocumentList getPublishedContent(String docType, boolean applyPaging) {
-        String query = String.format(STATEMENT_GET_PUBLISHED_CONTENT_BY_DOCTYPE, docType);
+        String query = String.format(STATEMENT_GET_PUBLISHED_CONTENT_BY_DOCTYPE, quoteIdentifier(docType));
         if (applyPaging && hasStartAndLimitBoundary()) {
             query += " SKIP " + start + " LIMIT " + limit;
         }
@@ -287,7 +288,7 @@ public class ContentStore {
     }
 
     public DocumentList getAllContent(String docType, boolean applyPaging) {
-        String query = String.format(STATEMENT_GET_ALL_CONTENT_BY_DOCTYPE, docType);
+        String query = String.format(STATEMENT_GET_ALL_CONTENT_BY_DOCTYPE, quoteIdentifier(docType));
         if (applyPaging && hasStartAndLimitBoundary()) {
             query += " SKIP " + start + " LIMIT " + limit;
         }
@@ -307,17 +308,17 @@ public class ContentStore {
     }
 
     public DocumentList getUnrenderedContent(String docType) {
-        String statement = String.format(STATEMENT_GET_UNDRENDERED_CONTENT, docType);
+        String statement = String.format(STATEMENT_GET_UNDRENDERED_CONTENT, quoteIdentifier(docType));
         return query(statement);
     }
 
     public void deleteContent(String docType, String uri) {
-        String statement = String.format(STATEMENT_DELETE_DOCTYPE_BY_SOURCEURI, docType);
+        String statement = String.format(STATEMENT_DELETE_DOCTYPE_BY_SOURCEURI, quoteIdentifier(docType));
         executeCommand(statement, uri);
     }
 
     public void markContentAsRendered(String docType) {
-        String statement = String.format(STATEMENT_MARK_CONTENT_AS_RENDERD, docType);
+        String statement = String.format(STATEMENT_MARK_CONTENT_AS_RENDERD, quoteIdentifier(docType));
         executeCommand(statement);
     }
 
@@ -326,7 +327,7 @@ public class ContentStore {
     }
 
     public void deleteAllByDocType(String docType) {
-        String statement = String.format(STATEMENT_DELETE_ALL, docType);
+        String statement = String.format(STATEMENT_DELETE_ALL, quoteIdentifier(docType));
         executeCommand(statement);
     }
 
@@ -364,7 +365,7 @@ public class ContentStore {
     public Set<String> getAllTags() {
         Set<String> result = new HashSet<>();
         for (String docType : DocumentTypes.getDocumentTypes()) {
-            String statement = String.format(STATEMENT_GET_TAGS_BY_DOCTYPE, docType);
+            String statement = String.format(STATEMENT_GET_TAGS_BY_DOCTYPE, quoteIdentifier(docType));
             DocumentList docs = query(statement);
             for (Map<String, Object> document : docs) {
                 String[] tags = DBUtil.toStringArray(document.get(Crawler.Attributes.TAGS));
@@ -458,5 +459,13 @@ public class ContentStore {
 
     public boolean isActive() {
         return db.isActiveOnCurrentThread();
+    }
+
+    static String quoteIdentifier(String input) {
+        if(input == null) {
+            return input;
+        } else {
+            return "`" + input.replaceAll("([\\\\`])", "\\\\$1") + "`";
+        }
     }
 }

--- a/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/ContentStoreTest.java
@@ -1,11 +1,18 @@
 package org.jbake.app;
 
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.jbake.FakeDocumentBuilder;
+import static org.jbake.app.ContentStore.quoteIdentifier;
+import org.jbake.app.Crawler.Attributes.Status;
 import org.jbake.model.DocumentAttributes;
+import org.jbake.model.DocumentTypes;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
 public class ContentStoreTest extends ContentStoreIntegrationTest {
@@ -66,4 +73,104 @@ public class ContentStoreTest extends ContentStoreIntegrationTest {
         assertEquals(0, docs.size());
     }
 
+    @Test
+    public void testStoreTypeWithSpecialCharacters() {
+        final String typeWithHyphen = "type-with-hyphen";
+
+        DocumentTypes.addDocumentType(typeWithHyphen);
+
+        final String tagWithHyphen = "tag-with-hyphen";
+        final String uri = "test/testMergeDocument";
+
+        Map<String, Object> values = new HashMap();
+        values.put(Crawler.Attributes.TYPE, typeWithHyphen);
+        values.put(Crawler.Attributes.TAG, tagWithHyphen);
+        values.put(Crawler.Attributes.TAGS, new String[]{tagWithHyphen});
+        values.put(Crawler.Attributes.STATUS, Status.DRAFT);
+        values.put(Crawler.Attributes.DATE, new Date());
+        values.put(DocumentAttributes.RENDERED.toString(), false);
+        values.put(DocumentAttributes.SOURCE_URI.toString(), uri);
+        values.put(DocumentAttributes.CACHED.toString(), true);
+        values.put(DocumentAttributes.RENDERED.toString(), false);
+        values.put("foo", "originalValue");
+
+        ODocument doc = new ODocument(typeWithHyphen);
+        doc.fromMap(values);
+        doc.save();
+
+        DocumentList documentList1 = db.getAllContent(typeWithHyphen);
+
+        assertEquals(1, documentList1.size());
+
+        DocumentList documentList2 = db.getAllContent(typeWithHyphen, true);
+
+        assertEquals(1, documentList2.size());
+
+        DocumentList documentList3 =  db.getDocumentByUri(typeWithHyphen, uri);
+
+        assertEquals(1, documentList3.size());
+
+        long documentCount1 = db.getDocumentCount(typeWithHyphen);
+
+        assertEquals(1L, documentCount1);
+
+        DocumentList documentList4 = db.getDocumentStatus(typeWithHyphen, uri);
+
+        assertEquals(1, documentList4.size());
+        assertEquals(Boolean.FALSE, documentList4.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
+
+        long documentCount2 = db.getPublishedCount(typeWithHyphen);
+        assertEquals(0, documentCount2);
+
+        Map<String,Object> published = new HashMap<>();
+        published.put(DocumentAttributes.SOURCE_URI.toString(), uri);
+        published.put(Crawler.Attributes.TYPE, typeWithHyphen);
+        published.put(Crawler.Attributes.STATUS, Status.PUBLISHED);
+        db.mergeDocument(published);
+
+        DocumentList documentList5 = db.getUnrenderedContent(typeWithHyphen);
+        assertEquals(1, documentList5.size());
+        assertEquals(Boolean.FALSE, documentList5.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
+        assertEquals(typeWithHyphen, documentList5.get(0).get(Crawler.Attributes.TYPE));
+        assertEquals(tagWithHyphen, documentList5.get(0).get(Crawler.Attributes.TAG));
+
+        long documentCount3 = db.getPublishedCount(typeWithHyphen);
+        assertEquals(1, documentCount3);
+
+        db.markContentAsRendered(typeWithHyphen);
+
+        DocumentList documentList6 = db.getPublishedContent(typeWithHyphen);
+        assertEquals(1, documentList6.size());
+        assertEquals(Boolean.TRUE, documentList6.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
+        assertEquals(typeWithHyphen, documentList6.get(0).get(Crawler.Attributes.TYPE));
+        assertEquals(tagWithHyphen, documentList6.get(0).get(Crawler.Attributes.TAG));
+
+        DocumentList documentList7 = db.getPublishedDocumentsByTag(tagWithHyphen);
+        assertEquals(1, documentList7.size());
+        assertEquals(Boolean.TRUE, documentList7.get(0).get(String.valueOf(DocumentAttributes.RENDERED)));
+        assertEquals(typeWithHyphen, documentList7.get(0).get(Crawler.Attributes.TYPE));
+        assertEquals(tagWithHyphen, documentList7.get(0).get(Crawler.Attributes.TAG));
+
+        DocumentList documentList8 = db.getPublishedPostsByTag(tagWithHyphen);
+        assertEquals(0, documentList8.size());
+
+        Set<String> tags = db.getAllTags();
+        assertEquals(Collections.singleton(tagWithHyphen), tags);
+
+        db.deleteContent(typeWithHyphen, uri);
+
+        long documentCount4 = db.getDocumentCount(typeWithHyphen);
+        assertEquals(0, documentCount4);
+
+        db.deleteAllByDocType(typeWithHyphen);
+    }
+
+    @Test
+    public void testIdentifierQuoting() {
+        assertNull(quoteIdentifier(null));
+        assertEquals("`normalIdentifier`", quoteIdentifier("normalIdentifier"));
+        assertEquals("`identifier-with-hyphen`", quoteIdentifier("identifier-with-hyphen"));
+        assertEquals("`identifier-with\\\\backslash`", quoteIdentifier("identifier-with\\backslash"));
+        assertEquals("`identifier-with\\`backtick`", quoteIdentifier("identifier-with`backtick"));
+    }
 }


### PR DESCRIPTION
The ContentStore implementation assumes, that the document types are
valid identifiers, that can be used without quoting them. This limits
document types to "simplified identifiers". This changeset quotes the
identifiers and thus allows for example using a hyphen in the document
type.

This problem was observed when trying to update an older setup, that
was using types like "page-front", "page-noaside", "platform-tutorial".
