### PR TITLE
Change DuplicatesStrategy from EXCLUDE to INCLUDE

### DIFF
--- a/jbake-core/build.gradle
+++ b/jbake-core/build.gradle
@@ -57,11 +57,9 @@ dependencies {
 }
 
 processResources {
-    from("src/main/resources") {
-        duplicatesStrategy = DuplicatesStrategy.INCLUDE
-        include 'default.properties'
+    filesMatching("default.properties") {
         expand jbakeVersion: project.version,
-               timestamp: grgit.head().dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss'['VV']'")),
-               gitHash: grgit.head().abbreviatedId
+            timestamp: grgit.head().dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss'['VV']'")),
+            gitHash: grgit.head().abbreviatedId
     }
 }

--- a/jbake-core/build.gradle
+++ b/jbake-core/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
 processResources {
     from("src/main/resources") {
-        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        duplicatesStrategy = DuplicatesStrategy.INHERIT
         include 'default.properties'
         expand jbakeVersion: project.version,
                timestamp: grgit.head().dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss'['VV']'")),

--- a/jbake-core/build.gradle
+++ b/jbake-core/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
 processResources {
     from("src/main/resources") {
-        duplicatesStrategy = DuplicatesStrategy.INHERIT
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
         include 'default.properties'
         expand jbakeVersion: project.version,
                timestamp: grgit.head().dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss'['VV']'")),


### PR DESCRIPTION
I just build JBake from source by run `./gradlew clean build distZip`, and run jbake command in the terminal, I got the following:
```
➜  jbake git:(ds) jbake 
JBake v${jbakeVersion} (${timestamp} ${gitHash}#) [http://jbake.org]
```

It seems that build process did not expand variables defined in default.properties. 
```
# application version
version=v${jbakeVersion}
# build timestamp
build.timestamp=${timestamp}
# abbreviated git hash
git.hash=${gitHash}
```

I retried the build by setting `duplicatesStrategy = DuplicatesStrategy.FAIL`, then it failed.   
But use `duplicatesStrategy = DuplicatesStrategy.INHERIT`,  the build process complains 
```
Entry default.properties is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.3.3/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
```
Then I tried `duplicatesStrategy = DuplicatesStrategy.INCLUDE`, works like a charm. Although it may not be the root cause...