### PR TITLE
security update logback, other dependency updates + upgrade to gradle 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ jdk:
 jobs:
   include:
 
-  - jdk: openjdk17
-    os: osx
+  - os: osx
+    osx_image: xcode13.2
 
   - jdk: openjdk11
     os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ install: true
 script:
 - "./gradlew check --stacktrace"
 
-jdk:
-  - openjdk17
-  - openjdk11
-
 jobs:
   include:
+
+  - jdk: openjdk17
+
+  - jdk: openjdk11
 
   - os: osx
     osx_image: xcode13.2
@@ -42,7 +42,6 @@ jobs:
 #    - "./gradlew -PskipSigning jacocoRootReport coveralls -i --stacktrace"
 
 notifications:
-  irc: "irc.freenode.org#jbake"
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/2d332fabb02dba68a36b

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ script:
 - "./gradlew check --stacktrace"
 
 jdk:
-  - openjdk15
+  - openjdk17
   - openjdk11
 
 jobs:
   include:
 
-  - jdk: openjdk15
+  - jdk: openjdk17
     os: osx
 
   - jdk: openjdk11

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,8 @@ clone_depth: 10
 environment:
   TERM: dumb
   matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - JAVA_HOME: C:\Program Files\Java\jdk11
-    - JAVA_HOME: C:\Program Files\Java\jdk15
+    - JAVA_HOME: C:\Program Files\Java\jdk17
 
 install:
   - SET PATH=%JAVA_HOME%\bin;%PATH%

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 import java.time.format.DateTimeFormatter
 
 plugins {
-    id "io.github.gradle-nexus.publish-plugin"  version "1.0.0"
-    id 'com.github.ben-manes.versions'          version '0.38.0'
+    id "io.github.gradle-nexus.publish-plugin"  version "$nexusPublishPluginVersion"
+    id 'com.github.ben-manes.versions'          version "$versionsPluginVersion"
     id 'org.ajoberstar.grgit'                   version "$grgitVersion"
     id "eclipse"
     id "idea"

--- a/buildSrc/src/main/groovy/org/jbake/convention/org.jbake.convention.java-common.gradle
+++ b/buildSrc/src/main/groovy/org/jbake/convention/org.jbake.convention.java-common.gradle
@@ -25,7 +25,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjCoreVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
-    testImplementation 'org.itsallcode:junit5-system-extensions:1.1.0'
+    testImplementation "org.itsallcode:junit5-system-extensions:$junit5SystemExtVersion"
 }
 
 tasks.withType(JavaCompile) {
@@ -91,7 +91,7 @@ jacocoTestReport.dependsOn test
 
 tasks.withType(Checkstyle) {
     reports {
-        xml.enabled false
-        html.enabled true
+        xml.required.set false
+        html.required.set true
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,48 +7,55 @@ issues                      = https://github.com/jbake-org/jbake/issues
 vcs                         = https://github.com/jbake-org/jbake/
 
 # runtime dependencies
-asciidoctorjVersion         = 2.4.3
-asciidoctorjDiagramVersion  = 2.1.0
+asciidoctorjVersion         = 2.5.2
+asciidoctorjDiagramVersion  = 2.2.1
 args4jVersion               = 2.33
-commonsIoVersion            = 2.8.0
+commonsIoVersion            = 2.11.0
 commonsConfigurationVersion = 2.7
 commonsBeanutilsVersion     = 1.9.4
 commonsLangVersion          = 3.12.0
-commonsVfs2Version          = 2.7.0
+commonsVfs2Version          = 2.9.0
 freemarkerVersion           = 2.3.31
 flexmarkVersion             = 0.62.2
-groovyVersion               = 3.0.7
-jettyServerVersion          = 9.4.36.v20210114
+groovyVersion               = 3.0.9
+jettyServerVersion          = 9.4.44.v20210927
 jsonSimpleVersion           = 1.1.1
 jade4jVersion               = 1.3.2
-jsoupVersion                = 1.13.1
-jgitVersion                 = 5.10.0.202012080955-r
-logbackVersion              = 1.2.3
-orientDbVersion             = 3.0.37
+jsoupVersion                = 1.14.3
+jgitVersion                 = 6.0.0.202111291000-r
+logbackVersion              = 1.2.10
+orientDbVersion             = 3.0.41
 pebbleVersion               = 3.1.5
-slf4jVersion                = 1.7.30
-snakeYamlVersion            = 1.28
-thymeleafVersion            = 3.0.12.RELEASE
-picocli                     = 4.6.1
+slf4jVersion                = 1.7.32
+snakeYamlVersion            = 1.30
+thymeleafVersion            = 3.0.14.RELEASE
+picocli                     = 4.6.2
 
 
 # testing dependencies
 junit4Version               = 4.13.2
-junit5Version               = 5.7.1
-junitPioneer                = 1.3.8
-assertjCoreVersion          = 3.19.0
-mockitoVersion              = 3.8.0
+junit5Version               = 5.8.2
+junit5SystemExtVersion      = 1.2.0
+junitPioneer                = 1.5.0
+assertjCoreVersion          = 3.21.0
+mockitoVersion              = 4.2.0
 
 # build dependencies
-jacocoVersion               = 0.8.6
-grgitVersion                = 4.1.0
+jacocoVersion               = 0.8.7
+grgitVersion                = 4.1.1
+nexusPublishPluginVersion   = 1.1.0
+versionsPluginVersion       = 0.40.0
+sdkmanVersion               = 3.0.0
+githubReleaseVersion        = 2.2.12
+optionalBaseVersion         = 7.0.0
+
+# jbake-maven-plugin dependencies
+mavenVersion                = 3.8.4
+mavenAnnotationsVersion     = 3.6.2
+sparkVersion                = 2.9.3
 
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configureondemand = true
 org.gradle.vfs.watch = true
 
-# jbake-maven-plugin dependencies
-mavenVersion                = 3.8.1
-mavenAnnotationsVersion     = 3.6.2
-sparkVersion                = 2.9.3

--- a/gradle/github-releases.gradle
+++ b/gradle/github-releases.gradle
@@ -6,7 +6,7 @@ rootProject.ext {
 }
 
 afterEvaluate {
-    def name = project(':jbake-dist').tasks.getByName("distZip").archiveName
+    def name = project(':jbake-dist').tasks.getByName("distZip").archiveFileName.getOrNull()
     def files = project(':jbake-dist').tasks.getByName("distZip").outputs.files.files
     if (!project.hasProperty('skipSigning')) {
         def signatureFile = project(':jbake-dist').tasks.getByName("signArchives").outputs.files.files.find { it.name.contains(name) }

--- a/jbake-core/build.gradle
+++ b/jbake-core/build.gradle
@@ -3,7 +3,7 @@ import java.time.format.DateTimeFormatter
 plugins {
     id "org.jbake.convention.java-common"
     id 'java-library'
-    id 'nebula.optional-base' version '3.0.3'
+    id 'nebula.optional-base' version "$optionalBaseVersion"
 }
 
 apply from: "$rootDir/gradle/maven-publishing.gradle"

--- a/jbake-core/src/main/java/org/jbake/app/Asset.java
+++ b/jbake-core/src/main/java/org/jbake/app/Asset.java
@@ -158,7 +158,7 @@ public class Asset {
         try {
             FileUtils.copyFile(asset, targetFolder);
             LOGGER.info("Copying [{}]... done!", asset.getPath());
-        } catch (IOException e) {
+        } catch (IOException|IllegalArgumentException e) {
             LOGGER.error("Copying [{}]... failed!", asset.getPath(), e);
             errors.add(e);
         }

--- a/jbake-dist/build.gradle
+++ b/jbake-dist/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id "io.sdkman.vendors"  version "2.0.0"
-    id "com.github.breadmoirai.github-release" version "2.2.12"
+    id "io.sdkman.vendors"  version "$sdkmanVersion"
+    id "com.github.breadmoirai.github-release" version "$githubReleaseVersion"
     id "org.jbake.convention.java-common"
     id 'application'
 }


### PR DESCRIPTION
As the distribution package of jbake does deliver a writable logback.xml
we need to fix this immediatly.

See https://jira.qos.ch/browse/LOGBACK-1591 and [News from 14th of December](http://logback.qos.ch/news.html)