### PR TITLE
Allow setting docker image timezone by env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,14 @@ FROM adoptopenjdk/openjdk11:alpine-jre
 ENV JBAKE_USER=jbake
 ENV JBAKE_HOME=/opt/jbake
 ENV PATH ${JBAKE_HOME}/bin:$PATH
+ENV TZ=UTC
+
+RUN apk --no-cache update && \
+    apk --no-cache upgrade && \
+    apk add --update tzdata && \
+    rm -rf /var/cache/apk/*
+
+RUN echo ${TZ} > /etc/timezone
 
 RUN adduser -D -u 1000 -g "" ${JBAKE_USER} ${JBAKE_USER}
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -91,6 +91,9 @@ This command will also expose port 8820 from the container, you'll also need to 
 server.hostname=0.0.0.0
 ----
 
+NOTE: Docker image timezone is _UTC_. This may affect the date and time expected in output content. To set different timezone, add `TZ` environment variable and set value to required https://en.wikipedia.org/wiki/List_of_tz_database_time_zones[timezone^]. Example - `docker run --rm -u jbake  -e TZ=America/New_York -v "$PWD":/mnt/site jbake/jbake:latest`
+
+
 == Build System
 
 The project uses http://gradle.org[Gradle] 4.9+ as the build system.


### PR DESCRIPTION
NOTE: Docker image timezone is _UTC_. This may affect the date and time expected in output content. To set different timezone, add `TZ` environment variable and set value to required https://en.wikipedia.org/wiki/List_of_tz_database_time_zones[timezone^]. 

Example - `docker run --rm -u jbake -e TZ=America/New_York -v "$PWD":/mnt/site jbake/jbake:latest`
