### PR TITLE
Fixes #726 - Sets TimeZone for Freemarker template engine

### DIFF
--- a/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/DefaultJBakeConfiguration.java
@@ -702,4 +702,13 @@ public class DefaultJBakeConfiguration implements JBakeConfiguration {
     public String getJvmLocale() {
         return getAsString(JVM_LOCALE.getKey());
     }
+
+    @Override
+    public TimeZone getFreemarkerTimeZone() {
+        String timezone = getAsString(FREEMARKER_TIMEZONE.getKey());
+        if (StringUtils.isNotEmpty(timezone)) {
+            return TimeZone.getTimeZone(timezone);
+        }
+        return null;
+    }
 }

--- a/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/JBakeConfiguration.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.TimeZone;
 
 /**
  * JBakeConfiguration gives you access to the project configuration. Typically located in a file called jbake.properties.
@@ -366,6 +367,12 @@ public interface JBakeConfiguration {
      * @return Locale to set in the JVM
      */
     String getJvmLocale();
+
+    /**
+     *
+     * @return TimeZone to use within Freemarker
+     */
+    TimeZone getFreemarkerTimeZone();
 
     Map<String, Object> asHashMap();
 

--- a/jbake-core/src/main/java/org/jbake/app/configuration/PropertyList.java
+++ b/jbake-core/src/main/java/org/jbake/app/configuration/PropertyList.java
@@ -110,6 +110,11 @@ public abstract class PropertyList {
         "filename to use for feed"
     );
 
+    public static final Property FREEMARKER_TIMEZONE = new Property(
+        "freemarker.timezone",
+        "TimeZone to use within Freemarker"
+    );
+
     public static final Property GIT_HASH = new Property(
         "git.hash",
         "abbreviated git hash"

--- a/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
+++ b/jbake-core/src/main/java/org/jbake/template/FreemarkerTemplateEngine.java
@@ -51,6 +51,10 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
         templateCfg = new Configuration(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
         templateCfg.setDefaultEncoding(config.getRenderEncoding());
         templateCfg.setOutputEncoding(config.getOutputEncoding());
+        if (config.getFreemarkerTimeZone() != null) {
+            templateCfg.setTimeZone(config.getFreemarkerTimeZone());
+            templateCfg.setSQLDateAndTimeTimeZone(config.getFreemarkerTimeZone());
+        }
         try {
             templateCfg.setDirectoryForTemplateLoading(config.getTemplateFolder());
         } catch (IOException e) {


### PR DESCRIPTION
Allows you to override the time zone used to display date and time in Freemarker templates.