### PR TITLE
Add support for data files specifically in YAML format

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,7 @@ logbackVersion              = 1.2.3
 orientDbVersion             = 3.0.37
 pebbleVersion               = 3.1.5
 slf4jVersion                = 1.7.30
+snakeYamlVersion            = 1.28
 thymeleafVersion            = 3.0.12.RELEASE
 
 # testing dependencies

--- a/jbake-core/build.gradle
+++ b/jbake-core/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation "com.vladsch.flexmark:flexmark-profile-pegdown:$flexmarkVersion", optional
     implementation "org.jsoup:jsoup:$jsoupVersion"
     implementation "io.pebbletemplates:pebble:$pebbleVersion", optional
+    implementation "org.yaml:snakeyaml:$snakeYamlVersion", optional
 
     // cli specific dependencies
     implementation "org.eclipse.jetty:jetty-server:$jettyServerVersion", optional

--- a/jbake-core/src/main/java/org/jbake/app/Crawler.java
+++ b/jbake-core/src/main/java/org/jbake/app/Crawler.java
@@ -73,6 +73,12 @@ public class Crawler {
 
     }
 
+    public void crawlDataFiles() {
+        crawl(config.getDataFolder());
+
+
+    }
+
     /**
      * Crawl all files and folders looking for content.
      *

--- a/jbake-core/src/main/java/org/jbake/app/FileUtil.java
+++ b/jbake-core/src/main/java/org/jbake/app/FileUtil.java
@@ -42,6 +42,21 @@ public class FileUtil {
     }
 
     /**
+     * Filters files based on their file extension - only find data files (i.e. files with .yaml or .yml extension)
+     *
+     * @return Object for filtering files
+     */
+    public static FileFilter getDataFileFilter() {
+        return new FileFilter() {
+
+            @Override
+            public boolean accept(File pathname) {
+                return "yaml".equalsIgnoreCase(fileExt(pathname)) || "yml".equalsIgnoreCase(fileExt(pathname));
+            }
+        };
+    }
+
+    /**
      * Gets the list of files that are not content files based on their extension.
      *
      * @return FileFilter object

--- a/jbake-core/src/main/java/org/jbake/app/Oven.java
+++ b/jbake-core/src/main/java/org/jbake/app/Oven.java
@@ -152,6 +152,9 @@ public class Oven {
             // process source content
             crawler.crawl();
 
+            // process data files
+            crawler.crawlDataFiles();
+
             // render content
             renderContent();
 
@@ -187,6 +190,9 @@ public class Oven {
         for (String docType : config.getDocumentTypes()) {
             DocumentTypes.addDocumentType(docType);
         }
+
+        // needs manually setting as this isn't defined in same way as document types for content files
+        DocumentTypes.addDocumentType(config.getDataFileDocType());
     }
 
     private void resetDocumentTypesAndExtractors() {

--- a/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
@@ -201,6 +201,15 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
     }
 
     @Override
+    public String getDataFileDocType() {
+        return getAsString(JBakeProperty.DATA_FILE_DOCTYPE);
+    }
+
+    public void setDataFileDocType(String dataFileDocType) {
+        setProperty(JBakeProperty.DATA_FILE_DOCTYPE, dataFileDocType);
+    }
+
+    @Override
     public String getDatabasePath() {
         return getAsString(JBakeProperty.DB_PATH);
     }
@@ -217,6 +226,8 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
     public void setDatabaseStore(String storeType) {
         setProperty(JBakeProperty.DB_STORE, storeType);
     }
+
+
 
     @Override
     public String getDateFormat() {
@@ -522,6 +533,7 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
         setupDefaultAssetFolder();
         setupDefaultTemplateFolder();
         setupDefaultContentFolder();
+        setupDefaultDataFolder();
     }
 
     private void setupDefaultDestination() {
@@ -555,6 +567,17 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
             setTemplateFolder(template);
         } else {
             setTemplateFolder(new File(getSourceFolder(), templateFolder));
+        }
+    }
+
+    private void setupDefaultDataFolder() {
+        String dataFolder = getAsString(JBakeProperty.DATA_FOLDER);
+
+        File data = new File(dataFolder);
+        if(data.isAbsolute()) {
+            setDataFolder(data);
+        } else {
+            setDataFolder(new File(getSourceFolder(), dataFolder));
         }
     }
 

--- a/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
@@ -27,6 +27,7 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
     private static final String ASSET_FOLDER_KEY = "assetFolder";
     private static final String TEMPLATE_FOLDER_KEY = "templateFolder";
     private static final String CONTENT_FOLDER_KEY = "contentFolder";
+    private static final String DATA_FOLDER_KEY = "dataFolder";
     private static final Pattern TEMPLATE_DOC_PATTERN = Pattern.compile("(?:template\\.)([a-zA-Z0-9-_]+)(?:\\.file)");
     private static final String DOCTYPE_FILE_POSTFIX = ".file";
     private static final String DOCTYPE_EXTENSION_POSTFIX = ".extension";
@@ -181,6 +182,22 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
     @Override
     public String getContentFolderName() {
         return getAsString(JBakeProperty.CONTENT_FOLDER);
+    }
+
+    @Override
+    public File getDataFolder() {
+        return getAsFolder(DATA_FOLDER_KEY);
+    }
+
+    public void setDataFolder(File dataFolder) {
+        if (dataFolder != null) {
+            setProperty(DATA_FOLDER_KEY, dataFolder);
+        }
+    }
+
+    @Override
+    public String getDataFolderName() {
+        return getAsString(JBakeProperty.DATA_FOLDER);
     }
 
     @Override

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
@@ -95,6 +95,11 @@ public interface JBakeConfiguration {
     String getDataFolderName();
 
     /**
+     * @return docType for data files
+     */
+    String getDataFileDocType();
+
+    /**
      * @return Folder to store database files in
      */
     String getDatabasePath();

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
@@ -85,6 +85,16 @@ public interface JBakeConfiguration {
     String getContentFolderName();
 
     /**
+     * @return the data folder
+     */
+    File getDataFolder();
+
+    /**
+     * @return name of Folder where data files reside in
+     */
+    String getDataFolderName();
+
+    /**
      * @return Folder to store database files in
      */
     String getDatabasePath();

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeProperty.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeProperty.java
@@ -12,6 +12,7 @@ public class JBakeProperty {
     public static final String BUILD_TIMESTAMP = "build.timestamp";
     public static final String CLEAR_CACHE = "db.clear.cache";
     public static final String CONTENT_FOLDER = "content.folder";
+    public static final String DATA_FOLDER = "data.folder";
     public static final String DATE_FORMAT = "date.format";
     public static final String DB_STORE = "db.store";
     public static final String DB_PATH = "db.path";

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeProperty.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeProperty.java
@@ -13,6 +13,7 @@ public class JBakeProperty {
     public static final String CLEAR_CACHE = "db.clear.cache";
     public static final String CONTENT_FOLDER = "content.folder";
     public static final String DATA_FOLDER = "data.folder";
+    public static final String DATA_FILE_DOCTYPE = "data.file.docType";
     public static final String DATE_FORMAT = "date.format";
     public static final String DB_STORE = "db.store";
     public static final String DB_PATH = "db.path";

--- a/jbake-core/src/main/java/org/jbake/launcher/BakeWatcher.java
+++ b/jbake-core/src/main/java/org/jbake/launcher/BakeWatcher.java
@@ -45,13 +45,15 @@ public class BakeWatcher {
             FileObject listenPath = fsMan.resolveFile(config.getContentFolder().toURI());
             FileObject templateListenPath = fsMan.resolveFile(config.getTemplateFolder().toURI());
             FileObject assetPath = fsMan.resolveFile(config.getAssetFolder().toURI());
+            FileObject dataPath = fsMan.resolveFile(config.getDataFolder().toURI());
 
-            logger.info("Watching for (content, template, asset) changes in [{}]", config.getSourceFolder().getPath());
+            logger.info("Watching for (content, data, template, asset) changes in [{}]", config.getSourceFolder().getPath());
             DefaultFileMonitor monitor = new DefaultFileMonitor(new CustomFSChangeListener(config));
             monitor.setRecursive(true);
             monitor.addFile(listenPath);
             monitor.addFile(templateListenPath);
             monitor.addFile(assetPath);
+            monitor.addFile(dataPath);
             monitor.start();
         } catch (FileSystemException e) {
             logger.error("Problems watching filesystem changes", e);

--- a/jbake-core/src/main/java/org/jbake/parser/YamlEngine.java
+++ b/jbake-core/src/main/java/org/jbake/parser/YamlEngine.java
@@ -1,0 +1,88 @@
+package org.jbake.parser;
+
+import org.apache.commons.io.IOUtils;
+import org.jbake.app.configuration.JBakeConfiguration;
+import org.jbake.model.DocumentTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class YamlEngine extends MarkupEngine {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(YamlEngine.class);
+
+    public static final String JBAKE_PREFIX = "jbake-";
+
+    /**
+     * Parses the YAML file and ensures the output is always a Map.
+     *
+     * @param file
+     * @return
+     */
+    private Map<String, Object> parseFile(File file) {
+        Map<String, Object> fileContents = new HashMap<>();
+        Yaml yaml = new Yaml();
+        try (InputStream is = new FileInputStream(file)) {
+            Object result = yaml.load(is);
+            if (result instanceof List) {
+                fileContents.put("data", result);
+            } else if (result instanceof Map) {
+                fileContents = (Map<String, Object>) result;
+            } else {
+
+            }
+        } catch (IOException e) {
+            LOGGER.error("Error while parsing file {}", file, e);
+        }
+        return fileContents;
+    }
+
+    @Override
+    public Map<String, Object> parse(JBakeConfiguration config, File file) {
+        return parseFile(file);
+    }
+
+    /**
+     * This method implements the contract allowing use of Yaml files as content files
+     *
+     * @param context the parser context
+     */
+    @Override
+    public void processHeader(final ParserContext context) {
+        Map<String, Object> fileContents = parseFile(context.getFile());
+        Map<String, Object> documentModel = context.getDocumentModel();
+
+        for (String key : fileContents.keySet()) {
+            if (hasJBakePrefix(key)) {
+                String pKey = key.substring(6);
+                documentModel.put(pKey, fileContents.get(key));
+            } else {
+                documentModel.put(key, fileContents.get(key));
+            }
+        }
+    }
+
+    /**
+     * This method implements the contract allowing use of Yaml files as content files. As such there is
+     * no body for Yaml files so this method just sets an empty String as the body.
+     *
+     * @param context the parser context
+     */
+    @Override
+    public void processBody(ParserContext context) {
+        context.setBody("");
+    }
+
+    private boolean hasJBakePrefix(String key) {
+        return key.startsWith(JBAKE_PREFIX);
+    }
+}

--- a/jbake-core/src/main/java/org/jbake/template/model/AllContentExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/AllContentExtractor.java
@@ -2,6 +2,7 @@ package org.jbake.template.model;
 
 import org.jbake.app.ContentStore;
 import org.jbake.app.DocumentList;
+import org.jbake.app.configuration.JBakeProperty;
 import org.jbake.model.DocumentTypes;
 import org.jbake.template.ModelExtractor;
 
@@ -11,11 +12,15 @@ public class AllContentExtractor implements ModelExtractor<DocumentList> {
 
     @Override
     public DocumentList get(ContentStore db, Map model, String key) {
+        Map<String, Object> config = (Map<String, Object>) model.get("config");
+        String dataFileDocType = config.get(JBakeProperty.DATA_FILE_DOCTYPE.replace(".", "_")).toString();
         DocumentList allContent = new DocumentList();
         String[] documentTypes = DocumentTypes.getDocumentTypes();
         for (String docType : documentTypes) {
-            DocumentList query = db.getAllContent(docType);
-            allContent.addAll(query);
+            if (!docType.equals(dataFileDocType)) {
+                DocumentList query = db.getAllContent(docType);
+                allContent.addAll(query);
+            }
         }
         return allContent;
     }

--- a/jbake-core/src/main/java/org/jbake/template/model/DataExtractor.java
+++ b/jbake-core/src/main/java/org/jbake/template/model/DataExtractor.java
@@ -1,0 +1,24 @@
+package org.jbake.template.model;
+
+import org.jbake.app.ContentStore;
+import org.jbake.app.DocumentList;
+import org.jbake.app.configuration.JBakeProperty;
+import org.jbake.template.ModelExtractor;
+import org.jbake.util.DataFileUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DataExtractor implements ModelExtractor<DataFileUtil> {
+
+    @Override
+    public DataFileUtil get(ContentStore db, Map model, String key) {
+        DocumentList dl = new DocumentList();
+        Map<String, Object> config = (Map<String, Object>) model.get("config");
+
+        String defaultDocType = config.get(JBakeProperty.DATA_FILE_DOCTYPE).toString();
+        DataFileUtil dataUtil = new DataFileUtil(db, defaultDocType);
+        return dataUtil;
+    }
+
+}

--- a/jbake-core/src/main/java/org/jbake/util/DataFileUtil.java
+++ b/jbake-core/src/main/java/org/jbake/util/DataFileUtil.java
@@ -1,0 +1,24 @@
+package org.jbake.util;
+
+import org.jbake.app.ContentStore;
+import org.jbake.app.DocumentList;
+
+import java.util.Map;
+
+public class DataFileUtil {
+    private ContentStore db;
+    private String defaultDocType;
+
+    public DataFileUtil(ContentStore db, String defaultDocType) {
+        this.db = db;
+        this.defaultDocType = defaultDocType;
+    }
+
+    public Map<String, Object> get(String ref) {
+        DocumentList docs = db.getDocumentByUri(defaultDocType, ref);
+        if (docs.size() == 1) {
+            return docs.get(0);
+        }
+        return null;
+    }
+}

--- a/jbake-core/src/main/java/org/jbake/util/DataFileUtil.java
+++ b/jbake-core/src/main/java/org/jbake/util/DataFileUtil.java
@@ -2,10 +2,16 @@ package org.jbake.util;
 
 import org.jbake.app.ContentStore;
 import org.jbake.app.DocumentList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class DataFileUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataFileUtil.class);
+
     private ContentStore db;
     private String defaultDocType;
 
@@ -15,10 +21,17 @@ public class DataFileUtil {
     }
 
     public Map<String, Object> get(String ref) {
+        Map<String, Object> result = new HashMap<>();
         DocumentList docs = db.getDocumentByUri(defaultDocType, ref);
-        if (docs.size() == 1) {
-            return docs.get(0);
+        if (docs.isEmpty()) {
+            LOGGER.warn("Unable to locate content for ref: {}", ref);
+        } else {
+            if (docs.size() == 1) {
+                result = docs.get(0);
+            } else {
+                LOGGER.warn("Located multiple hits for ref: {}", ref);
+            }
         }
-        return null;
+        return result;
     }
 }

--- a/jbake-core/src/main/resources/META-INF/org.jbake.parser.MarkupEngines.properties
+++ b/jbake-core/src/main/resources/META-INF/org.jbake.parser.MarkupEngines.properties
@@ -1,3 +1,4 @@
 org.jbake.parser.RawMarkupEngine=html
 org.jbake.parser.AsciidoctorEngine=ad,adoc,asciidoc
 org.jbake.parser.MarkdownEngine=md
+org.jbake.parser.YamlEngine=yml,yaml

--- a/jbake-core/src/main/resources/META-INF/org.jbake.template.ModelExtractors.properties
+++ b/jbake-core/src/main/resources/META-INF/org.jbake.template.ModelExtractors.properties
@@ -9,4 +9,5 @@ org.jbake.template.model.PublishedDateExtractor=published_date
 org.jbake.template.model.DBExtractor=db
 org.jbake.template.model.TagPostsExtractor=tag_posts
 org.jbake.template.model.TaggedDocumentsExtractor=tagged_documents
+org.jbake.template.model.DataExtractor=data
 

--- a/jbake-core/src/main/resources/default.properties
+++ b/jbake-core/src/main/resources/default.properties
@@ -28,6 +28,10 @@ content.folder=content
 asset.folder=assets
 # Flag indicating if hidden asset resources should be ignored
 asset.ignore=false
+# folder that contains all data files
+data.folder=data
+# document type to use for data files
+data.file.docType=data
 
 # render index file?
 render.index=true

--- a/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
+++ b/jbake-core/src/test/java/org/jbake/app/CrawlerTest.java
@@ -3,6 +3,8 @@ package org.jbake.app;
 import org.apache.commons.io.FilenameUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.jbake.model.DocumentTypes;
+import org.jbake.util.DataFileUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -45,6 +47,21 @@ public class CrawlerTest extends ContentStoreIntegrationTest {
         // covers bug #213
         DocumentList publishedPostsByTag = db.getPublishedPostsByTag("blog");
         Assert.assertEquals(3, publishedPostsByTag.size());
+    }
+
+    @Test
+    public void crawlDataFiles() {
+        Crawler crawler = new Crawler(db, config);
+        // manually register data doctype
+        DocumentTypes.addDocumentType(config.getDataFileDocType());
+        db.updateSchema();
+        crawler.crawlDataFiles();
+        Assert.assertEquals(1, db.getDocumentCount("data"));
+
+        DataFileUtil util = new DataFileUtil(db, "data");
+        Map<String, Object> data = util.get("videos.yaml");
+        Assert.assertFalse(data.isEmpty());
+        Assert.assertNotNull(data.get("data"));
     }
 
     @Test

--- a/jbake-core/src/test/java/org/jbake/template/ModelExtractorsTest.java
+++ b/jbake-core/src/test/java/org/jbake/template/ModelExtractorsTest.java
@@ -91,13 +91,13 @@ public class ModelExtractorsTest {
         ModelExtractors.getInstance().registerExtractorsForCustomTypes(newDocumentType);
 
         //expect:
-        assertThat(ModelExtractors.getInstance().keySet().size()).isEqualTo(17);
+        assertThat(ModelExtractors.getInstance().keySet().size()).isEqualTo(18);
 
         //when:
         ModelExtractors.getInstance().reset();
 
         //then:
-        assertThat(ModelExtractors.getInstance().keySet().size()).isEqualTo(15);
+        assertThat(ModelExtractors.getInstance().keySet().size()).isEqualTo(16);
 
     }
 }

--- a/jbake-core/src/test/resources/fixture/data/videos.yaml
+++ b/jbake-core/src/test/resources/fixture/data/videos.yaml
@@ -1,0 +1,21 @@
+-
+    youtubeId: blK7gxqu2B0
+    title: "Unit testing constraints"
+    author: triceo
+    date: 2021-03009
+    tags:
+        - testing
+
+-
+    youtubeId: gIaHtATz6n8
+    title: "Maintenance scheduling"
+    author: jucui
+    date: 2021-02-24
+    tags:
+        - maintenance scheduling
+
+-
+    youtubeId: LTkoaBk-P6U
+    title: "Vaccination appointment scheduling"
+    author: ge0ffrey
+    date: 2021-02-03


### PR DESCRIPTION
Resolves #680 

Analogous to feature in Awestruct, exposes data structures defined in YAML files for use within template files. Different to content files in that existence of data file doesn't automatically mean you want to produce 1-to-1 mapping with output file, hence the need to define new folder for these files.