### PR TITLE
Fix java.lang.UnsatisfiedLinkError thrown on Apple M1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ issues                      = https://github.com/jbake-org/jbake/issues
 vcs                         = https://github.com/jbake-org/jbake/
 
 # runtime dependencies
-asciidoctorjVersion         = 2.5.2
+asciidoctorjVersion         = 2.5.7
 asciidoctorjDiagramVersion  = 2.2.1
 args4jVersion               = 2.33
 commonsIoVersion            = 2.11.0


### PR DESCRIPTION
This fixes `java.lang.UnsatisfiedLinkError` thrown by jbake-maven-plugin 2.7.0-rc.6 on Apple's M1 hardware (see #769).

The problem was caused by an older version of JRuby (a dependency of AsciidoctorJ) that does not support macos-aarch64. By upgrading AsciidoctorJ to the latest version, a newer version of JRuby supporting M1 is used, and `java.lang.UnsatisfiedLinkError` is no longer thrown.

Fixes #769.