### PR TITLE
chore: upgrade gh action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,21 +28,10 @@ jobs:
               with:
                   java-version: 11
                   distribution: 'temurin'
-                  cache: 'gradle'
 
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v5
 
-            - uses: actions/cache@v4
-              with:
-                  path: ~/.gradle/caches
-                  key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
-                  restore-keys: |
-                      ${{ runner.os }}-gradle-
-            - uses: actions/cache@v4
-              with:
-                  path: ~/.gradle/wrapper
-                  key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradlew') }}
-                  restore-keys: |
-                      ${{ runner.os }}-gradlew-
             - name: Build-win
               if: runner.os == 'Windows'
               shell: cmd

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -21,20 +21,10 @@ jobs:
               with:
                   java-version: 11
                   distribution: 'temurin'
-                  cache: 'gradle'
 
-            - uses: actions/cache@v4
-              with:
-                  path: ~/.gradle/caches
-                  key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
-                  restore-keys: |
-                      ${{ runner.os }}-gradle-
-            - uses: actions/cache@v4
-              with:
-                  path: ~/.gradle/wrapper
-                  key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradlew') }}
-                  restore-keys: |
-                      ${{ runner.os }}-gradlew-
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v5
+
             - name: Build
               run: ./gradlew build -S
 


### PR DESCRIPTION
This PR just upgrades the Github Actions versions to the latest and let the actions work again.