### PR TITLE
produce reproducible archives (distribution zip and jar files)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id "org.sonarqube"                  version "3.1.1"     apply false
     id 'com.github.ben-manes.versions'  version '0.38.0'
     id "nebula.optional-base"           version "5.0.3"     apply false
+    id 'org.ajoberstar.grgit' version "$grgitVersion"
 }
 
 // common variables
@@ -56,6 +57,10 @@ allprojects {
         toolVersion = jacocoVersion
     }
 
+    tasks.withType(AbstractArchiveTask) {
+        preserveFileTimestamps = false
+        reproducibleFileOrder = true
+    }
 }
 
 /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ mockitoVersion              = 3.8.0
 
 # build dependencies
 jacocoVersion               = 0.8.6
-grgitVersion                = 1.6.0
+grgitVersion                = 4.1.0
 
 bintrayDryRun = false
 bintrayOrg = jbake

--- a/gradle/application.gradle
+++ b/gradle/application.gradle
@@ -1,21 +1,7 @@
-import org.ajoberstar.grgit.Grgit
-
-import java.text.SimpleDateFormat
-
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "org.ajoberstar:grgit:$grgitVersion"
-    }
-}
-
 apply plugin: 'application'
 
 mainClassName = "org.jbake.launcher.Main"
 applicationName = "jbake"
-
 
 def examplesBase = "$project.buildDir/examples"
 
@@ -26,16 +12,6 @@ def exampleRepositories = [
     "example_project_groovy-mte": "git://github.com/jbake-org/jbake-example-project-groovy-mte.git",
     "example_project_jade"      : "git://github.com/jbake-org/jbake-example-project-jade.git"
 ]
-
-processResources {
-    from("src/main/resources"){
-        include 'default.properties'
-        expand  jbakeVersion: project.version,
-                timestamp: new SimpleDateFormat("yyyy-MM-dd HH:mm:ssa").format( new Date() )
-    }
-}
-
-
 
 //create clone and Zip Task for each repository
 exampleRepositories.each { name, repository ->
@@ -49,7 +25,7 @@ exampleRepositories.each { name, repository ->
         outputs.dir repositoryName
 
         doLast {
-            Grgit.clone(dir: repositoryName, uri: repository)
+            grgit.clone(dir: repositoryName, uri: repository)
         }
     }
 

--- a/gradle/maven-publishing.gradle
+++ b/gradle/maven-publishing.gradle
@@ -1,11 +1,11 @@
-import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 
 apply plugin: 'maven-publish'
 
-Date buildTimeAndDate = new Date()
+def buildTimeAndDate = grgit.head().dateTime
 ext {
-    buildDate = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)
-    buildTime = new SimpleDateFormat('HH:mm:ss.SSSZ').format(buildTimeAndDate)
+    buildDate = buildTimeAndDate.format(DateTimeFormatter.ofPattern('yyyy-MM-dd'))
+    buildTime = buildTimeAndDate.format(DateTimeFormatter.ofPattern('HH:mm:ss.SSSZ'))
     isReleaseVersion = !version.endsWith("SNAPSHOT")
 }
 

--- a/jbake-core/build.gradle
+++ b/jbake-core/build.gradle
@@ -1,4 +1,5 @@
 import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 
 apply from: "$rootDir/gradle/sonarqube.gradle"
 apply plugin: 'java-library'
@@ -36,7 +37,6 @@ processResources {
     from("src/main/resources") {
         include 'default.properties'
         expand jbakeVersion: project.version,
-                timestamp: new SimpleDateFormat("yyyy-MM-dd HH:mm:ssa").format(new Date())
+               timestamp: grgit.head().dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss'['VV']'"))
     }
 }
-

--- a/jbake-dist/build.gradle
+++ b/jbake-dist/build.gradle
@@ -52,3 +52,5 @@ smokeTest {
 }
 
 check.dependsOn smokeTest
+
+jar.enabled=false


### PR DESCRIPTION
Using the timestamp of the current repository HEAD and make sure the generated jar and zipfiles evaluate to the same checksums after rebuilding.