### PR TITLE
Support xref aka cross reference link fix in adoc

### DIFF
--- a/jbake-core/src/main/java/org/jbake/app/Crawler.java
+++ b/jbake-core/src/main/java/org/jbake/app/Crawler.java
@@ -213,9 +213,9 @@ public class Crawler {
                     fileContents.put(Attributes.NO_EXTENSION_URI, uri.replace("/index.html", "/"));
                 }
 
-                if (config.getImgPathUpdate()) {
-                    // Prevent image source url's from breaking
-                    HtmlUtil.fixImageSourceUrls(fileContents, config);
+                if (config.getImgPathUpdate() || config.getRelativePathUpdate()) {
+                    // Prevent image or other tag's source url's from breaking
+                    HtmlUtil.fixUrls(fileContents, config);
                 }
 
                 ODocument doc = new ODocument(documentType);

--- a/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
@@ -7,10 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -532,6 +529,15 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
         return getAsBoolean(JBakeProperty.IMG_PATH_PREPEND_HOST);
     }
 
+    @Override
+    public boolean getRelativePathPrependHost() {
+        return getAsBoolean(JBakeProperty.RELATIVE_PATH_PREPEND_HOST);
+    }
+
+    public void setRelativePathPrependHost(boolean relativePathPrependHost) {
+        setProperty(JBakeProperty.RELATIVE_PATH_PREPEND_HOST, relativePathPrependHost);
+    }
+
     public void setImgPathPrependHost(boolean imgPathPrependHost) {
         setProperty(JBakeProperty.IMG_PATH_PREPEND_HOST, imgPathPrependHost);
     }
@@ -541,7 +547,36 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
         return getAsBoolean(JBakeProperty.IMG_PATH_UPDATE);
     }
 
-    public void setImgPathUPdate(boolean imgPathUpdate) {
+    @Override
+    public boolean getRelativePathUpdate() {
+        return getAsBoolean(JBakeProperty.RELATIVE_PATH_UPDATE);
+    }
+
+    public void setRelativePathUpdate(String relativePathUpdate) {
+        setProperty(JBakeProperty.RELATIVE_PATH_UPDATE, relativePathUpdate);
+    }
+
+    @Override
+    public Map<String, String> getTagAttributes() {
+        List<String> pairs = getAsList(JBakeProperty.RELATIVE_TAG_ATTRIBUTE);
+        Map<String, String> tagAttribute = new HashMap<>();
+        char eq = '=';
+        for (String pair : pairs) {
+            int idx = pair.indexOf(eq);
+            if (idx > 0) {
+                String tag = pair.substring(0, idx);
+                String attr = pair.substring(idx + 1);
+                tagAttribute.put(tag, attr);
+            }
+        }
+        return tagAttribute;
+    }
+
+    public void setTagAttributes(String... tagAttributes) {
+        setProperty(JBakeProperty.RELATIVE_TAG_ATTRIBUTE, StringUtils.join(tagAttributes, ","));
+    }
+
+    public void setImgPathUpdate(boolean imgPathUpdate) {
         setProperty(JBakeProperty.IMG_PATH_UPDATE, imgPathUpdate);
     }
 }

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
@@ -3,10 +3,11 @@ package org.jbake.app.configuration;
 import java.io.File;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * JBakeConfiguration gives you access to the project configuration. Typically located in a file called jbake.properties.
- *
+ * <p>
  * Use one of {@link JBakeConfigurationFactory} methods to create an instance.
  */
 public interface JBakeConfiguration {
@@ -289,10 +290,27 @@ public interface JBakeConfiguration {
     boolean getImgPathPrependHost();
 
     /**
+     * @return Flag indicating if a relative paths should be prepended with {@link #getSiteHost()} value - only has an effect if
+     * {@link #getRelativePathUpdate()} is set to true
+     */
+    boolean getRelativePathPrependHost();
+
+    /**
      * @return Flag indicating if image paths in content should be updated with absolute path (using URI value of content file),
      * see {@link #getImgPathUpdate()} which allows you to control the absolute path used
      */
     boolean getImgPathUpdate();
+
+    /**
+     * @return Flag indicating if relative paths in content should be updated with absolute path (using URI value of content file),
+     * see {@link #getRelativePathUpdate()} which allows you to control the absolute path used
+     */
+    boolean getRelativePathUpdate();
+
+    /**
+     * @return Tag and it's attribute name which contains a path that maybe relative.
+     */
+    Map<String, String> getTagAttributes();
 
     /**
      * @return Version of JBake

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeProperty.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeProperty.java
@@ -45,8 +45,12 @@ public class JBakeProperty {
     public static final String URI_NO_EXTENSION_PREFIX = "uri.noExtension.prefix";
     public static final String IMG_PATH_UPDATE = "img.path.update";
     public static final String IMG_PATH_PREPEND_HOST = "img.path.prepend.host";
+    public static final String RELATIVE_PATH_UPDATE = "relative.path.update";
+    public static final String RELATIVE_PATH_PREPEND_HOST = "relative.path.prepend.host";
+    public static final String RELATIVE_TAG_ATTRIBUTE = "relative.tag.attribute";
     public static final String VERSION = "version";
 
-    private JBakeProperty() {}
+    private JBakeProperty() {
+    }
 
 }

--- a/jbake-core/src/main/resources/default.properties
+++ b/jbake-core/src/main/resources/default.properties
@@ -1,7 +1,7 @@
 # application version
 version=v${jbakeVersion}
 # build timestamp
-build.timestamp=${timestamp} 
+build.timestamp=${timestamp}
 # path to destination folder by default
 destination.folder=output
 # folder that contains all template files
@@ -58,7 +58,7 @@ render.tagsindex=false
 # folder name to use for tag files
 tag.path=tags
 # sanitize tag value before it is used as filename (i.e. replace spaces with hyphens)
-tag.sanitize=false 
+tag.sanitize=false
 
 # file extension for output content files
 output.extension=.html
@@ -124,3 +124,9 @@ header.separator=~~~~~~
 img.path.update=false
 # Prepend site.host to image paths
 img.path.prepend.host=true
+# update relative path
+relative.path.update=false
+# prepend site.host to tag paths
+relative.path.prepend.host=true
+# relative tag and attribute, for img's src and a's href.
+relative.tag.attribute=img=src,a=href

--- a/jbake-core/src/test/java/org/jbake/util/HtmlUtilTest.java
+++ b/jbake-core/src/test/java/org/jbake/util/HtmlUtilTest.java
@@ -7,7 +7,6 @@ import org.jbake.app.configuration.DefaultJBakeConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,7 +29,23 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
         fileContent.put(Attributes.BODY, "<div> Test <img src='/blog/2017/05/first.jpg' /></div>");
 
-        HtmlUtil.fixImageSourceUrls(fileContent, config);
+        HtmlUtil.fixUrls(fileContent, config);
+
+        String body = fileContent.get(Attributes.BODY).toString();
+
+        assertThat(body).doesNotContain("<body>");
+        assertThat(body).doesNotContain("</body>");
+
+    }
+
+    @Test
+    public void shouldNotAddBodyHTMLElement0() {
+        Map<String, Object> fileContent = new HashMap<String, Object>();
+        fileContent.put(Attributes.ROOTPATH, "../../../");
+        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+        fileContent.put(Attributes.BODY, "<div> Test <a href='/blog/2017/05/second_post.html' /></div>");
+
+        HtmlUtil.fixUrls(fileContent, config);
 
         String body = fileContent.get(Attributes.BODY).toString();
 
@@ -47,11 +62,27 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.BODY, "<div> Test <img src='./first.jpg' /></div>");
         config.setImgPathPrependHost(false);
 
-        HtmlUtil.fixImageSourceUrls(fileContent, config);
+        HtmlUtil.fixUrls(fileContent, config);
 
         String body = fileContent.get(Attributes.BODY).toString();
 
         assertThat(body).contains("src=\"blog/2017/05/first.jpg\"");
+
+    }
+
+    @Test
+    public void shouldNotAddSiteHost0() {
+        Map<String, Object> fileContent = new HashMap<String, Object>();
+        fileContent.put(Attributes.ROOTPATH, "../../../");
+        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+        fileContent.put(Attributes.BODY, "<div> Test <a href='./first.jpg' /></div>");
+        config.setRelativePathPrependHost(false);
+
+        HtmlUtil.fixUrls(fileContent, config);
+
+        String body = fileContent.get(Attributes.BODY).toString();
+
+        assertThat(body).contains("href=\"blog/2017/05/first.jpg\"");
 
     }
 
@@ -63,11 +94,26 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.BODY, "<div> Test <img src='img/deeper/underground.jpg' /></div>");
         config.setImgPathPrependHost(true);
 
-        HtmlUtil.fixImageSourceUrls(fileContent, config);
+        HtmlUtil.fixUrls(fileContent, config);
 
         String body = fileContent.get(Attributes.BODY).toString();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/img/deeper/underground.jpg\"");
+    }
+
+    @Test
+    public void shouldAddSiteHostWithRelativeImageToDocument0() {
+        Map<String, Object> fileContent = new HashMap<>();
+        fileContent.put(Attributes.ROOTPATH, "../../../");
+        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+        fileContent.put(Attributes.BODY, "<div> Test <a href='img/deeper/underground.jpg' /></div>");
+        config.setRelativePathPrependHost(true);
+
+        HtmlUtil.fixUrls(fileContent, config);
+
+        String body = fileContent.get(Attributes.BODY).toString();
+
+        assertThat(body).contains("href=\"http://www.jbake.org/blog/2017/05/img/deeper/underground.jpg\"");
     }
 
     @Test
@@ -77,11 +123,26 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
         fileContent.put(Attributes.BODY, "<div> Test <img src='./first.jpg' /></div>");
 
-        HtmlUtil.fixImageSourceUrls(fileContent, config);
+        HtmlUtil.fixUrls(fileContent, config);
 
         String body = fileContent.get(Attributes.BODY).toString();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
+
+    }
+
+    @Test
+    public void shouldAddContentPath0() {
+        Map<String, Object> fileContent = new HashMap<String, Object>();
+        fileContent.put(Attributes.ROOTPATH, "../../../");
+        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+        fileContent.put(Attributes.BODY, "<div> Test <a href='./first.jpg' /></div>");
+
+        HtmlUtil.fixUrls(fileContent, config);
+
+        String body = fileContent.get(Attributes.BODY).toString();
+
+        assertThat(body).contains("href=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 
     }
 
@@ -92,11 +153,26 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
         fileContent.put(Attributes.BODY, "<div> Test <img src='first.jpg' /></div>");
 
-        HtmlUtil.fixImageSourceUrls(fileContent, config);
+        HtmlUtil.fixUrls(fileContent, config);
 
         String body = fileContent.get(Attributes.BODY).toString();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
+
+    }
+
+    @Test
+    public void shouldAddContentPathForCurrentDirectory0() {
+        Map<String, Object> fileContent = new HashMap<String, Object>();
+        fileContent.put(Attributes.ROOTPATH, "../../../");
+        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+        fileContent.put(Attributes.BODY, "<div> Test <a href='first.jpg' /></div>");
+
+        HtmlUtil.fixUrls(fileContent, config);
+
+        String body = fileContent.get(Attributes.BODY).toString();
+
+        assertThat(body).contains("href=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 
     }
 
@@ -107,11 +183,26 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
         fileContent.put(Attributes.BODY, "<div> Test <img src='/blog/2017/05/first.jpg' /></div>");
 
-        HtmlUtil.fixImageSourceUrls(fileContent, config);
+        HtmlUtil.fixUrls(fileContent, config);
 
         String body = fileContent.get(Attributes.BODY).toString();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
+
+    }
+
+    @Test
+    public void shouldNotAddRootPath0() {
+        Map<String, Object> fileContent = new HashMap<String, Object>();
+        fileContent.put(Attributes.ROOTPATH, "../../../");
+        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+        fileContent.put(Attributes.BODY, "<div> Test <a href='/blog/2017/05/first.jpg' /></div>");
+
+        HtmlUtil.fixUrls(fileContent, config);
+
+        String body = fileContent.get(Attributes.BODY).toString();
+
+        assertThat(body).contains("href=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 
     }
 
@@ -123,11 +214,27 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
         fileContent.put(Attributes.BODY, "<div> Test <img src='/blog/2017/05/first.jpg' /></div>");
 
-        HtmlUtil.fixImageSourceUrls(fileContent, config);
+        HtmlUtil.fixUrls(fileContent, config);
 
         String body = fileContent.get(Attributes.BODY).toString();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
+
+    }
+
+    @Test
+    public void shouldNotAddRootPathForNoExtension0() {
+        Map<String, Object> fileContent = new HashMap<String, Object>();
+        fileContent.put(Attributes.ROOTPATH, "../../../");
+        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+        fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
+        fileContent.put(Attributes.BODY, "<div> Test <a href='/blog/2017/05/first.jpg' /></div>");
+
+        HtmlUtil.fixUrls(fileContent, config);
+
+        String body = fileContent.get(Attributes.BODY).toString();
+
+        assertThat(body).contains("href=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 
     }
 
@@ -139,11 +246,26 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
         fileContent.put(Attributes.BODY, "<div> Test <img src='./first.jpg' /></div>");
 
-        HtmlUtil.fixImageSourceUrls(fileContent, config);
+        HtmlUtil.fixUrls(fileContent, config);
 
         String body = fileContent.get(Attributes.BODY).toString();
 
         assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
+    }
+
+    @Test
+    public void shouldAddContentPathForNoExtension0() {
+        Map<String, Object> fileContent = new HashMap<String, Object>();
+        fileContent.put(Attributes.ROOTPATH, "../../../");
+        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+        fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
+        fileContent.put(Attributes.BODY, "<div> Test <a href='./first.jpg' /></div>");
+
+        HtmlUtil.fixUrls(fileContent, config);
+
+        String body = fileContent.get(Attributes.BODY).toString();
+
+        assertThat(body).contains("href=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
     }
 
     @Test
@@ -154,11 +276,27 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
         fileContent.put(Attributes.BODY, "<div> Test <img src='http://example.com/first.jpg' /></div>");
 
-        HtmlUtil.fixImageSourceUrls(fileContent, config);
+        HtmlUtil.fixUrls(fileContent, config);
 
         String body = fileContent.get(Attributes.BODY).toString();
 
         assertThat(body).contains("src=\"http://example.com/first.jpg\"");
+
+    }
+
+    @Test
+    public void shouldNotChangeForHTTP0() {
+        Map<String, Object> fileContent = new HashMap<String, Object>();
+        fileContent.put(Attributes.ROOTPATH, "../../../");
+        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+        fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
+        fileContent.put(Attributes.BODY, "<div> Test <a href='http://example.com/first.jpg' /></div>");
+
+        HtmlUtil.fixUrls(fileContent, config);
+
+        String body = fileContent.get(Attributes.BODY).toString();
+
+        assertThat(body).contains("href=\"http://example.com/first.jpg\"");
 
     }
 
@@ -170,10 +308,25 @@ public class HtmlUtilTest {
         fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
         fileContent.put(Attributes.BODY, "<div> Test <img src='https://example.com/first.jpg' /></div>");
 
-        HtmlUtil.fixImageSourceUrls(fileContent, config);
+        HtmlUtil.fixUrls(fileContent, config);
 
         String body = fileContent.get(Attributes.BODY).toString();
 
         assertThat(body).contains("src=\"https://example.com/first.jpg\"");
+    }
+
+    @Test
+    public void shouldNotChangeForHTTPS0() {
+        Map<String, Object> fileContent = new HashMap<String, Object>();
+        fileContent.put(Attributes.ROOTPATH, "../../../");
+        fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+        fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
+        fileContent.put(Attributes.BODY, "<div> Test <a href='https://example.com/first.jpg' /></div>");
+
+        HtmlUtil.fixUrls(fileContent, config);
+
+        String body = fileContent.get(Attributes.BODY).toString();
+
+        assertThat(body).contains("href=\"https://example.com/first.jpg\"");
     }
 }


### PR DESCRIPTION
I use JBake version 2.6.5 and adoc to write some blog. JBake has two configuration properties to fix relative image src. And they are `img.path.update` and `img.path.prepend.host`. These two properties only affect `img` tag and it's `src` attribute.

But in adoc, we can add a reference in one doc to another by for example` xref:a-gentle-introduction-to-multithreading.adoc[introduction] `, like image , this will generate a `<a href='a-gentle-introduction-to-multithreading.html''>...</>` tag with relative path. This need fix too.

I introduce three new properties, `relative.path.update`, `relative.path.prepend.host` and `relative.tag.attribute`. `relative.path.update` and `relative.path.prepend.host` are for configuring all relative paths updates, not just `img` tag. And the third property `relative.tag.attribute` defines which tags need fix, for example `relative.tag.attribute=img=src,a=href`.

For backward compatible, both the new and old properties should work.

With a false default value, we should use the properties this way
`boolean pathUpdate = config.getImgPathUpdate() || config.getRelativePathUpdate()`
With a true default value, we should use the properties this way:
`boolean prependSiteHost = configuration.getImgPathPrependHost() && configuration.getRelativePathPrependHost();`